### PR TITLE
add version to websocket paths

### DIFF
--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -95,7 +95,7 @@ func httpRequestHandler(walletExt *walletextension.WalletExtension, resp http.Re
 func NewWSRoutes(walletExt *walletextension.WalletExtension) []Route {
 	return []Route{
 		{
-			Name: common.PathRoot,
+			Name: common.APIVersion1 + common.PathRoot,
 			Func: wsHandler(walletExt, ethRequestHandler),
 		},
 		{

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -132,7 +132,7 @@ func makeHTTPEthJSONReqWithUserID(port int, method string, params interface{}, u
 // Makes an Ethereum JSON RPC request over websockets and returns the response body.
 func makeWSEthJSONReq(port int, method string, params interface{}) ([]byte, *websocket.Conn) {
 	reqBody := prepareRequestBody(method, params)
-	return makeRequestWS(fmt.Sprintf("ws://%s:%d", common.Localhost, port), reqBody)
+	return makeRequestWS(fmt.Sprintf("ws://%s:%d%s/", common.Localhost, port, common.APIVersion1), reqBody)
 }
 
 func makeWSEthJSONReqWithConn(conn *websocket.Conn, method string, params interface{}) []byte {
@@ -141,7 +141,7 @@ func makeWSEthJSONReqWithConn(conn *websocket.Conn, method string, params interf
 }
 
 func openWSConn(port int) (*websocket.Conn, error) {
-	conn, dialResp, err := websocket.DefaultDialer.Dial(fmt.Sprintf("ws://%s:%d", common.Localhost, port), nil)
+	conn, dialResp, err := websocket.DefaultDialer.Dial(fmt.Sprintf("ws://%s:%d%s/", common.Localhost, port, common.APIVersion1), nil)
 	if dialResp != nil && dialResp.Body != nil {
 		defer dialResp.Body.Close()
 	}


### PR DESCRIPTION
### Why this change is needed

There was no version (as for http) for websocket paths.

### What changes were made as part of this PR

Version added to the path

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


