### PR TITLE
add default user for old endpoints

### DIFF
--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -162,7 +162,7 @@ func ethRequestHandler(walletExt *walletextension.WalletExtension, conn userconn
 	// Get userID
 	hexUserID, err := getUserID(conn, 1)
 	if err != nil || !walletExt.UserExists(hexUserID) {
-		walletExt.Logger().Error("user not found in the query params: %w. Using the default user", log.ErrKey, err)
+		walletExt.Logger().Info("user not found in the query params: %w. Using the default user", log.ErrKey, err)
 		hexUserID = hex.EncodeToString([]byte(common.DefaultUser)) // todo (@ziga) - this can be removed once old WE endpoints are removed
 	}
 
@@ -342,7 +342,7 @@ func queryRequestHandler(walletExt *walletextension.WalletExtension, conn userco
 	hexUserID, err := getUserID(conn, 2)
 	if err != nil {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("user ('u') not found in query parameters"))
-		walletExt.Logger().Error("user not found in the query params", log.ErrKey, err)
+		walletExt.Logger().Info("user not found in the query params", log.ErrKey, err)
 		return
 	}
 	address, err := getQueryParameter(conn.ReadRequestParams(), common.AddressQueryParameter)
@@ -394,7 +394,7 @@ func revokeRequestHandler(walletExt *walletextension.WalletExtension, conn userc
 	hexUserID, err := getUserID(conn, 2)
 	if err != nil {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("user ('u') not found in query parameters"))
-		walletExt.Logger().Error("user not found in the query params", log.ErrKey, err)
+		walletExt.Logger().Info("user not found in the query params", log.ErrKey, err)
 		return
 	}
 

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -60,12 +60,14 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	accountPrivateKey, err := crypto.GenerateKey()
 	if err != nil {
 		logger.Error("Unable to generate key pair for default user", log.ErrKey, err)
+		os.Exit(1)
 	}
 
 	// get all users and their private keys from the database
 	allUsers, err := databaseStorage.GetAllUsers()
 	if err != nil {
 		logger.Error(fmt.Errorf("error getting all users from database, %w", err).Error())
+		os.Exit(1)
 	}
 
 	// iterate over users create accountManagers and add all defaultUserAccounts to them per user
@@ -79,11 +81,13 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 			accounts, err := databaseStorage.GetAccounts(user.UserID)
 			if err != nil {
 				logger.Error(fmt.Errorf("error getting accounts for user: %s, %w", hex.EncodeToString(user.UserID), err).Error())
+				os.Exit(1)
 			}
 			for _, account := range accounts {
 				encClient, err := wecommon.CreateEncClient(hostRPCBindAddr, account.AccountAddress, user.PrivateKey, account.Signature, logger)
 				if err != nil {
 					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
+					os.Exit(1)
 				}
 
 				// add a client to default user

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/stopcontrol"
 	"github.com/ten-protocol/go-ten/go/rpc"
@@ -50,6 +52,16 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 
 	// add default user (when no UserID is provided in the query parameter - for WE endpoints)
 	userAccountManager.AddAndReturnAccountManager(hex.EncodeToString([]byte(wecommon.DefaultUser)))
+
+	// add default user to the database (temporary fix before removing wallet extension endpoints)
+	accountPrivateKey, err := crypto.GenerateKey()
+	if err != nil {
+		logger.Error("Unable to generate hey pair for default user", log.ErrKey, err)
+	}
+	err = databaseStorage.AddUser([]byte(wecommon.DefaultUser), crypto.FromECDSA(accountPrivateKey))
+	if err != nil {
+		logger.Error("Unable to save default user to the database", log.ErrKey, err)
+	}
 
 	// get all users and their private keys from the database
 	allUsers, err := databaseStorage.GetAllUsers()

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -1,11 +1,14 @@
 package container
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -51,17 +54,12 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	userAccountManager := useraccountmanager.NewUserAccountManager(unAuthedClient, logger, databaseStorage, hostRPCBindAddr)
 
 	// add default user (when no UserID is provided in the query parameter - for WE endpoints)
-	userAccountManager.AddAndReturnAccountManager(hex.EncodeToString([]byte(wecommon.DefaultUser)))
+	defaultUserAccountManager := userAccountManager.AddAndReturnAccountManager(hex.EncodeToString([]byte(wecommon.DefaultUser)))
 
 	// add default user to the database (temporary fix before removing wallet extension endpoints)
 	accountPrivateKey, err := crypto.GenerateKey()
 	if err != nil {
 		logger.Error("Unable to generate key pair for default user", log.ErrKey, err)
-	}
-	err = databaseStorage.AddUser([]byte(wecommon.DefaultUser), crypto.FromECDSA(accountPrivateKey))
-	if err != nil {
-		logger.Error("Unable to save default user to the database", log.ErrKey, err)
-		os.Exit(1)
 	}
 
 	// get all users and their private keys from the database
@@ -70,10 +68,34 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 		logger.Error(fmt.Errorf("error getting all users from database, %w", err).Error())
 	}
 
-	// iterate over users create accountManagers and add all accounts to them per user
+	// iterate over users create accountManagers and add all defaultUserAccounts to them per user
 	for _, user := range allUsers {
 		userAccountManager.AddAndReturnAccountManager(hex.EncodeToString(user.UserID))
 		logger.Info(fmt.Sprintf("account manager added for user: %s", hex.EncodeToString(user.UserID)))
+
+		// to ensure backwards compatibility we want to load clients for the default user
+		// TODO @ziga - this code needs to be removed when removing old wallet extension endpoints
+		if bytes.Equal(user.UserID, []byte(wecommon.DefaultUser)) {
+			accounts, err := databaseStorage.GetAccounts(user.UserID)
+			if err != nil {
+				logger.Error(fmt.Errorf("error getting accounts for user: %s, %w", hex.EncodeToString(user.UserID), err).Error())
+			}
+			for _, account := range accounts {
+				encClient, err := wecommon.CreateEncClient(hostRPCBindAddr, account.AccountAddress, user.PrivateKey, account.Signature, logger)
+				if err != nil {
+					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
+				}
+
+				// add a client to default user
+				defaultUserAccountManager.AddClient(common.BytesToAddress(account.AccountAddress), encClient)
+			}
+		}
+	}
+	// TODO @ziga - remove this when removing wallet extension endpoints
+	err = databaseStorage.AddUser([]byte(wecommon.DefaultUser), crypto.FromECDSA(accountPrivateKey))
+	if err != nil {
+		logger.Error("Unable to save default user to the database", log.ErrKey, err)
+		os.Exit(1)
 	}
 
 	// captures version in the env vars

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -56,11 +56,12 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	// add default user to the database (temporary fix before removing wallet extension endpoints)
 	accountPrivateKey, err := crypto.GenerateKey()
 	if err != nil {
-		logger.Error("Unable to generate hey pair for default user", log.ErrKey, err)
+		logger.Error("Unable to generate key pair for default user", log.ErrKey, err)
 	}
 	err = databaseStorage.AddUser([]byte(wecommon.DefaultUser), crypto.FromECDSA(accountPrivateKey))
 	if err != nil {
 		logger.Error("Unable to save default user to the database", log.ErrKey, err)
+		os.Exit(1)
 	}
 
 	// get all users and their private keys from the database

--- a/tools/walletextension/test/wallet_extension_test.go
+++ b/tools/walletextension/test/wallet_extension_test.go
@@ -294,7 +294,7 @@ func TestGetStorageAtForReturningUserID(t *testing.T) {
 	}
 
 	// make a request to GetStorageAt with correct parameters, but userID that is not present in the database
-	invalidUserID := "abc123"
+	invalidUserID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	respBody2 := makeHTTPEthJSONReqWithUserID(walletHTTPPort, rpc.GetStorageAt, []interface{}{"getUserID", "0", nil}, invalidUserID)
 
 	if !strings.Contains(string(respBody2), "method eth_getStorageAt cannot be called with an unauthorised client - no signed viewing keys found") {

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/accountmanager"
+
 	"github.com/ten-protocol/go-ten/tools/walletextension/config"
 
 	"github.com/ten-protocol/go-ten/go/common/log"
@@ -336,6 +338,15 @@ func (w *WalletExtension) getStorageAtInterceptor(request *common.RPCRequest, he
 		if err != nil {
 			w.logger.Warn("GetStorageAt called with appropriate parameters to return userID, but not found in the database: ", "userId", hexUserID)
 			return nil
+		}
+
+		// check if we have default user (we don't want to send userID of it out)
+		if hexUserID == hex.EncodeToString([]byte(common.DefaultUser)) {
+			response := map[string]interface{}{}
+			response[common.JSONKeyRPCVersion] = jsonrpc.Version
+			response[common.JSONKeyID] = request.ID
+			response[common.JSONKeyResult] = fmt.Sprintf(accountmanager.ErrNoViewingKey, "eth_getStorageAt")
+			return response
 		}
 
 		_, err = w.storage.GetUserPrivateKey(userID)


### PR DESCRIPTION
### Why this change is needed

Following test was failing after latest changes: TestCannotInvokeSensitiveMethodsWithoutViewingKey
To get it working as expected we need to add a default user that is used with old endpoints and if userID was not found.

### What changes were made as part of this PR

Added default userID to the database at startup

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


