### PR TITLE
Fix the msg bus deploy at genesis

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -208,7 +208,8 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 		return nil, fmt.Errorf("failed adding cross chain data to batch. Cause: %w", err)
 	}
 
-	executor.populateHeader(&copyBatch, allReceipts(txReceipts, ccReceipts))
+	allReceipts := append(txReceipts, ccReceipts...)
+	executor.populateHeader(&copyBatch, allReceipts)
 	if failForEmptyBatch &&
 		len(txReceipts) == 0 &&
 		len(ccReceipts) == 0 &&
@@ -220,7 +221,7 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 	}
 
 	// the logs and receipts produced by the EVM have the wrong hash which must be adjusted
-	for _, receipt := range txReceipts {
+	for _, receipt := range allReceipts {
 		receipt.BlockHash = copyBatch.Hash()
 		for _, l := range receipt.Logs {
 			l.BlockHash = copyBatch.Hash()
@@ -229,7 +230,7 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 
 	return &ComputedBatch{
 		Batch:    &copyBatch,
-		Receipts: txReceipts,
+		Receipts: allReceipts,
 		Commit: func(deleteEmptyObjects bool) (gethcommon.Hash, error) {
 			executor.stateDBMutex.Lock()
 			defer executor.stateDBMutex.Unlock()
@@ -427,10 +428,6 @@ func (executor *batchExecutor) processTransactions(
 	sort.Sort(sortByTxIndex(txReceipts))
 
 	return executedTransactions, excludedTransactions, txReceipts, nil
-}
-
-func allReceipts(txReceipts []*types.Receipt, depositReceipts []*types.Receipt) types.Receipts {
-	return append(txReceipts, depositReceipts...)
 }
 
 type sortByTxIndex []*types.Receipt

--- a/integration/obscuroscan/obscuroscan_test.go
+++ b/integration/obscuroscan/obscuroscan_test.go
@@ -81,12 +81,12 @@ func TestObscuroscan(t *testing.T) {
 	statusCode, body, err := fasthttp.Get(nil, fmt.Sprintf("%s/count/contracts/", serverAddress))
 	assert.NoError(t, err)
 	assert.Equal(t, 200, statusCode)
-	assert.Equal(t, "{\"count\":1}", string(body))
+	assert.Equal(t, "{\"count\":2}", string(body))
 
 	statusCode, body, err = fasthttp.Get(nil, fmt.Sprintf("%s/count/transactions/", serverAddress))
 	assert.NoError(t, err)
 	assert.Equal(t, 200, statusCode)
-	assert.Equal(t, "{\"count\":5}", string(body))
+	assert.Equal(t, "{\"count\":6}", string(body))
 
 	statusCode, body, err = fasthttp.Get(nil, fmt.Sprintf("%s/items/batch/latest/", serverAddress))
 	assert.NoError(t, err)
@@ -120,8 +120,8 @@ func TestObscuroscan(t *testing.T) {
 	publicTxsObj := publicTxsRes{}
 	err = json.Unmarshal(body, &publicTxsObj)
 	assert.NoError(t, err)
-	assert.Equal(t, 5, len(publicTxsObj.Result.TransactionsData))
-	assert.Equal(t, uint64(5), publicTxsObj.Result.Total)
+	assert.Equal(t, 6, len(publicTxsObj.Result.TransactionsData))
+	assert.Equal(t, uint64(6), publicTxsObj.Result.Total)
 
 	statusCode, body, err = fasthttp.Get(nil, fmt.Sprintf("%s/items/batches/?offset=0&size=10", serverAddress))
 	assert.NoError(t, err)

--- a/tools/walletextension/test/utils.go
+++ b/tools/walletextension/test/utils.go
@@ -31,7 +31,7 @@ import (
 
 const jsonID = "1"
 
-func createWalExtCfg(connectPort, wallHTTPPort, wallWSPort int) *config.Config {
+func createWalExtCfg(connectPort, wallHTTPPort, wallWSPort int) *config.Config { //nolint: unparam
 	testDBPath, err := os.CreateTemp("", "")
 	if err != nil {
 		panic("could not create persistence file for wallet extension tests")
@@ -61,7 +61,7 @@ func createWalExt(t *testing.T, walExtCfg *config.Config) func() error {
 }
 
 // Creates an RPC layer that the wallet extension can connect to. Returns a handle to shut down the host.
-func createDummyHost(t *testing.T, wsRPCPort int) (*DummyAPI, func() error) {
+func createDummyHost(t *testing.T, wsRPCPort int) (*DummyAPI, func() error) { //nolint: unparam
 	dummyAPI := NewDummyAPI()
 	cfg := gethnode.Config{
 		WSHost:    common.Localhost,
@@ -124,7 +124,7 @@ func makeHTTPEthJSONReqWithPath(port int, path string) []byte {
 }
 
 // Makes an Ethereum JSON RPC request over HTTP and returns the response body with userID query paremeter.
-func makeHTTPEthJSONReqWithUserID(port int, method string, params interface{}, userID string) []byte {
+func makeHTTPEthJSONReqWithUserID(port int, method string, params interface{}, userID string) []byte { //nolint: unparam
 	reqBody := prepareRequestBody(method, params)
 	return makeRequestHTTP(fmt.Sprintf("http://%s:%d/v1/?u=%s", common.Localhost, port, userID), reqBody)
 }

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -41,7 +41,7 @@ func TestWalletExtension(t *testing.T) {
 		"canRegisterViewingKeyAndMakeRequestsOverWebsockets":          canRegisterViewingKeyAndMakeRequestsOverWebsockets,
 	} {
 		t.Run(name, func(t *testing.T) {
-			hostPort := _hostWSPort + i*_testOffset
+			hostPort := _hostWSPort
 			dummyAPI, shutDownHost := createDummyHost(t, hostPort)
 			shutdownWallet := createWalExt(t, createWalExtCfg(hostPort, hostPort+1, hostPort+2))
 

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -18,9 +18,7 @@ import (
 const (
 	errFailedDecrypt = "could not decrypt bytes with viewing key"
 	dummyParams      = "dummyParams"
-	jsonKeyTopics    = "topics"
 	_hostWSPort      = integration.StartPortWalletExtensionUnitTest
-	_testOffset      = 100 // offset each test by a multiplier of the offset to avoid port colision. ie: 	hostPort := _hostWSPort + _testOffset*2
 )
 
 type testHelper struct {
@@ -41,14 +39,13 @@ func TestWalletExtension(t *testing.T) {
 		"canRegisterViewingKeyAndMakeRequestsOverWebsockets":          canRegisterViewingKeyAndMakeRequestsOverWebsockets,
 	} {
 		t.Run(name, func(t *testing.T) {
-			hostPort := _hostWSPort
-			dummyAPI, shutDownHost := createDummyHost(t, hostPort)
-			shutdownWallet := createWalExt(t, createWalExtCfg(hostPort, hostPort+1, hostPort+2))
+			dummyAPI, shutDownHost := createDummyHost(t, _hostWSPort)
+			shutdownWallet := createWalExt(t, createWalExtCfg(_hostWSPort, _hostWSPort+1, _hostWSPort+2))
 
 			h := &testHelper{
-				hostPort:       hostPort,
-				walletHTTPPort: hostPort + 1,
-				walletWSPort:   hostPort + 2,
+				hostPort:       _hostWSPort,
+				walletHTTPPort: _hostWSPort + 1,
+				walletWSPort:   _hostWSPort + 2,
 				hostAPI:        dummyAPI,
 			}
 
@@ -173,14 +170,13 @@ func canRegisterViewingKeyAndMakeRequestsOverWebsockets(t *testing.T, testHelper
 }
 
 func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
-	hostPort := _hostWSPort + _testOffset*7
-	walletHTTPPort := hostPort + 1
-	walletWSPort := hostPort + 2
+	walletHTTPPort := _hostWSPort + 1
+	walletWSPort := _hostWSPort + 2
 
-	_, shutdownHost := createDummyHost(t, hostPort)
+	_, shutdownHost := createDummyHost(t, _hostWSPort)
 	defer shutdownHost() //nolint: errcheck
 
-	shutdownWallet := createWalExt(t, createWalExtCfg(hostPort, walletHTTPPort, walletWSPort))
+	shutdownWallet := createWalExt(t, createWalExtCfg(_hostWSPort, walletHTTPPort, walletWSPort))
 	defer shutdownWallet() //nolint: errcheck
 
 	conn, err := openWSConn(walletWSPort)
@@ -202,13 +198,12 @@ func TestCannotInvokeSensitiveMethodsWithoutViewingKey(t *testing.T) {
 }
 
 func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
-	hostPort := _hostWSPort + _testOffset*8
-	walletHTTPPort := hostPort + 1
-	walletWSPort := hostPort + 2
+	walletHTTPPort := _hostWSPort + 1
+	walletWSPort := _hostWSPort + 2
 
-	dummyAPI, shutdownHost := createDummyHost(t, hostPort)
+	dummyAPI, shutdownHost := createDummyHost(t, _hostWSPort)
 	defer shutdownHost() //nolint: errcheck
-	walExtCfg := createWalExtCfg(hostPort, walletHTTPPort, walletWSPort)
+	walExtCfg := createWalExtCfg(_hostWSPort, walletHTTPPort, walletWSPort)
 	shutdownWallet := createWalExt(t, walExtCfg)
 
 	addr, viewingKeyBytes, signature := simulateViewingKeyRegister(t, walletHTTPPort, walletWSPort, false)
@@ -278,13 +273,12 @@ func TestKeysAreReloadedWhenWalletExtensionRestarts(t *testing.T) {
 //}
 
 func TestGetStorageAtForReturningUserID(t *testing.T) {
-	hostPort := _hostWSPort + _testOffset*8
-	walletHTTPPort := hostPort + 1
-	walletWSPort := hostPort + 2
+	walletHTTPPort := _hostWSPort + 1
+	walletWSPort := _hostWSPort + 2
 
-	createDummyHost(t, hostPort)
-	walExtCfg := createWalExtCfg(hostPort, walletHTTPPort, walletWSPort)
-	createWalExtCfg(hostPort, walletHTTPPort, walletWSPort)
+	createDummyHost(t, _hostWSPort)
+	walExtCfg := createWalExtCfg(_hostWSPort, walletHTTPPort, walletWSPort)
+	createWalExtCfg(_hostWSPort, walletHTTPPort, walletWSPort)
 	createWalExt(t, walExtCfg)
 
 	// create userID


### PR DESCRIPTION
### Why this change is needed

Message bus deployment fix.

The message bus contract is deployed on batch # 2. 
Previously the msg bus contract would be added to the mempool and eventually minted, but now it can't be added to the mempool because it's a syntetic tx which geth doesnt know about.


### What changes were made as part of this PR

- After the creation of the genesis batch a new batch is produced with the msg bus transaction


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality to include cross-chain receipts in results.
  - Introduced a new parameter to control batch production behavior on empty transactions.

- **Bug Fixes**
  - Fixed issues with genesis batch creation when no transactions are present.
  - Adjusted test cases to align with updated transaction and contract counts.

- **Refactor**
  - Streamlined batch processing by removing redundant functions.
  - Updated batch duplication logic to accommodate new return types.

- **Tests**
  - Simplified port assignments in wallet extension tests.
  - Removed unused constants and refactored test functions for clarity.

- **Documentation**
  - Improved logging details for genesis batch creation and Message Bus Contract minting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->