### PR TITLE
Contract deployment: store important addresses

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -309,6 +309,7 @@ jobs:
           -l2_private_key=8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b \
           -l2_hoc_private_key=6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682 \
           -l2_poc_private_key=4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8 \
+          -management_contract_addr=${{ needs.build.outputs.MGMT_CONTRACT_ADDR }} \
           -message_bus_contract_addr=${{ needs.build.outputs.MSG_BUS_CONTRACT_ADDR }} \
           -docker_image=${{ vars.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG }} \
           -faucet_funds=${{ vars.FAUCET_INITIAL_FUNDS }}

--- a/contracts/deployment_scripts/messenger/layer1/001_deploy_cross_chain_messenger.ts
+++ b/contracts/deployment_scripts/messenger/layer1/001_deploy_cross_chain_messenger.ts
@@ -13,16 +13,26 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     const { deployer } = await hre.companionNetworks.layer1.getNamedAccounts();
 
-    // Read the message bus address from the management contract deployment.
+    // Use the contract addresses from the management contract deployment.
+    const mgmtContractAddress = process.env.MGMT_CONTRACT_ADDRESS!!
     const messageBusAddress : string = process.env.MESSAGE_BUS_ADDRESS!!
     console.log(`Message Bus address ${messageBusAddress}`);
 
     // Setup the cross chain messenger and point it to the message bus from the management contract to be used for validation
