### PR TITLE
Increase enclave heap size

### DIFF
--- a/go/obscuronode/enclave/main/enclave.json
+++ b/go/obscuronode/enclave/main/enclave.json
@@ -1,0 +1,9 @@
+{
+  "exe": "main",
+  "key": "private.pem",
+  "debug": true,
+  "heapSize": 1024,
+  "executableHeap": true,
+  "productID": 1,
+  "securityVersion": 1
+}


### PR DESCRIPTION
### Why is this change needed?

the docker tests are failing with mmap errors. The ego team suggested a fix to increase the heap size in an enclave.json file

### What changes were made as part of this PR:

- added that file

### What are the key areas to look at
