### PR TITLE
Tiny fix: log formatting to not swallow error

### DIFF
--- a/go/host/host.go
+++ b/go/host/host.go
@@ -173,7 +173,7 @@ func (h *host) Start() error {
 
 		err := h.refreshP2PPeerList()
 		if err != nil {
-			h.logger.Warn("unable to sync current p2p peer list on startup - %w", err)
+			h.logger.Warn("unable to sync current p2p peer list on startup", log.ErrKey, err)
 		}
 
 		// start the host's main processing loop


### PR DESCRIPTION
### Why this change is needed

Keep seeing this error in datadog but the actual error message is being swallowed because the wrong log format.

### What changes were made as part of this PR

Fix log format

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