-    await deployments.deploy('CrossChainMessenger', {
+    const crossChainDeployment = await deployments.deploy('CrossChainMessenger', {
         from: deployer,
         args: [ messageBusAddress ],
         log: true,
     });
+
+    // get management contract and write the cross chain messenger address to it
+    const mgmtContract = (await hre.ethers.getContractFactory('ManagementContract')).attach(mgmtContractAddress)
+    const tx = await mgmtContract.SetImportantContractAddress("L1CrossChainMessenger", crossChainDeployment.address);
+    const receipt = await tx.wait();
+    if (receipt.status !== 1) {
+        console.log("Failed to set L1CrossChainMessenger in management contract");
+    }
+    console.log(`L1CrossChainMessenger=${crossChainDeployment.address}`)
 };
 
 export default func;

--- a/testnet/launcher/l2contractdeployer/cmd/cli.go
+++ b/testnet/launcher/l2contractdeployer/cmd/cli.go
@@ -11,6 +11,7 @@ type L2ContractDeployerConfigCLI struct {
 	dockerImage            string
 	l2Host                 string
 	l2WSPort               int
+	managementContractAddr string
 	messageBusContractAddr string
 	l2PrivateKey           string
 	l2HOCPrivateKey        string
@@ -28,6 +29,7 @@ func ParseConfigCLI() *L2ContractDeployerConfigCLI {
 	dockerImage := flag.String(dockerImageFlag, "testnetobscuronet.azurecr.io/obscuronet/hardhatdeployer:latest", flagUsageMap[dockerImageFlag])
 	l2Host := flag.String(l2HostFlag, "", flagUsageMap[l2HostFlag])
 	l2WSPort := flag.Int(l2WSPortFlag, 9000, flagUsageMap[l2WSPortFlag])
+	managementContractAddr := flag.String(managementContractAddrFlag, "", flagUsageMap[managementContractAddrFlag])
 	messageBusContractAddr := flag.String(messageBusContractAddrFlag, "", flagUsageMap[messageBusContractAddrFlag])
 	l2PrivateKey := flag.String(l2privateKeyFlag, "", flagUsageMap[l2privateKeyFlag])
 	l2HOCPrivateKey := flag.String(l2HOCPrivateKeyFlag, "", flagUsageMap[l2HOCPrivateKeyFlag])
@@ -41,6 +43,7 @@ func ParseConfigCLI() *L2ContractDeployerConfigCLI {
 	cfg.dockerImage = *dockerImage
 	cfg.l2Host = *l2Host
 	cfg.l2WSPort = *l2WSPort
+	cfg.managementContractAddr = *managementContractAddr
 	cfg.messageBusContractAddr = *messageBusContractAddr
 	cfg.l2PrivateKey = *l2PrivateKey
 	cfg.l2HOCPrivateKey = *l2POCPrivateKey

--- a/testnet/launcher/l2contractdeployer/cmd/cli_flags.go
+++ b/testnet/launcher/l2contractdeployer/cmd/cli_flags.go
@@ -7,6 +7,7 @@ const (
 	dockerImageFlag            = "docker_image"
 	l2HostFlag                 = "l2_host"
 	l2WSPortFlag               = "l2_ws_port"
+	managementContractAddrFlag = "management_contract_addr"
 	messageBusContractAddrFlag = "message_bus_contract_addr"
 	l2privateKeyFlag           = "l2_private_key"
 	l2HOCPrivateKeyFlag        = "l2_hoc_private_key"
@@ -23,6 +24,7 @@ func getFlagUsageMap() map[string]string {
 		dockerImageFlag:            "Docker image to run",
 		l2HostFlag:                 "Layer 2 network host addr",
 		l2WSPortFlag:               "Layer 2 network WebSocket port",
+		managementContractAddrFlag: "Management contract address",
 		messageBusContractAddrFlag: "Message bus contract address",
 		l2privateKeyFlag:           "Layer 2 private key",
 		l2HOCPrivateKeyFlag:        "Layer 2 HOC contract private key",

--- a/testnet/launcher/l2contractdeployer/cmd/main.go
+++ b/testnet/launcher/l2contractdeployer/cmd/main.go
@@ -16,6 +16,7 @@ func main() {
 			l2cd.WithL2Host(cliConfig.l2Host),                                    // "host"
 			l2cd.WithL2WSPort(cliConfig.l2WSPort),                                // 81
 			l2cd.WithL1PrivateKey(cliConfig.privateKey),                          // "f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb"
+			l2cd.WithManagementContractAddress(cliConfig.managementContractAddr), //
 			l2cd.WithMessageBusContractAddress(cliConfig.messageBusContractAddr), // "0xFD03804faCA2538F4633B3EBdfEfc38adafa259B"
 			l2cd.WithL2PrivateKey(cliConfig.l2PrivateKey),                        // "8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"
 			l2cd.WithHocPKString(cliConfig.l2HOCPrivateKey),                      // "6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"),

--- a/testnet/launcher/l2contractdeployer/config.go
+++ b/testnet/launcher/l2contractdeployer/config.go
@@ -5,16 +5,17 @@ type Option = func(c *Config)
 
 // Config holds the properties that configure the package
 type Config struct {
-	l1HTTPURL           string
-	l1privateKey        string
-	l2Port              int
-	l2Host              string
-	l2PrivateKey        string
-	hocPKString         string
-	pocPKString         string
-	messageBusAddress   string
-	dockerImage         string
-	faucetPrefundAmount string
+	l1HTTPURL                 string
+	l1privateKey              string
+	l2Port                    int
+	l2Host                    string
+	l2PrivateKey              string
+	hocPKString               string
+	pocPKString               string
+	managementContractAddress string
+	messageBusAddress         string
+	dockerImage               string
+	faucetPrefundAmount       string
 }
 
 func NewContractDeployerConfig(opts ...Option) *Config {
@@ -50,6 +51,12 @@ func WithL2WSPort(i int) Option {
 func WithL2Host(s string) Option {
 	return func(c *Config) {
 		c.l2Host = s
+	}
+}
+
+func WithManagementContractAddress(s string) Option {
+	return func(c *Config) {
+		c.managementContractAddress = s
 	}
 }
 

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -33,9 +33,9 @@ func (n *ContractDeployer) Start() error {
 	}
 
 	envs := map[string]string{
-		"PREFUND_FAUCET_AMOUNT":       n.cfg.faucetPrefundAmount,
-		"MANAGEMENT_CONTRACT_ADDRESS": n.cfg.managementContractAddress,
-		"MESSAGE_BUS_ADDRESS":         n.cfg.messageBusAddress,
+		"PREFUND_FAUCET_AMOUNT": n.cfg.faucetPrefundAmount,
+		"MGMT_CONTRACT_ADDRESS": n.cfg.managementContractAddress,
+		"MESSAGE_BUS_ADDRESS":   n.cfg.messageBusAddress,
 		"NETWORK_JSON": fmt.Sprintf(`
 {
         "layer1" : {

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -33,8 +33,9 @@ func (n *ContractDeployer) Start() error {
 	}
 
 	envs := map[string]string{
-		"PREFUND_FAUCET_AMOUNT": n.cfg.faucetPrefundAmount,
-		"MESSAGE_BUS_ADDRESS":   n.cfg.messageBusAddress,
+		"PREFUND_FAUCET_AMOUNT":       n.cfg.faucetPrefundAmount,
+		"MANAGEMENT_CONTRACT_ADDRESS": n.cfg.managementContractAddress,
+		"MESSAGE_BUS_ADDRESS":         n.cfg.messageBusAddress,
 		"NETWORK_JSON": fmt.Sprintf(`
 {
         "layer1" : {


### PR DESCRIPTION
### Why this change is needed

When L1Bridge and L1CrossChainMessenger contracts are deployed we want to write their addresses to the mgmt contract so they are stored in an accessible source of truth (useful for automated testing with often short-lived testnets)

### What changes were made as part of this PR

- pass mgmt contract address to L2 contract deployment
- call mgmt contract 'SetImportantContractAddress' method after the two deployments mentioned above

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 




