### PR TITLE
Host: Monitor and serve important contract addresses

### DIFF
--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -101,10 +101,8 @@ type L1Publisher interface {
 	InitializeSecret(attestation *common.AttestationReport, encSecret common.EncryptedSharedEnclaveSecret) error
 	// RequestSecret will send a management contract transaction to request a secret from the enclave, returning the L1 head at time of sending
 	RequestSecret(report *common.AttestationReport) (gethcommon.Hash, error)
-	// ExtractSecretResponses will return all secret response tx from an L1 block
-	ExtractSecretResponses(block *types.Block) []*ethadapter.L1RespondSecretTx
-	// ExtractRollupTxs will return all rollup txs from an L1 block
-	ExtractRollupTxs(block *types.Block) []*ethadapter.L1RollupTx
+	// ExtractObscuroRelevantTransactions will return all Obscuro relevant tx from an L1 block
+	ExtractObscuroRelevantTransactions(block *types.Block) ([]*ethadapter.L1RespondSecretTx, []*ethadapter.L1RollupTx, []*ethadapter.L1SetImportantContractsTx)
 	// PublishRollup will create and publish a rollup tx to the management contract - fire and forget we don't wait for receipt
 	// todo (#1624) - With a single sequencer, it is problematic if rollup publication fails; handle this case better
 	PublishRollup(producedRollup *common.ExtRollup)
@@ -114,6 +112,11 @@ type L1Publisher interface {
 	FetchLatestPeersList() ([]string, error)
 
 	FetchLatestSeqNo() (*big.Int, error)
+
+	// GetImportantContracts returns a (cached) record of addresses of the important network contracts
+	GetImportantContracts() map[string]gethcommon.Address
+	// ResyncImportantContracts will fetch the latest important contracts from the management contract, update the cache
+	ResyncImportantContracts() error
 }
 
 // L2BatchRepository provides an interface for the host to request L2 batch data (live-streaming and historical)

--- a/go/common/query_types.go
+++ b/go/common/query_types.go
@@ -89,4 +89,5 @@ type ObscuroNetworkInfo struct {
 	L1StartHash               common.Hash
 	SequencerID               common.Address
 	MessageBusAddress         common.Address
+	ImportantContracts        map[string]common.Address // map of contract name to address
 }

--- a/go/ethadapter/l1_transaction.go
+++ b/go/ethadapter/l1_transaction.go
@@ -33,6 +33,11 @@ type L1RespondSecretTx struct {
 	HostAddress string
 }
 
+type L1SetImportantContractsTx struct {
+	Key        string
+	NewAddress gethcommon.Address
+}
+
 // Sign signs the payload with a given private key
 func (l *L1RespondSecretTx) Sign(privateKey *ecdsa.PrivateKey) *L1RespondSecretTx {
 	var data []byte

--- a/go/ethadapter/mgmtcontractlib/mgmt_contract_ABI.go
+++ b/go/ethadapter/mgmtcontractlib/mgmt_contract_ABI.go
@@ -3,11 +3,14 @@ package mgmtcontractlib
 import "github.com/ten-protocol/go-ten/contracts/generated/ManagementContract"
 
 const (
-	AddRollupMethod        = "AddRollup"
-	RespondSecretMethod    = "RespondNetworkSecret"
-	RequestSecretMethod    = "RequestNetworkSecret"
-	InitializeSecretMethod = "InitializeNetworkSecret" //#nosec
-	GetHostAddressesMethod = "GetHostAddresses"
+	AddRollupMethod                = "AddRollup"
+	RespondSecretMethod            = "RespondNetworkSecret"
+	RequestSecretMethod            = "RequestNetworkSecret"
+	InitializeSecretMethod         = "InitializeNetworkSecret" //#nosec
+	GetHostAddressesMethod         = "GetHostAddresses"
+	GetImportantContractKeysMethod = "GetImportantContractKeys"
+	SetImportantContractsMethod    = "SetImportantContractAddress"
+	GetImportantAddressMethod      = "importantContractAddresses"
 )
 
 var MgmtContractABI = ManagementContract.ManagementContractMetaData.ABI

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -277,9 +277,6 @@ func (g *Guardian) provideSecret() error {
 			return fmt.Errorf("next block after block=%s not found - %w", awaitFromBlock, err)
 		}
 		secretRespTxs, _, _ := g.sl.L1Publisher().ExtractObscuroRelevantTransactions(nextBlock)
-		if err != nil {
-			return fmt.Errorf("could not extract secret responses from block=%s - %w", nextBlock.Hash(), err)
-		}
 		for _, scrt := range secretRespTxs {
 			if scrt.RequesterID.Hex() == g.hostData.ID.Hex() {
 				err = g.enclaveClient.InitEnclave(scrt.Secret)

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -276,7 +276,7 @@ func (g *Guardian) provideSecret() error {
 		if err != nil {
 			return fmt.Errorf("next block after block=%s not found - %w", awaitFromBlock, err)
 		}
-		secretRespTxs := g.sl.L1Publisher().ExtractSecretResponses(nextBlock)
+		secretRespTxs, _, _ := g.sl.L1Publisher().ExtractObscuroRelevantTransactions(nextBlock)
 		if err != nil {
 			return fmt.Errorf("could not extract secret responses from block=%s - %w", nextBlock.Hash(), err)
 		}
@@ -435,13 +435,12 @@ func (g *Guardian) submitL1Block(block *common.L1Block, isLatest bool) (bool, er
 
 func (g *Guardian) processL1BlockTransactions(block *common.L1Block) {
 	// if there are any secret responses in the block we should refresh our P2P list to re-sync with the network
-	respTxs := g.sl.L1Publisher().ExtractSecretResponses(block)
-	if len(respTxs) > 0 {
+	secretRespTxs, rollupTxs, contractAddressTxs := g.sl.L1Publisher().ExtractObscuroRelevantTransactions(block)
+	if len(secretRespTxs) > 0 {
 		// new peers may have been granted access to the network, notify p2p service to refresh its peer list
 		go g.sl.P2P().RefreshPeerList()
 	}
 
-	rollupTxs := g.sl.L1Publisher().ExtractRollupTxs(block)
 	for _, rollup := range rollupTxs {
 		r, err := common.DecodeRollup(rollup.Rollup)
 		if err != nil {
@@ -455,6 +454,15 @@ func (g *Guardian) processL1BlockTransactions(block *common.L1Block) {
 				g.logger.Error("Could not store rollup.", log.ErrKey, err)
 			}
 		}
+	}
+
+	if len(contractAddressTxs) > 0 {
+		go func() {
+			err := g.sl.L1Publisher().ResyncImportantContracts()
+			if err != nil {
+				g.logger.Error("Could not resync important contracts", log.ErrKey, err)
+			}
+		}()
 	}
 }
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -204,8 +204,9 @@ func (h *host) ObscuroConfig() (*common.ObscuroNetworkInfo, error) {
 		ManagementContractAddress: h.config.ManagementContractAddress,
 		L1StartHash:               h.config.L1StartHash,
 
-		SequencerID:       h.config.SequencerID,
-		MessageBusAddress: h.config.MessageBusAddress,
+		SequencerID:        h.config.SequencerID,
+		MessageBusAddress:  h.config.MessageBusAddress,
+		ImportantContracts: h.services.L1Publisher().GetImportantContracts(),
 	}, nil
 }
 

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -161,6 +161,8 @@ func (p *Publisher) PublishSecretResponse(secretResponse *common.ProducedSecretR
 	return nil
 }
 
+// ExtractObscuroRelevantTransactions will extract any transactions from the block that are relevant to obscuro
+// todo (#2495) we should monitor for relevant L1 events instead of scanning every transaction in the block
 func (p *Publisher) ExtractObscuroRelevantTransactions(block *types.Block) ([]*ethadapter.L1RespondSecretTx, []*ethadapter.L1RollupTx, []*ethadapter.L1SetImportantContractsTx) {
 	var secretRespTxs []*ethadapter.L1RespondSecretTx
 	var rollupTxs []*ethadapter.L1RollupTx

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ten-protocol/go-ten/go/common/stopcontrol"
@@ -26,6 +27,11 @@ type Publisher struct {
 	hostWallet      wallet.Wallet // Wallet used to issue ethereum transactions
 	ethClient       ethadapter.EthClient
 	mgmtContractLib mgmtcontractlib.MgmtContractLib // Library to handle Management Contract lib operations
+
+	// cached map of important contract addresses (updated when we see a SetImportantContractsTx)
+	importantContractAddresses map[string]gethcommon.Address
+	// lock for the important contract addresses map
+	importantAddressesMutex sync.RWMutex
 
 	repository host.L1BlockRepository
 	logger     gethlog.Logger
@@ -57,10 +63,20 @@ func NewL1Publisher(
 		logger:                    logger,
 		maxWaitForL1Receipt:       maxWaitForL1Receipt,
 		retryIntervalForL1Receipt: retryIntervalForL1Receipt,
+
+		importantContractAddresses: map[string]gethcommon.Address{},
+		importantAddressesMutex:    sync.RWMutex{},
 	}
 }
 
 func (p *Publisher) Start() error {
+	go func() {
+		// Do an initial read of important contract addresses when service starts up
+		err := p.ResyncImportantContracts()
+		if err != nil {
+			p.logger.Error("Could not load important contract addresses", log.ErrKey, err)
+		}
+	}()
 	return nil
 }
 
@@ -145,8 +161,10 @@ func (p *Publisher) PublishSecretResponse(secretResponse *common.ProducedSecretR
 	return nil
 }
 
-func (p *Publisher) ExtractSecretResponses(block *types.Block) []*ethadapter.L1RespondSecretTx {
+func (p *Publisher) ExtractObscuroRelevantTransactions(block *types.Block) ([]*ethadapter.L1RespondSecretTx, []*ethadapter.L1RollupTx, []*ethadapter.L1SetImportantContractsTx) {
 	var secretRespTxs []*ethadapter.L1RespondSecretTx
+	var rollupTxs []*ethadapter.L1RollupTx
+	var contractAddressTxs []*ethadapter.L1SetImportantContractsTx
 	for _, tx := range block.Transactions() {
 		t := p.mgmtContractLib.DecodeTx(tx)
 		if t == nil {
@@ -154,23 +172,18 @@ func (p *Publisher) ExtractSecretResponses(block *types.Block) []*ethadapter.L1R
 		}
 		if scrtTx, ok := t.(*ethadapter.L1RespondSecretTx); ok {
 			secretRespTxs = append(secretRespTxs, scrtTx)
-		}
-	}
-	return secretRespTxs
-}
-
-func (p *Publisher) ExtractRollupTxs(block *types.Block) []*ethadapter.L1RollupTx {
-	var rollupTxs []*ethadapter.L1RollupTx
-	for _, tx := range block.Transactions() {
-		t := p.mgmtContractLib.DecodeTx(tx)
-		if t == nil {
 			continue
 		}
 		if rollupTx, ok := t.(*ethadapter.L1RollupTx); ok {
 			rollupTxs = append(rollupTxs, rollupTx)
+			continue
+		}
+		if contractAddressTx, ok := t.(*ethadapter.L1SetImportantContractsTx); ok {
+			contractAddressTxs = append(contractAddressTxs, contractAddressTx)
+			continue
 		}
 	}
-	return rollupTxs
+	return secretRespTxs, rollupTxs, contractAddressTxs
 }
 
 func (p *Publisher) FetchLatestSeqNo() (*big.Int, error) {
@@ -208,7 +221,7 @@ func (p *Publisher) PublishRollup(producedRollup *common.ExtRollup) {
 }
 
 func (p *Publisher) FetchLatestPeersList() ([]string, error) {
-	msg, err := p.mgmtContractLib.GetHostAddresses()
+	msg, err := p.mgmtContractLib.GetHostAddressesMsg()
 	if err != nil {
 		return nil, err
 	}
@@ -216,11 +229,10 @@ func (p *Publisher) FetchLatestPeersList() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	decodedResponse, err := p.mgmtContractLib.DecodeCallResponse(response)
+	hostAddresses, err := p.mgmtContractLib.DecodeHostAddressesResponse(response)
 	if err != nil {
 		return nil, err
 	}
-	hostAddresses := decodedResponse[0]
 
 	// We remove any duplicate addresses and our own address from the retrieved peer list
 	var filteredHostAddresses []string
@@ -237,6 +249,55 @@ func (p *Publisher) FetchLatestPeersList() ([]string, error) {
 	}
 
 	return filteredHostAddresses, nil
+}
+
+func (p *Publisher) GetImportantContracts() map[string]gethcommon.Address {
+	p.importantAddressesMutex.RLock()
+	defer p.importantAddressesMutex.RUnlock()
+	return p.importantContractAddresses
+}
+
+// ResyncImportantContracts will fetch the latest important contracts from the management contract and update the cached map
+// Note: this should be run in a goroutine as it makes L1 transactions in series and will block.
+// Cache is not overwritten until it completes.
+func (p *Publisher) ResyncImportantContracts() error {
+	getKeysCallMsg, err := p.mgmtContractLib.GetImportantContractKeysMsg()
+	if err != nil {
+		return fmt.Errorf("could not build callMsg for important contracts: %w", err)
+	}
+	keysResp, err := p.ethClient.CallContract(getKeysCallMsg)
+	if err != nil {
+		return fmt.Errorf("could not fetch important contracts: %w", err)
+	}
+
+	importantContracts, err := p.mgmtContractLib.DecodeImportantContractKeysResponse(keysResp)
+	if err != nil {
+		return fmt.Errorf("could not decode important contracts resp: %w", err)
+	}
+
+	contractsMap := make(map[string]gethcommon.Address)
+
+	for _, contract := range importantContracts {
+		getAddressCallMsg, err := p.mgmtContractLib.GetImportantAddressCallMsg(contract)
+		if err != nil {
+			return fmt.Errorf("could not build callMsg for important contract=%s: %w", contract, err)
+		}
+		addrResp, err := p.ethClient.CallContract(getAddressCallMsg)
+		if err != nil {
+			return fmt.Errorf("could not fetch important contract=%s: %w", contract, err)
+		}
+		contractAddress, err := p.mgmtContractLib.DecodeImportantAddressResponse(addrResp)
+		if err != nil {
+			return fmt.Errorf("could not decode important contract=%s resp: %w", contract, err)
+		}
+		contractsMap[contract] = contractAddress
+	}
+
+	p.importantAddressesMutex.Lock()
+	defer p.importantAddressesMutex.Unlock()
+	p.importantContractAddresses = contractsMap
+
+	return nil
 }
 
 // publishTransaction will keep trying unless the L1 seems to be unavailable or the tx is otherwise rejected

--- a/integration/ethereummock/mgmt_contract_lib.go
+++ b/integration/ethereummock/mgmt_contract_lib.go
@@ -71,12 +71,32 @@ func (m *mockContractLib) CreateInitializeSecret(tx *ethadapter.L1InitializeSecr
 	return encodeTx(tx, initializeSecretTxAddr)
 }
 
-func (m *mockContractLib) GetHostAddresses() (ethereum.CallMsg, error) {
+func (m *mockContractLib) GetHostAddressesMsg() (ethereum.CallMsg, error) {
 	return ethereum.CallMsg{}, nil
 }
 
-func (m *mockContractLib) DecodeCallResponse([]byte) ([][]string, error) {
-	return [][]string{{""}}, nil
+func (m *mockContractLib) DecodeHostAddressesResponse([]byte) ([]string, error) {
+	return []string{""}, nil
+}
+
+func (m *mockContractLib) GetImportantContractKeysMsg() (ethereum.CallMsg, error) {
+	return ethereum.CallMsg{}, nil
+}
+
+func (m *mockContractLib) DecodeImportantContractKeysResponse([]byte) ([]string, error) {
+	return []string{""}, nil
+}
+
+func (m *mockContractLib) SetImportantContractMsg(string, gethcommon.Address) (ethereum.CallMsg, error) {
+	return ethereum.CallMsg{}, nil
+}
+
+func (m *mockContractLib) GetImportantAddressCallMsg(string) (ethereum.CallMsg, error) {
+	return ethereum.CallMsg{}, nil
+}
+
+func (m *mockContractLib) DecodeImportantAddressResponse([]byte) (gethcommon.Address, error) {
+	return gethcommon.Address{}, nil
 }
 
 func decodeTx(tx *types.Transaction) ethadapter.L1Transaction {

--- a/integration/networktest/actions/l1/important_contracts.go
+++ b/integration/networktest/actions/l1/important_contracts.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/obscuronet/go-obscuro/go/common/retry"
-	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
-	"github.com/obscuronet/go-obscuro/go/obsclient"
-	"github.com/obscuronet/go-obscuro/integration/common/testlog"
-	"github.com/obscuronet/go-obscuro/integration/networktest"
 	"github.com/pkg/errors"
+	"github.com/ten-protocol/go-ten/go/common/retry"
+	"github.com/ten-protocol/go-ten/go/ethadapter/mgmtcontractlib"
+	"github.com/ten-protocol/go-ten/go/obsclient"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
+	"github.com/ten-protocol/go-ten/integration/networktest"
 )
 
 type setImportantContract struct {

--- a/integration/networktest/actions/l1/important_contracts.go
+++ b/integration/networktest/actions/l1/important_contracts.go
@@ -1,0 +1,106 @@
+package l1
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/obscuronet/go-obscuro/go/common/retry"
+	"github.com/obscuronet/go-obscuro/go/ethadapter/mgmtcontractlib"
+	"github.com/obscuronet/go-obscuro/go/obsclient"
+	"github.com/obscuronet/go-obscuro/integration/common/testlog"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/pkg/errors"
+)
+
+type setImportantContract struct {
+	contractKey     string
+	contractAddress common.Address
+}
+
+func SetImportantContract(contractKey string, contractAddress common.Address) networktest.Action {
+	return &setImportantContract{
+		contractKey:     contractKey,
+		contractAddress: contractAddress,
+	}
+}
+
+func (s *setImportantContract) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+	obsClient, err := obsclient.Dial(network.ValidatorRPCAddress(0))
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to dial obsClient")
+	}
+
+	networkCfg, err := obsClient.GetConfig()
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to get network config")
+	}
+
+	l1Client, err := network.GetL1Client()
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to get L1 client")
+	}
+
+	mgmtContract := mgmtcontractlib.NewMgmtContractLib(&networkCfg.ManagementContractAddress, testlog.Logger())
+
+	msg, err := mgmtContract.SetImportantContractMsg(s.contractKey, s.contractAddress)
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to create SetImportantContractMsg")
+	}
+
+	txData := &types.LegacyTx{
+		To:   &networkCfg.ManagementContractAddress,
+		Data: msg.Data,
+	}
+	mcOwner, err := network.GetMCOwnerWallet()
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to get MC owner wallet")
+	}
+	// !! Important note !!
+	// The ownerOnly check in the contract doesn't like the gas estimate in here, to test you may need to hardcode a
+	// the gas value when the estimate errors
+	tx, err := l1Client.PrepareTransactionToSend(txData, networkCfg.ManagementContractAddress, mcOwner.GetNonceAndIncrement())
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to prepare tx")
+	}
+	signedTx, err := mcOwner.SignTransaction(tx)
+	if err != nil {
+		return ctx, errors.Wrap(err, "failed to sign tx")
+	}
+	err = l1Client.SendTransaction(signedTx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to send tx")
+	}
+
+	// wait for tx to be mined
+	return ctx, retry.Do(func() error {
+		receipt, err := l1Client.TransactionReceipt(signedTx.Hash())
+		if err != nil {
+			return err
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			return retry.FailFast(errors.New("tx failed"))
+		}
+		return nil
+	}, retry.NewTimeoutStrategy(15*time.Second, 1*time.Second))
+}
+
+func (s *setImportantContract) Verify(_ context.Context, network networktest.NetworkConnector) error {
+	cli, err := obsclient.Dial(network.ValidatorRPCAddress(0))
+	if err != nil {
+		return errors.Wrap(err, "failed to dial obsClient")
+	}
+	networkCfg, err := cli.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get network config")
+	}
+
+	if networkCfg.ImportantContracts == nil || len(networkCfg.ImportantContracts) == 0 {
+		return errors.New("no important contracts set")
+	}
+	if addr, ok := networkCfg.ImportantContracts[s.contractKey]; !ok || addr != s.contractAddress {
+		return errors.New("important contract not set")
+	}
+	return nil
+}

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/obscuronet/go-obscuro/go/wallet"
+	"github.com/ten-protocol/go-ten/go/wallet"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"time"
+
+	"github.com/obscuronet/go-obscuro/go/wallet"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -123,4 +126,8 @@ func (t *testnetConnector) AllocateFaucetFundsWithWallet(ctx context.Context, ac
 		return fmt.Errorf("faucet transaction receipt status not successful - %v", receipt.Status)
 	}
 	return nil
+}
+
+func (t *testnetConnector) GetMCOwnerWallet() (wallet.Wallet, error) {
+	return nil, errors.New("testnet connector environments cannot access the MC owner wallet")
 }

--- a/integration/networktest/interfaces.go
+++ b/integration/networktest/interfaces.go
@@ -4,13 +4,16 @@ import (
 	"context"
 
 	"github.com/ten-protocol/go-ten/go/ethadapter"
+	"github.com/ten-protocol/go-ten/go/wallet"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // NetworkConnector represents the network being tested against, e.g. testnet, dev-testnet, dev-sim
 //
-// It provides network details (standard contract addresses) and easy client setup for sim users
+// # It provides network details (standard contract addresses) and easy client setup for sim users
+//
+// Note: some of these methods may not be available for some networks (e.g. MC Owner wallet for live testnets)
 type NetworkConnector interface {
 	ChainID() int64
 	// AllocateFaucetFunds uses the networks default faucet mechanism for allocating funds to a test account
@@ -21,6 +24,7 @@ type NetworkConnector interface {
 	GetSequencerNode() NodeOperator
 	GetValidatorNode(idx int) NodeOperator
 	GetL1Client() (ethadapter.EthClient, error)
+	GetMCOwnerWallet() (wallet.Wallet, error) // wallet that owns the management contract (network admin)
 }
 
 // Action is any step in a test, they will typically be either minimally small steps in the test or they will be containers

--- a/integration/networktest/tests/bridge/important_contracts_test.go
+++ b/integration/networktest/tests/bridge/important_contracts_test.go
@@ -1,0 +1,23 @@
+package bridge
+
+import (
+	"testing"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/obscuronet/go-obscuro/integration/networktest"
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
+	"github.com/obscuronet/go-obscuro/integration/networktest/actions/l1"
+	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+)
+
+func TestImportantContractsLookup(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"important-contracts-lookup",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			l1.SetImportantContract("L1TestContract", gethcommon.HexToAddress("0x64")),
+		),
+	)
+}

--- a/integration/networktest/tests/bridge/important_contracts_test.go
+++ b/integration/networktest/tests/bridge/important_contracts_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/obscuronet/go-obscuro/integration/networktest"
-	"github.com/obscuronet/go-obscuro/integration/networktest/actions"
-	"github.com/obscuronet/go-obscuro/integration/networktest/actions/l1"
-	"github.com/obscuronet/go-obscuro/integration/networktest/env"
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions/l1"
+	"github.com/ten-protocol/go-ten/integration/networktest/env"
 )
 
 func TestImportantContractsLookup(t *testing.T) {

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -54,6 +54,10 @@ type InMemDevNetwork struct {
 	faucetLock sync.Mutex
 }
 
+func (s *InMemDevNetwork) GetMCOwnerWallet() (wallet.Wallet, error) {
+	return s.networkWallets.MCOwnerWallet, nil
+}
+
 func (s *InMemDevNetwork) ChainID() int64 {
 	return integration.ObscuroChainID
 }


### PR DESCRIPTION
### Why this change is needed

For the near term we want to make important network contract addresses to be available. This is especially useful for short-lived testnets etc.

The data is published to the L1 management contract, this PR has node hosts monitor that contract and serve the addresses that are stored in it.

### What changes were made as part of this PR

- host to cache L1 important contracts data and serve it with network info on RPC method
- guardian to look out for L1 transactions that change the important contracts, update cache
- add network test that adds an important contract to the L1 and checks that the host starts serving it

Serve the cached addresses with the network info RPC method.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/obscuronet/obscuro-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


