### PR TITLE
Enclave: produce no batch if all tx failed

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -213,7 +213,7 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 	if failForEmptyBatch &&
 		len(txReceipts) == 0 &&
 		len(ccReceipts) == 0 &&
-		len(transactionsToProcess) == 0 &&
+		len(transactionsToProcess)-len(excludedTxs) == 0 &&
 		len(crossChainTransactions) == 0 &&
 		len(messages) == 0 &&
 		len(transfers) == 0 {


### PR DESCRIPTION
### Why this change is needed

Avoid spamming empty batches when there is a rejected tx but no successful transactions.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


