### PR TITLE
Perf fixes

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -322,7 +322,7 @@ func (e *enclaveImpl) Status() (common.Status, common.SystemError) {
 		return common.Status{StatusCode: common.Unavailable}, responses.ToInternalError(err)
 	}
 	var l1HeadHash gethcommon.Hash
-	l1Head, err := e.storage.FetchHeadBlock()
+	l1Head, err := e.l1BlockProcessor.GetHead()
 	if err != nil {
 		// this might be normal while enclave is starting up, just send empty hash
 		e.logger.Debug("failed to fetch L1 head block for status response", log.ErrKey, err)
@@ -1470,7 +1470,7 @@ func extractGetLogsParams(paramList []interface{}) (*filters.FilterCriteria, *ge
 
 func (e *enclaveImpl) rejectBlockErr(cause error) *errutil.BlockRejectError {
 	var hash common.L1BlockHash
-	l1Head, err := e.storage.FetchHeadBlock()
+	l1Head, err := e.l1BlockProcessor.GetHead()
 	// todo - handle error
 	if err == nil {
 		hash = l1Head.Hash()

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -44,8 +44,8 @@ const (
 
 	isCanonQuery = "select is_canonical from block where hash=?"
 
-	queryTxList      = "select tx.full_hash, batch.height from exec_tx join batch on batch.sequence=exec_tx.batch join tx on tx.hash=exec_tx.tx"
-	queryTxCountList = "select count(1) from exec_tx join batch on batch.sequence=exec_tx.batch"
+	queryTxList      = "select tx.full_hash, batch.height from exec_tx join batch on batch.sequence=exec_tx.batch join tx on tx.hash=exec_tx.tx where batch.is_canonical=true"
+	queryTxCountList = "select count(1) from exec_tx join batch on batch.sequence=exec_tx.batch where batch.is_canonical=true"
 )
 
 // WriteBatchAndTransactions - persists the batch and the transactions


### PR DESCRIPTION
### Why this change is needed

to improve performance

### What changes were made as part of this PR

- use the cached head block to avoid slow query
- add "isCanonical" check to queries to hit the [height, is_canonical] index (hopefully)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


