### PR TITLE
Host RPC: use checksum format for contract addresses

### DIFF
--- a/go/host/rpc/clientapi/client_api_obscuro.go
+++ b/go/host/rpc/clientapi/client_api_obscuro.go
@@ -1,6 +1,7 @@
 package clientapi
 
 import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ten-protocol/go-ten/go/common"
 	"github.com/ten-protocol/go-ten/go/common/host"
 )
@@ -22,6 +23,36 @@ func (api *ObscuroAPI) Health() (*host.HealthCheck, error) {
 }
 
 // Config returns the config status of obscuro host + enclave + db
-func (api *ObscuroAPI) Config() (*common.ObscuroNetworkInfo, error) {
-	return api.host.ObscuroConfig()
+func (api *ObscuroAPI) Config() (*JSONFriendlyObscuroNetworkInfo, error) {
+	config, err := api.host.ObscuroConfig()
+	if err != nil {
+		return nil, err
+	}
+	return jsonFriendly(config), nil
+}
+
+// JSONFriendlyObscuroNetworkInfo is a JSON-friendly version of ObscuroNetworkInfo.
+// In particular, it serialises the addresses as EIP55 checksum addresses.
+type JSONFriendlyObscuroNetworkInfo struct {
+	ManagementContractAddress gethcommon.AddressEIP55
+	L1StartHash               gethcommon.Hash
+	SequencerID               gethcommon.AddressEIP55
+	MessageBusAddress         gethcommon.AddressEIP55
+	L2MessageBusAddress       gethcommon.AddressEIP55
+	ImportantContracts        map[string]gethcommon.AddressEIP55 // map of contract name to address
+}
+
+func jsonFriendly(info *common.ObscuroNetworkInfo) *JSONFriendlyObscuroNetworkInfo {
+	importantContracts := make(map[string]gethcommon.AddressEIP55)
+	for name, addr := range info.ImportantContracts {
+		importantContracts[name] = gethcommon.AddressEIP55(addr)
+	}
+	return &JSONFriendlyObscuroNetworkInfo{
+		ManagementContractAddress: gethcommon.AddressEIP55(info.ManagementContractAddress),
+		L1StartHash:               info.L1StartHash,
+		SequencerID:               gethcommon.AddressEIP55(info.SequencerID),
+		MessageBusAddress:         gethcommon.AddressEIP55(info.MessageBusAddress),
+		L2MessageBusAddress:       gethcommon.AddressEIP55(info.L2MessageBusAddress),
+		ImportantContracts:        importantContracts,
+	}
 }

--- a/go/host/rpc/clientapi/client_api_obscuro.go
+++ b/go/host/rpc/clientapi/client_api_obscuro.go
@@ -23,17 +23,16 @@ func (api *ObscuroAPI) Health() (*host.HealthCheck, error) {
 }
 
 // Config returns the config status of obscuro host + enclave + db
-func (api *ObscuroAPI) Config() (*JSONFriendlyObscuroNetworkInfo, error) {
+func (api *ObscuroAPI) Config() (*ChecksumFormattedObscuroNetworkConfig, error) {
 	config, err := api.host.ObscuroConfig()
 	if err != nil {
 		return nil, err
 	}
-	return jsonFriendly(config), nil
+	return checksumFormatted(config), nil
 }
 
-// JSONFriendlyObscuroNetworkInfo is a JSON-friendly version of ObscuroNetworkInfo.
-// In particular, it serialises the addresses as EIP55 checksum addresses.
-type JSONFriendlyObscuroNetworkInfo struct {
+// ChecksumFormattedObscuroNetworkConfig serialises the addresses as EIP55 checksum addresses.
+type ChecksumFormattedObscuroNetworkConfig struct {
 	ManagementContractAddress gethcommon.AddressEIP55
 	L1StartHash               gethcommon.Hash
 	SequencerID               gethcommon.AddressEIP55
@@ -42,12 +41,12 @@ type JSONFriendlyObscuroNetworkInfo struct {
 	ImportantContracts        map[string]gethcommon.AddressEIP55 // map of contract name to address
 }
 
-func jsonFriendly(info *common.ObscuroNetworkInfo) *JSONFriendlyObscuroNetworkInfo {
+func checksumFormatted(info *common.ObscuroNetworkInfo) *ChecksumFormattedObscuroNetworkConfig {
 	importantContracts := make(map[string]gethcommon.AddressEIP55)
 	for name, addr := range info.ImportantContracts {
 		importantContracts[name] = gethcommon.AddressEIP55(addr)
 	}
-	return &JSONFriendlyObscuroNetworkInfo{
+	return &ChecksumFormattedObscuroNetworkConfig{
 		ManagementContractAddress: gethcommon.AddressEIP55(info.ManagementContractAddress),
 		L1StartHash:               info.L1StartHash,
 		SequencerID:               gethcommon.AddressEIP55(info.SequencerID),


### PR DESCRIPTION
### Why this change is needed

Moray suggested we should provide contract addresses in the standard checksum format for callers.

### What changes were made as part of this PR

Changed the json serialisation of the network config response to use the checksum formatting geth Address type.

I ran the test to verify this doesn't break the RPC client.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


