### PR TITLE
Use eth sign typed data v4 in gateway

### DIFF
--- a/go/common/tracers/tracers.go
+++ b/go/common/tracers/tracers.go
@@ -1,7 +1,7 @@
 // Package tracers: This file was copied/adapted from geth - go-ethereum/eth/tracers
 //
 
-//nolint
+// nolint
 package tracers
 
 import (

--- a/go/common/tracers/tracers.go
+++ b/go/common/tracers/tracers.go
@@ -1,7 +1,7 @@
 // Package tracers: This file was copied/adapted from geth - go-ethereum/eth/tracers
 //
 
-// nolint
+//nolint
 package tracers
 
 import (

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -9,13 +9,11 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	"github.com/ten-protocol/go-ten/integration"
-
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/ten-protocol/go-ten/go/wallet"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -131,7 +129,7 @@ func GenerateSignMessageOG(vkPubKey []byte, addr *gethcommon.Address) string {
 
 // GenerateAuthenticationEIP712RawData generates raw data (bytes)
 // for an EIP-712 message used to authenticate an address with user
-func GenerateAuthenticationEIP712RawData(userID string) ([]byte, error) {
+func GenerateAuthenticationEIP712RawData(userID string, chainID int64) ([]byte, error) {
 	if len(userID) != UserIDHexLength {
 		return nil, fmt.Errorf("userID hex length must be %d, received %d", UserIDHexLength, len(userID))
 	}
@@ -151,7 +149,7 @@ func GenerateAuthenticationEIP712RawData(userID string) ([]byte, error) {
 	domain := apitypes.TypedDataDomain{
 		Name:    EIP712DomainNameValue,
 		Version: EIP712DomainVersionValue,
-		ChainId: (*math.HexOrDecimal256)(big.NewInt(integration.ObscuroChainID)), // TODO !ziga (read this from config!)
+		ChainId: (*math.HexOrDecimal256)(big.NewInt(chainID)),
 	}
 
 	message := map[string]interface{}{
@@ -195,9 +193,9 @@ func CalculateUserID(publicKeyBytes []byte) []byte {
 	return crypto.Keccak256Hash(publicKeyBytes).Bytes()[:20]
 }
 
-func VerifySignatureEIP712(userID string, address *gethcommon.Address, signature []byte) (bool, error) {
+func VerifySignatureEIP712(userID string, address *gethcommon.Address, signature []byte, chainID int64) (bool, error) {
 	// get raw data for structured message
-	rawData, err := GenerateAuthenticationEIP712RawData(userID)
+	rawData, err := GenerateAuthenticationEIP712RawData(userID, chainID)
 	if err != nil {
 		return false, err
 	}

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -34,17 +34,19 @@ type SubscriptionManager struct {
 	storage              storage.Storage
 
 	subscriptions     map[gethrpc.ID]*common.LogSubscription
+	chainID           int64
 	subscriptionMutex *sync.RWMutex // the mutex guards the subscriptions/lastHead pair
 
 	logger gethlog.Logger
 }
 
-func NewSubscriptionManager(rpcEncryptionManager *rpc.EncryptionManager, storage storage.Storage, logger gethlog.Logger) *SubscriptionManager {
+func NewSubscriptionManager(rpcEncryptionManager *rpc.EncryptionManager, storage storage.Storage, chainID int64, logger gethlog.Logger) *SubscriptionManager {
 	return &SubscriptionManager{
 		rpcEncryptionManager: rpcEncryptionManager,
 		storage:              storage,
 
 		subscriptions:     map[gethrpc.ID]*common.LogSubscription{},
+		chainID:           chainID,
 		subscriptionMutex: &sync.RWMutex{},
 		logger:            logger,
 	}
@@ -64,7 +66,7 @@ func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encryptedSubscripti
 	}
 
 	// create viewing key encryption handler for pushing future logs
-	encryptor, err := vkhandler.New(subscription.Account, subscription.PublicViewingKey, subscription.Signature)
+	encryptor, err := vkhandler.New(subscription.Account, subscription.PublicViewingKey, subscription.Signature, s.chainID)
 	if err != nil {
 		return fmt.Errorf("unable to create vk encryption for request - %w", err)
 	}

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -3,6 +3,7 @@ package vkhandler
 import (
 	"crypto/rand"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -28,13 +29,13 @@ type VKHandler struct {
 // New creates a new viewing key handler if signature is valid and was produced by given address
 // It receives address, viewing key and a signature over viewing key.
 // In order to check signature validity, we need to reproduce a message that was originally signed
-func New(requestedAddr *gethcommon.Address, vkPubKeyBytes, accountSignatureHexBytes []byte) (*VKHandler, error) {
+func New(requestedAddr *gethcommon.Address, vkPubKeyBytes, accountSignatureHexBytes []byte, chainID int64) (*VKHandler, error) {
 	// get userID from viewingKey public key
 	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 
 	// check if the signature is valid
 	// TODO: @ziga - after removing old wallet extension signatures we can return if the signature is invalid
-	isValidSignature, _ := viewingkey.VerifySignatureEIP712(userID, requestedAddr, accountSignatureHexBytes)
+	isValidSignature, _ := viewingkey.VerifySignatureEIP712(userID, requestedAddr, accountSignatureHexBytes, chainID)
 
 	// Old wallet extension message format
 	// We recover the key based on the signed message and the signature (same as before, but with legacy message format "vk"+<vk>"

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -1,7 +1,6 @@
 package vkhandler
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -10,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 )
+
+const chainID = 443
 
 func TestVKHandler(t *testing.T) {
 	// generate user private Key
@@ -25,9 +26,9 @@ func TestVKHandler(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
-	userID := hex.EncodeToString(crypto.Keccak256Hash(vkPubKeyBytes).Bytes()[:20])
+	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
-	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID)
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID, chainID)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -44,7 +45,7 @@ func TestVKHandler(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Create a new vk Handler
-			_, err = New(&userAddr, vkPubKeyBytes, signature)
+			_, err = New(&userAddr, vkPubKeyBytes, signature, chainID)
 			assert.NoError(t, err)
 		})
 	}
@@ -64,9 +65,9 @@ func TestSignAndCheckSignature(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
-	userID := hex.EncodeToString(crypto.Keccak256Hash(vkPubKeyBytes).Bytes()[:20])
+	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
-	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID)
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID, chainID)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -1,6 +1,7 @@
 package vkhandler
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -24,15 +25,22 @@ func TestVKHandler(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
+	userID := hex.EncodeToString(crypto.Keccak256Hash(vkPubKeyBytes).Bytes()[:20])
+	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData)
 
-	tests := map[string]string{
-		"WEMessageFormatTest": viewingkey.GenerateSignMessage(vkPubKeyBytes),
-		"OGMessageFormatTest": viewingkey.GenerateSignMessageOG(vkPubKeyBytes, &userAddr),
+	tests := map[string][]byte{
+		"WEMessageFormatTest":     WEMessageFormatTestHash,
+		"EIP712MessageFormatTest": EIP712MessageFormatTestHash,
 	}
 
-	for testName, msgToSign := range tests {
+	for testName, msgHashToSign := range tests {
 		t.Run(testName, func(t *testing.T) {
-			signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), userPrivKey)
+			signature, err := crypto.Sign(msgHashToSign, userPrivKey)
 			assert.NoError(t, err)
 
 			// Create a new vk Handler
@@ -56,25 +64,32 @@ func TestSignAndCheckSignature(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
+	userID := hex.EncodeToString(crypto.Keccak256Hash(vkPubKeyBytes).Bytes()[:20])
+	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData)
 
-	tests := map[string]string{
-		"WEMessageFormatTest": viewingkey.GenerateSignMessage(vkPubKeyBytes),
-		"OGMessageFormatTest": viewingkey.GenerateSignMessageOG(vkPubKeyBytes, &userAddr),
+	tests := map[string][]byte{
+		"WEMessageFormatTest":     WEMessageFormatTestHash,
+		"EIP712MessageFormatTest": EIP712MessageFormatTestHash,
 	}
 
-	for testName, msgToSign := range tests {
+	for testName, msgHashToSign := range tests {
 		t.Run(testName, func(t *testing.T) {
 			// sign the message
-			signature, err := crypto.Sign(accounts.TextHash([]byte(msgToSign)), userPrivKey)
+			signature, err := crypto.Sign(msgHashToSign, userPrivKey)
 			assert.NoError(t, err)
 
 			// Recover the key based on the signed message and the signature.
-			recoveredAccountPublicKey, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSign)), signature)
+			recoveredAccountPublicKey, err := crypto.SigToPub(msgHashToSign, signature)
 			assert.NoError(t, err)
 			recoveredAccountAddress := crypto.PubkeyToAddress(*recoveredAccountPublicKey)
 
 			if recoveredAccountAddress.Hex() != userAddr.Hex() {
-				t.Errorf("unable to recover user address from signature")
+				t.Fatalf("Expected user address %s, got %s", userAddr.Hex(), recoveredAccountAddress.Hex())
 			}
 
 			_, err = crypto.DecompressPubkey(vkPubKeyBytes)

--- a/integration/obscurogateway/obscurogateway_test.go
+++ b/integration/obscurogateway/obscurogateway_test.go
@@ -63,6 +63,7 @@ func TestObscuroGateway(t *testing.T) {
 		LogPath:                 "sys_out",
 		VerboseFlag:             false,
 		DBType:                  "sqlite",
+		TenChainID:              443,
 	}
 
 	obscuroGwContainer := container.NewWalletExtensionContainerFromConfig(obscuroGatewayConf, testlog.Logger())

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -301,25 +301,25 @@ func authenticateRequestHandler(walletExt *walletextension.WalletExtension, conn
 		return
 	}
 
-	// get message from the request
-	message, ok := reqJSONMap[common.JSONKeyMessage]
-	if !ok || message == "" {
-		handleError(conn, walletExt.Logger(), fmt.Errorf("unable to read message field from the request"))
+	// get address from the request
+	address, ok := reqJSONMap[common.JSONKeyAddress]
+	if !ok || address == "" {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("unable to read address field from the request"))
 		return
 	}
 
 	// read userID from query params
 	hexUserID, err := getUserID(conn, 2)
 	if err != nil {
-		handleError(conn, walletExt.Logger(), fmt.Errorf("malformed query: 'u' required - representing userID - %w", err))
+		handleError(conn, walletExt.Logger(), fmt.Errorf("malformed query: 'u' required - representing encryption token - %w", err))
 		return
 	}
 
 	// check signature and add address and signature for that user
-	err = walletExt.AddAddressToUser(hexUserID, message, signature)
+	err = walletExt.AddAddressToUser(hexUserID, address, signature)
 	if err != nil {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("internal error"))
-		walletExt.Logger().Error("error adding address to user with message", "message", message, log.ErrKey, err)
+		walletExt.Logger().Error(fmt.Sprintf("error adding address: %s to user: %s with signature: %s", address, hexUserID, signature))
 		return
 	}
 	err = conn.WriteResponse([]byte(common.SuccessMsg))

--- a/tools/walletextension/api/staticOG/javascript.js
+++ b/tools/walletextension/api/staticOG/javascript.js
@@ -19,6 +19,7 @@ const pathQuery = obscuroGatewayVersion + "/query/";
 const pathRevoke = obscuroGatewayVersion + "/revoke/";
 const pathVersion = "/version/";
 const obscuroChainIDDecimal = 443;
+const userIDHexLength = 40;
 const methodPost = "post";
 const methodGet = "get";
 const jsonHeaders = {
@@ -30,7 +31,7 @@ const metamaskPersonalSign = "personal_sign";
 const obscuroChainIDHex = "0x" + obscuroChainIDDecimal.toString(16); // Convert to hexadecimal and prefix with '0x'
 
 function isValidUserIDFormat(value) {
-  return typeof value === "string" && value.length === 64;
+  return typeof value === "string" && value.length === userIDHexLength;
 }
 
 let obscuroGatewayAddress =
@@ -118,38 +119,57 @@ async function addNetworkToMetaMask(ethereum, userID, chainIDDecimal) {
   return true;
 }
 
-async function authenticateAccountWithObscuroGateway(
-  ethereum,
-  account,
-  userID
-) {
-  const isAuthenticated = await accountIsAuthenticated(account, userID);
+async function authenticateAccountWithObscuroGatewayEIP712(ethereum, account, userID) {
+  const isAuthenticated = await accountIsAuthenticated(account, userID)
+
   if (isAuthenticated) {
-    return "Account is already authenticated";
+    return "Account is already authenticated"
   }
 
-  const textToSign = "Register " + userID + " for " + account.toLowerCase();
-  const signature = await ethereum
-    .request({
-      method: metamaskPersonalSign,
-      params: [textToSign, account],
-    })
-    .catch((_) => {
-      return -1;
-    });
-  if (signature === -1) {
-    return "Signing failed";
-  }
+  const typedData = {
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+      ],
+      Authentication: [
+        { name: "Encryption Token", type: "address" },
+      ],
+    },
+    primaryType: "Authentication",
+    domain: {
+      name: "Ten",
+      version: "1.0",
+      chainId: obscuroChainIDDecimal,
+    },
+    message: {
+      "Encryption Token": "0x"+userID
+    },
+  };
 
-  const authenticateUserURL = pathAuthenticate + "?u=" + userID;
-  const authenticateFields = { signature: signature, message: textToSign };
-  const authenticateResp = await fetch(authenticateUserURL, {
-    method: methodPost,
-    headers: jsonHeaders,
-    body: JSON.stringify(authenticateFields),
+  const data = JSON.stringify(typedData);
+  const signature = await ethereum.request({
+    method: "eth_signTypedData_v4",
+    params: [account, data],
+  }).catch(_ => {
+    console.log("signing failed!")
+    return -1;
   });
-  return await authenticateResp.text();
+
+
+  const authenticateUserURL = pathAuthenticate+"?u="+userID
+  const authenticateFields = {"signature": signature, "address": account }
+  const authenticateResp = await fetch(
+      authenticateUserURL, {
+        method: methodPost,
+        headers: jsonHeaders,
+        body: JSON.stringify(authenticateFields)
+      }
+  );
+  return await authenticateResp.text()
 }
+
 
 async function accountIsAuthenticated(account, userID) {
   const queryAccountUserID = pathQuery + "?u=" + userID + "&a=" + account;
@@ -275,7 +295,7 @@ async function populateAccountsTable(document, tableBody, userID) {
       connectButton.style.cursor = "pointer";
       connectButton.addEventListener("click", async (event) => {
         event.preventDefault();
-        await authenticateAccountWithObscuroGateway(ethereum, account, userID);
+        await authenticateAccountWithObscuroGatewayEIP712(ethereum, account, userID);
       });
       statusCell.appendChild(connectButton);
     }
@@ -435,7 +455,7 @@ const initialize = async () => {
       beginBox.style.visibility = "hidden";
       spinner.style.visibility = "visible";
       for (const account of accounts) {
-        await authenticateAccountWithObscuroGateway(ethereum, account, userID);
+        await authenticateAccountWithObscuroGatewayEIP712(ethereum, account, userID);
         accountsTable.style.display = "block";
         await populateAccountsTable(document, tableBody, userID);
       }
@@ -445,7 +465,7 @@ const initialize = async () => {
         if (isValidUserIDFormat(await getUserID())) {
           userID = await getUserID();
           for (const account of accounts) {
-            await authenticateAccountWithObscuroGateway(
+            await authenticateAccountWithObscuroGatewayEIP712(
               ethereum,
               account,
               userID

--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -1,12 +1,9 @@
 package common
 
 import (
-	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
@@ -16,8 +13,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
-
-var authenticateMessageRegex = regexp.MustCompile(MessageFormatRegex)
 
 // PrivateKeyToCompressedPubKey converts *ecies.PrivateKey to compressed PubKey ([]byte with length 33)
 func PrivateKeyToCompressedPubKey(prvKey *ecies.PrivateKey) []byte {
@@ -35,30 +30,6 @@ func BytesToPrivateKey(keyBytes []byte) (*ecies.PrivateKey, error) {
 
 	eciesPrivateKey := ecies.ImportECDSA(ecdsaPrivateKey)
 	return eciesPrivateKey, nil
-}
-
-// CalculateUserID calculates userID from a public key
-func CalculateUserID(publicKeyBytes []byte) []byte {
-	return crypto.Keccak256Hash(publicKeyBytes).Bytes()
-}
-
-// GetUserIDAndAddressFromMessage checks if message is in correct format and extracts userID and address from it
-func GetUserIDAndAddressFromMessage(message string) (string, string, error) {
-	if authenticateMessageRegex.MatchString(message) {
-		params := authenticateMessageRegex.FindStringSubmatch(message)
-		return params[1], params[2], nil
-	}
-	return "", "", errors.New("invalid message format")
-}
-
-// GetAddressAndPubKeyFromSignature gets an address that was used to sign given signature
-func GetAddressAndPubKeyFromSignature(messageHash []byte, signature []byte) (gethcommon.Address, *ecdsa.PublicKey, error) {
-	pubKey, err := crypto.SigToPub(messageHash, signature)
-	if err != nil {
-		return gethcommon.Address{}, nil, err
-	}
-
-	return crypto.PubkeyToAddress(*pubKey), pubKey, nil
 }
 
 // GetUserIDbyte converts userID from string to correct byte format

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -40,7 +40,7 @@ const (
 	UserQueryParameter                  = "u"
 	AddressQueryParameter               = "a"
 	MessageFormatRegex                  = `^Register\s(\w+)\sfor\s(\w+)$`
-	MessageUserIDLen                    = 64
+	MessageUserIDLen                    = 40
 	SignatureLen                        = 65
 	EthereumAddressLen                  = 42
 	PersonalSignMessagePrefix           = "\x19Ethereum Signed Message:\n%d%s"

--- a/tools/walletextension/config/config.go
+++ b/tools/walletextension/config/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	VerboseFlag             bool
 	DBType                  string
 	DBConnectionURL         string
+	TenChainID              int
 }

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -86,7 +86,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	}
 
 	stopControl := stopcontrol.New()
-	walletExt := walletextension.New(hostRPCBindAddr, &userAccountManager, databaseStorage, stopControl, version, logger)
+	walletExt := walletextension.New(hostRPCBindAddr, &userAccountManager, databaseStorage, stopControl, version, logger, &config)
 	httpRoutes := api.NewHTTPRoutes(walletExt)
 	httpServer := api.NewHTTPServer(fmt.Sprintf("%s:%d", config.WalletExtensionHost, config.WalletExtensionPortHTTP), httpRoutes)
 

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ten-protocol/go-ten/integration"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
@@ -44,7 +46,7 @@ func (o *OGLib) Join() error {
 
 func (o *OGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
-	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawData(string(o.userID))
+	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawData(string(o.userID), integration.ObscuroChainID)
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -11,7 +11,7 @@ import (
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ten-protocol/go-ten/tools/walletextension/common"
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"github.com/valyala/fasthttp"
 )
 
@@ -44,17 +44,19 @@ func (o *OGLib) Join() error {
 
 func (o *OGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
-	message := fmt.Sprintf("Register %s for %s", o.userID, strings.ToLower(addr.Hex()))
-	prefixedMessage := fmt.Sprintf(common.PersonalSignMessagePrefix, len(message), message)
+	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawData(string(o.userID))
+	if err != nil {
+		return err
+	}
 
-	messageHash := crypto.Keccak256([]byte(prefixedMessage))
+	messageHash := crypto.Keccak256(rawMessage)
 	sig, err := crypto.Sign(messageHash, pk)
 	if err != nil {
 		return fmt.Errorf("failed to sign message: %w", err)
 	}
 	sig[64] += 27
 	signature := "0x" + hex.EncodeToString(sig)
-	payload := fmt.Sprintf("{\"signature\": \"%s\", \"message\": \"%s\"}", signature, message)
+	payload := fmt.Sprintf("{\"signature\": \"%s\", \"address\": \"%s\"}", signature, addr.Hex())
 
 	// issue the registration message
 	req, err := http.NewRequestWithContext(
@@ -76,9 +78,12 @@ func (o *OGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) e
 	}
 
 	defer response.Body.Close()
-	_, err = io.ReadAll(response.Body)
+	r, err := io.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("unable to read response - %w", err)
+	}
+	if string(r) != "success" {
+		return fmt.Errorf("expected success, got %s", string(r))
 	}
 	return nil
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -51,6 +51,10 @@ const (
 	dbConnectionURLFlagName    = "dbConnectionURL"
 	dbConnectionURLFlagDefault = ""
 	dbConnectionURLFlagUsage   = "If dbType is set to mariaDB, this must be set. ex: obscurouser:password@tcp(127.0.0.1:3306)/ogdb"
+
+	tenChainIDName      = "tenChainID"
+	tenChainIDDefault   = 443
+	tenChainIDFlagUsage = "ChainID of Ten network that the gateway is communicating with"
 )
 
 func parseCLIArgs() config.Config {
@@ -65,6 +69,7 @@ func parseCLIArgs() config.Config {
 	verboseFlag := flag.Bool(verboseFlagName, verboseFlagDefault, verboseFlagUsage)
 	dbType := flag.String(dbTypeFlagName, dbTypeFlagDefault, dbTypeFlagUsage)
 	dbConnectionURL := flag.String(dbConnectionURLFlagName, dbConnectionURLFlagDefault, dbConnectionURLFlagUsage)
+	tenChainID := flag.Int(tenChainIDName, tenChainIDDefault, tenChainIDFlagUsage)
 	flag.Parse()
 
 	return config.Config{
@@ -78,5 +83,6 @@ func parseCLIArgs() config.Config {
 		VerboseFlag:             *verboseFlag,
 		DBType:                  *dbType,
 		DBConnectionURL:         *dbConnectionURL,
+		TenChainID:              *tenChainID,
 	}
 }

--- a/tools/walletextension/storage/database/001_init.sql
+++ b/tools/walletextension/storage/database/001_init.sql
@@ -5,11 +5,11 @@ USE ogdb;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ogdb.* TO 'obscurouser';
 
 CREATE TABLE IF NOT EXISTS ogdb.users (
-    user_id varbinary(32) PRIMARY KEY,
+    user_id varbinary(20) PRIMARY KEY,
     private_key varbinary(32)
     );
 CREATE TABLE IF NOT EXISTS ogdb.accounts (
-    user_id varbinary(32),
+    user_id varbinary(20),
     account_address varbinary(20),
     signature varbinary(65),
     FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE

--- a/tools/walletextension/storage/database/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite.go
@@ -39,7 +39,7 @@ func NewSqliteDatabase(dbPath string) (*SqliteDatabase, error) {
 
 	// create users table
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS users (
-		user_id binary(32) PRIMARY KEY,
+		user_id binary(20) PRIMARY KEY,
 		private_key binary(32)
 	);`)
 
@@ -49,7 +49,7 @@ func NewSqliteDatabase(dbPath string) (*SqliteDatabase, error) {
 
 	// create accounts table
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS accounts (
-		user_id binary(32),
+		user_id binary(20),
 		account_address binary(20),
 		signature binary(65),
     	FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	l2ChainIDHex         = "0x309"
+	l2ChainIDDecimal     = 443
 	enclavePrivateKeyHex = "81acce9620f0adf1728cb8df7f6b8b8df857955eb9e8b7aed6ef8390c09fc207"
 )
 
@@ -171,7 +172,7 @@ func (api *DummyAPI) reEncryptParams(encryptedParams []byte) (*responses.Enclave
 		return responses.AsEmptyResponse(), fmt.Errorf("could not decrypt params with enclave private key. Cause: %w", err)
 	}
 
-	encryptor, err := vkhandler.New(api.address, api.viewingKey, api.signature)
+	encryptor, err := vkhandler.New(api.address, api.viewingKey, api.signature, l2ChainIDDecimal)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create vk encryption for request - %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/config"
+
 	"github.com/ten-protocol/go-ten/go/common/log"
 
 	"github.com/ten-protocol/go-ten/tools/walletextension/useraccountmanager"
@@ -33,6 +35,7 @@ type WalletExtension struct {
 	logger             gethlog.Logger
 	stopControl        *stopcontrol.StopControl
 	version            string
+	config             *config.Config
 }
 
 func New(
@@ -42,6 +45,7 @@ func New(
 	stopControl *stopcontrol.StopControl,
 	version string,
 	logger gethlog.Logger,
+	config *config.Config,
 ) *WalletExtension {
 	return &WalletExtension{
 		hostAddr:           hostAddr,
@@ -51,6 +55,7 @@ func New(
 		logger:             logger,
 		stopControl:        stopControl,
 		version:            version,
+		config:             config,
 	}
 }
 
@@ -203,9 +208,8 @@ func (w *WalletExtension) GenerateAndStoreNewUser() (string, error) {
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
 func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte) error {
 	addressFromMessage := gethcommon.HexToAddress(address)
-
 	// check if a message was signed by the correct address and if the signature is valid
-	valid, err := viewingkey.VerifySignatureEIP712(hexUserID, &addressFromMessage, signature)
+	valid, err := viewingkey.VerifySignatureEIP712(hexUserID, &addressFromMessage, signature, int64(w.config.TenChainID))
 	if !valid && err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

We want to use EIP-712 style signatures to make it more clear what users are signing when prompted to sign viewingkey.
Additionally I changed userID size to 20 bytes.

### What changes were made as part of this PR

-  New method to verify EIP-712 messages when authenticating
- Check and accept new signatures in the enclave
- Fix tests to use new version
- Fix Obscuro Gateway frontent (javascript) to use new format
- Updated design file describing the approach used
- Changed size of userID to 20 bytes


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 




