### PR TITLE
Prevent concurrent writes to a websocket connection

### DIFF
--- a/tools/walletextension/userconn/user_conn.go
+++ b/tools/walletextension/userconn/user_conn.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/ten-protocol/go-ten/go/common/log"
 
@@ -39,6 +40,7 @@ type userConnWS struct {
 	isClosed bool
 	logger   gethlog.Logger
 	req      *http.Request
+	mu       sync.Mutex
 }
 
 func NewUserConnHTTP(resp http.ResponseWriter, req *http.Request, logger gethlog.Logger) UserConn {
@@ -106,6 +108,9 @@ func (w *userConnWS) ReadRequest() ([]byte, error) {
 }
 
 func (w *userConnWS) WriteResponse(msg []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	err := w.conn.WriteMessage(websocket.TextMessage, msg)
 	if err != nil {
 		if websocket.IsCloseError(err) || strings.Contains(string(msg), "EOF") {


### PR DESCRIPTION
### Why this change is needed

Gateway crashed because of this. See logs:

https://app.datadoghq.eu/logs?query=service%3Aobscuro_gateway_sepolia_testnet%20container_id%3A6f39991112df50e334e5c2627fa104decaae3e0977db20b27ef10540a5d843f9%20&cols=host%2Cservice&event=AgAAAYv1CizXdvjiHgAAAAAAAAAYAAAAAEFZdjFDamRRQUFDZHVZQnZoUWZ5M1FBSAAAACQAAAAAMDE4YmY1MmYtNGM3NC00MDRiLWFiNGUtOGZhNDcxN2EwNzMw&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1700556971076&to_ts=1700643371076&live=true

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


