### PR TITLE
Reenable disabled block provider test

### DIFF
--- a/go/ethadapter/blockprovider.go
+++ b/go/ethadapter/blockprovider.go
@@ -79,7 +79,7 @@ func (e *EthBlockProvider) streamBlocks(ctx context.Context, fromHeight *big.Int
 			// this will block if we're up-to-date with live blocks
 			block, err := e.fetchNextCanonicalBlock(ctx, fromHeight, latestSent)
 			if err != nil {
-				e.logger.Error("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
+				e.logger.Warn("unexpected error while preparing block to stream, will retry in 1 sec", log.ErrKey, err)
 				// todo: consider possible scenarios and what an appropriate wait time is here. Perhaps use a back-off strategy?
 				time.Sleep(10 * time.Millisecond)
 				continue

--- a/go/ethadapter/blockprovider_test.go
+++ b/go/ethadapter/blockprovider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -18,12 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const gethTestEnv = "GETH_TEST_ENABLED"
-
 func TestBlockProviderHappyPath_LiveStream(t *testing.T) {
-	if os.Getenv(gethTestEnv) == "" {
-		t.Skipf("set the variable to run this test: `%s=true`", gethTestEnv)
-	}
 	mockEthClient := mockEthClient(3)
 	blockProvider := setupBlockProvider(mockEthClient)
 


### PR DESCRIPTION
### Why this change is needed

Reenable disabled test (https://github.com/obscuronet/obscuro-internal/issues/1331)

Haven't been able to reproduce it failing yet, although it does spam out some error messages while it's waiting for the mock L1 blocks to start arriving so maybe that's what got it disabled. I've downgraded that to WARN as it's something we recover from that could be common.

### What changes were made as part of this PR

- Re-enable test
- Downgrade blockprovider error log message

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


