### PR TITLE
Adding Tx Hash to the faucet funding

### DIFF
--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -111,7 +111,7 @@ func createObscuroNetwork(t *testing.T, startPort int) {
 }
 
 func fundWallet(port int, w wallet.Wallet) error {
-	url := fmt.Sprintf("http://localhost:%d/fund/eth", port)
+	url := fmt.Sprintf("http://localhost:%d/auth/fund/eth", port)
 	method := "POST"
 
 	payload := strings.NewReader(fmt.Sprintf(`{"address":"%s"}`, w.Address()))
@@ -122,6 +122,7 @@ func fundWallet(port int, w wallet.Wallet) error {
 		return err
 	}
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.xDOI1Cc30Zuj7VYKiRTqB2VntEKpZ5SkJW1heSsvzFw")
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/tools/faucet/faucet/faucet.go
+++ b/tools/faucet/faucet/faucet.go
@@ -51,34 +51,34 @@ func NewFaucet(rpcURL string, chainID int64, pkString string) (*Faucet, error) {
 	}, nil
 }
 
-func (f *Faucet) Fund(address *common.Address, token string, amount *big.Int) error {
+func (f *Faucet) Fund(address *common.Address, token string, amount *big.Int) (string, error) {
 	var err error
 	var signedTx *types.Transaction
 
 	if token == NativeToken || token == DeprecatedNativeToken {
 		signedTx, err = f.fundNativeToken(address, amount)
 	} else {
-		return fmt.Errorf("token not fundable atm")
+		return "", fmt.Errorf("token not fundable atm")
 		// signedTx, err = f.fundERC20Token(address, token)
 		// todo implement this when contracts are deployable somewhere
 	}
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// the faucet should be the only user of the faucet pk
 	txMarshal, err := json.Marshal(signedTx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	f.Logger.Info(fmt.Sprintf("Funded address: %s - tx: %+v\n", address.Hex(), string(txMarshal)))
 	// todo handle tx receipt
 
 	if err := f.validateTx(signedTx); err != nil {
-		return fmt.Errorf("unable to validate tx %s: %w", signedTx.Hash(), err)
+		return "", fmt.Errorf("unable to validate tx %s: %w", signedTx.Hash(), err)
 	}
 
-	return nil
+	return signedTx.Hash().Hex(), nil
 }
 
 func (f *Faucet) validateTx(tx *types.Transaction) error {

--- a/tools/faucet/webserver/web_server.go
+++ b/tools/faucet/webserver/web_server.go
@@ -147,12 +147,13 @@ func fundingHandler(faucetServer *faucet.Faucet, defaultAmount *big.Int) gin.Han
 
 		// fund the address
 		addr := common.HexToAddress(req.Address)
-		if err := faucetServer.Fund(&addr, token, defaultAmount); err != nil {
+		hash, err := faucetServer.Fund(&addr, token, defaultAmount)
+		if err != nil {
 			errorHandler(c, fmt.Errorf("unable to fund request %w", err), faucetServer.Logger)
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "tx": hash})
 	}
 }
 


### PR DESCRIPTION
### Why this change is needed

Adds the tx hash to the reply from the faucet.
Updates test to use the Authenticated path .

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


