### PR TITLE
Adds CORS as needed for the WE endpoints

### DIFF
--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -175,7 +175,11 @@ func setUpLogs(logPath string) {
 }
 
 // Used to check whether the server is ready.
-func (we *WalletExtension) handleReady(http.ResponseWriter, *http.Request) {}
+func (we *WalletExtension) handleReady(resp http.ResponseWriter, req *http.Request) {
+	if we.enableCORS(resp, req) {
+		return
+	}
+}
 
 // Handles the Ethereum JSON-RPC request over HTTP.
 func (we *WalletExtension) handleEthJSONHTTP(resp http.ResponseWriter, req *http.Request) {
@@ -303,6 +307,10 @@ func parseRequest(body []byte) (*accountmanager.RPCRequest, error) {
 
 // Generates a new viewing key.
 func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, req *http.Request) {
+	if we.enableCORS(resp, req) {
+		return
+	}
+
 	userConn := userconn.NewUserConnHTTP(resp, req)
 
 	body, err := userConn.ReadRequest()
@@ -345,6 +353,10 @@ func (we *WalletExtension) handleGenerateViewingKey(resp http.ResponseWriter, re
 
 // Submits the viewing key and signed bytes to the enclave.
 func (we *WalletExtension) handleSubmitViewingKey(resp http.ResponseWriter, req *http.Request) {
+	if we.enableCORS(resp, req) {
+		return
+	}
+
 	userConn := userconn.NewUserConnHTTP(resp, req)
 
 	body, err := userConn.ReadRequest()


### PR DESCRIPTION
### Why is this change needed?

Allows the viewing keys to be generated from a browser front-end, and not just the standard `localhost:3000/viewingkeys` page.

### What changes were made as part of this PR:

- Enables CORS for the relevant endpoints

### :rotating_light: Definition of done :rotating_light:
- [ ] Unit tests added to cover new or changed functionality 
- [ ] Docs pages updated to cover new or changed functionality
- [ ] [Changelog.md](https://github.com/obscuronet/go-obscuro/blob/main/docs/testnet/changelog.md) updated 
