### PR TITLE
RPC API: ensure hash field included in batches json

### DIFF
--- a/go/common/headers.go
+++ b/go/common/headers.go
@@ -47,6 +47,7 @@ type BatchHeader struct {
 }
 
 type batchHeaderEncoding struct {
+	Hash             common.Hash     `json:"hash"`
 	ParentHash       L2BatchHash     `json:"parentHash"`
 	Root             common.Hash     `json:"stateRoot"`
 	TxHash           common.Hash     `json:"transactionsRoot"`
@@ -72,6 +73,7 @@ type batchHeaderEncoding struct {
 // MarshalJSON custom marshals the BatchHeader into a json
 func (b *BatchHeader) MarshalJSON() ([]byte, error) {
 	return json.Marshal(batchHeaderEncoding{
+		b.Hash(),
 		b.ParentHash,
 		b.Root,
 		b.TxHash,

--- a/integration/networktest/actions/publicdata/tenscan_data.go
+++ b/integration/networktest/actions/publicdata/tenscan_data.go
@@ -1,0 +1,41 @@
+package publicdata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ten-protocol/go-ten/go/common"
+	"github.com/ten-protocol/go-ten/go/obsclient"
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+)
+
+// VerifyBatchesDataAction tests the batches data RPC endpoint
+func VerifyBatchesDataAction() networktest.Action {
+	return actions.VerifyOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) error {
+		client, err := obsclient.Dial(network.ValidatorRPCAddress(0))
+		if err != nil {
+			return err
+		}
+
+		pagination := common.QueryPagination{
+			Offset: 0,
+			Size:   20,
+		}
+		batchListing, err := client.GetBatchesListing(&pagination)
+		if err != nil {
+			return err
+		}
+		if len(batchListing.BatchesData) != 20 {
+			return fmt.Errorf("expected 20 batches, got %d", len(batchListing.BatchesData))
+		}
+		if batchListing.Total <= 10 {
+			return fmt.Errorf("expected more than 10 batches, got %d", batchListing.Total)
+		}
+		if batchListing.BatchesData[0].Number.Cmp(batchListing.BatchesData[1].Number) < 0 {
+			return fmt.Errorf("expected batches to be sorted by height descending")
+		}
+
+		return nil
+	})
+}

--- a/integration/networktest/tests/tenscan/tenscan_rpc_test.go
+++ b/integration/networktest/tests/tenscan/tenscan_rpc_test.go
@@ -1,0 +1,24 @@
+package tenscan
+
+import (
+	"testing"
+
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions/publicdata"
+	"github.com/ten-protocol/go-ten/integration/networktest/env"
+)
+
+// Verify and debug the RPC endpoints that Tenscan relies on for data in various environments
+
+func TestRPC(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"tenscan-rpc-data",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			publicdata.VerifyBatchesDataAction(),
+		),
+	)
+}


### PR DESCRIPTION
### Why this change is needed

Tenscan is showing N/A for hash column on batches tables because the field is missing from the json responses. It was lost as part of the json marshalling fixes recently.

### What changes were made as part of this PR

Ensure hash field included in the batch header json output.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


