### PR TITLE
use the 3.18 go alpine image (#1687)

### DIFF
--- a/dockerfiles/enclave.debug.Dockerfile
+++ b/dockerfiles/enclave.debug.Dockerfile
@@ -4,7 +4,7 @@
 # build-enclave = copies over the source and builds the enclave using a go compiler cache
 # final = using the base system copies over only the enclave executable and creates the final image without source and dependencies. 
 
-FROM golang:1.20-alpine as system
+FROM golang:1.20-alpine3.18 as system
 
 # install build utils
 RUN apk add build-base

--- a/dockerfiles/host.Dockerfile
+++ b/dockerfiles/host.Dockerfile
@@ -4,7 +4,7 @@
 # build-host = copies over the source code and builds the binaries using a compiler cache
 # final = copies over only the executables in an alpine image that doesn't have any additional load.
 
-FROM golang:1.20-alpine as system
+FROM golang:1.20-alpine3.18 as system
 # set the base libs to build / run
 RUN apk add build-base bash
 ENV CGO_ENABLED=1
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build
 
 # Trigger another build stage to remove unnecessary files.
-FROM alpine:3.17
+FROM alpine:3.18
 
 # Copy over just the binary from the previous build stage into this one.
 COPY --from=build-host \

--- a/tools/hardhatdeployer/Dockerfile
+++ b/tools/hardhatdeployer/Dockerfile
@@ -7,7 +7,7 @@
 # final = copies over the solidity/hardhat source, takes the installed project from the 'install-npm-deps' and the final wallet executable
 #         in a lightweight image.
 
-FROM golang:1.20-alpine as system
+FROM golang:1.20-alpine3.18 as system
 
 # set the base libs to build / run
 RUN apk add build-base bash git

--- a/tools/obscuroscan/Dockerfile
+++ b/tools/obscuroscan/Dockerfile
@@ -4,7 +4,7 @@
 # build-obscuroscan = copies over the source code and builds the binaries using a compiler cache
 # final = copies over only the executables in an alpine image that doesn't have any additional load.
 
-FROM golang:1.20-alpine as system
+FROM golang:1.20-alpine3.18 as system
 
 # set the base libs to build / run
 RUN apk add build-base bash git
@@ -31,7 +31,7 @@ WORKDIR /home/obscuro/go-obscuro/tools/obscuroscan/main
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 COPY --from=build-obscuroscan /home/obscuro/go-obscuro/tools/obscuroscan/main /home/obscuro/go-obscuro/tools/obscuroscan/main
 WORKDIR /home/obscuro/go-obscuro

--- a/tools/walletextension/Dockerfile
+++ b/tools/walletextension/Dockerfile
@@ -4,7 +4,7 @@
 # build-wallet = copies over the source code and builds the binaries using a compiler cache
 # final = copies over only the executables in an alpine image that doesn't have any additional load.
 
-FROM golang:1.20-alpine as system
+FROM golang:1.20-alpine3.18 as system
 
 # set the base libs to build / run
 RUN apk add build-base bash git
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -o ../bin/wallet_extension_linux
 
 # Lightweight final build stage. Includes bare minimum to start wallet extension
-FROM alpine:3.17
+FROM alpine:3.18
 
 COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/bin /home/obscuro/go-obscuro/tools/walletextension/bin
 WORKDIR /home/obscuro/go-obscuro/tools/walletextension/bin


### PR DESCRIPTION
### Why this change is needed

cherry pick from `release/0.20`

https://github.com/ten-protocol/go-ten/pull/1687

