### PR TITLE
L1 contracts: increase timeout for extra transactions

### DIFF
--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -67,8 +67,8 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (*node.NetworkConfig, e
 	}
 	defer cli.Close()
 
-	// make sure the container has finished execution
-	err = docker.WaitForContainerToFinish(n.containerID, time.Minute)
+	// make sure the container has finished execution (3 minutes allows time for L1 transactions to be mined)
+	err = docker.WaitForContainerToFinish(n.containerID, 3*time.Minute)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why this change is needed

Testnet deployments are failing because new transactions on the L1 contract deployer (to write important contract addresses to the management contract) have slowed the script down but the timeout wasn't increased.

### What changes were made as part of this PR

Bump the allowed time from 1min to 3mins (was taking about 1.5mins on dev-testnet, plus some padding for sepolia being slower).

When things go wrong the container generally fails fast so shouldn't add much time when there are issues.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


