### PR TITLE
Change network name back to Obscuro Testnet, to avoid warnings

### DIFF
--- a/tools/walletextension/frontend/src/lib/constants.ts
+++ b/tools/walletextension/frontend/src/lib/constants.ts
@@ -13,7 +13,7 @@ export const GOOGLE_ANALYTICS_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
 export const testnetUrls = {
   sepolia: {
-    name: "Ten Dev-Testnet",
+    name: "Obscuro Testnet",
     url: "https://sepolia-testnet.obscu.ro",
     rpc: "https://rpc.sepolia-testnet.obscu.ro",
   },
@@ -28,7 +28,7 @@ export const testnetUrls = {
     rpc: "https://rpc.dev-testnet.obscu.ro",
   },
   default: {
-    name: "Ten Testnet",
+    name: "Obscuro Testnet",
     url: tenGatewayAddress,
   },
 };


### PR DESCRIPTION
### Why this change is needed

To avoid warnings from Metamask, caused by having different name for the network

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


