### PR TITLE
add another signed message format gateway

### DIFF
--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -237,7 +237,6 @@ func VerifySignatureEIP712(userID string, address *gethcommon.Address, signature
 		hash := gethcommon.BytesToHash(hashBytes)
 
 		if len(signature) != 65 {
-			// return false, fmt.Errorf("invalid signature length: %d", len(signature))
 			continue
 		}
 
@@ -249,20 +248,17 @@ func VerifySignatureEIP712(userID string, address *gethcommon.Address, signature
 
 		pubKeyBytes, err := crypto.Ecrecover(hash[:], signature)
 		if err != nil {
-			// return false, fmt.Errorf("invalid signature: %w", err)
 			continue
 		}
 
 		pubKey, err := crypto.UnmarshalPubkey(pubKeyBytes)
 		if err != nil {
-			// return false, fmt.Errorf("cannot unmarshal public key: %w", err)
 			continue
 		}
 
 		recoveredAddr := crypto.PubkeyToAddress(*pubKey)
 
 		if !bytes.Equal(recoveredAddr.Bytes(), address.Bytes()) {
-			// return false, errors.New("address from signature not the same as expected")
 			continue
 		}
 
@@ -276,5 +272,5 @@ func VerifySignatureEIP712(userID string, address *gethcommon.Address, signature
 			return true, nil
 		}
 	}
-	return false, errors.New("signature is not valid")
+	return false, errors.New("signature verification failed")
 }

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -28,11 +28,11 @@ func TestVKHandler(t *testing.T) {
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
 	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
-	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID, chainID)
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData)
+	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData[0])
 
 	tests := map[string][]byte{
 		"WEMessageFormatTest":     WEMessageFormatTestHash,
@@ -67,11 +67,11 @@ func TestSignAndCheckSignature(t *testing.T) {
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
 	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
-	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawData(userID, chainID)
+	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData)
+	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData[0])
 
 	tests := map[string][]byte{
 		"WEMessageFormatTest":     WEMessageFormatTestHash,

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -28,11 +28,14 @@ func TestVKHandler(t *testing.T) {
 	vkPubKeyBytes := crypto.CompressPubkey(ecies.ImportECDSAPublic(&vkPrivKey.PublicKey).ExportECDSA())
 	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
-	EIP712MessageData, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)
+	EIP712MessageDataOptions, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData[0])
+	if len(EIP712MessageDataOptions) == 0 {
+		t.Fatalf("GenerateAuthenticationEIP712RawDataOptions returned no results")
+	}
+	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageDataOptions[0])
 
 	tests := map[string][]byte{
 		"WEMessageFormatTest":     WEMessageFormatTestHash,

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -88,6 +88,8 @@ func TestTenGateway(t *testing.T) {
 	// prefunded wallet
 	w := wallet.NewInMemoryWalletFromConfig(genesis.TestnetPrefundedPK, integration.TenChainID, testlog.Logger())
 
+	time.Sleep(time.Hour)
+
 	// run the tests against the exis
 	for name, test := range map[string]func(*testing.T, string, string, wallet.Wallet){
 		//"testAreTxsMinted":            testAreTxsMinted, this breaks the other tests bc, enable once concurency issues are fixed

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -88,8 +88,6 @@ func TestTenGateway(t *testing.T) {
 	// prefunded wallet
 	w := wallet.NewInMemoryWalletFromConfig(genesis.TestnetPrefundedPK, integration.TenChainID, testlog.Logger())
 
-	time.Sleep(time.Hour)
-
 	// run the tests against the exis
 	for name, test := range map[string]func(*testing.T, string, string, wallet.Wallet){
 		//"testAreTxsMinted":            testAreTxsMinted, this breaks the other tests bc, enable once concurency issues are fixed

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -46,12 +46,12 @@ func (o *TGLib) Join() error {
 
 func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
-	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawData(string(o.userID), integration.TenChainID)
+	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(string(o.userID), integration.TenChainID)
 	if err != nil {
 		return err
 	}
 
-	messageHash := crypto.Keccak256(rawMessage)
+	messageHash := crypto.Keccak256(rawMessage[0])
 	sig, err := crypto.Sign(messageHash, pk)
 	if err != nil {
 		return fmt.Errorf("failed to sign message: %w", err)

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -46,12 +46,15 @@ func (o *TGLib) Join() error {
 
 func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
-	rawMessage, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(string(o.userID), integration.TenChainID)
+	rawMessageOptions, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(string(o.userID), integration.TenChainID)
 	if err != nil {
 		return err
 	}
+	if len(rawMessageOptions) == 0 {
+		return fmt.Errorf("GenerateAuthenticationEIP712RawDataOptions returned 0 options")
+	}
 
-	messageHash := crypto.Keccak256(rawMessage[0])
+	messageHash := crypto.Keccak256(rawMessageOptions[0])
 	sig, err := crypto.Sign(messageHash, pk)
 	if err != nil {
 		return fmt.Errorf("failed to sign message: %w", err)


### PR DESCRIPTION
### Why this change is needed

Add another option for for EIP712 signatures. It supports both `Encryption Token` and `EncryptionToken` to enable support for older versions of third party libraries.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


