### PR TITLE
close mempool and use the geth defaults for the mempool

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -196,7 +196,7 @@ func NewEnclave(
 	sharedSecretProcessor := components.NewSharedSecretProcessor(mgmtContractLib, attestationProvider, storage, logger)
 
 	blockchain := ethchainadapter.NewEthChainAdapter(big.NewInt(config.ObscuroChainID), registry, storage, logger)
-	mempool, err := txpool.NewTxPool(blockchain, config.MinGasPrice)
+	mempool, err := txpool.NewTxPool(blockchain, config.MinGasPrice, logger)
 	if err != nil {
 		logger.Crit("unable to init eth tx pool", log.ErrKey, err)
 	}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -972,8 +972,13 @@ func (e *enclaveImpl) Stop() common.SystemError {
 		e.registry.UnsubscribeFromBatches()
 	}
 
+	err := e.service.Close()
+	if err != nil {
+		e.logger.Error("Could not stop node service", log.ErrKey, err)
+	}
+
 	time.Sleep(time.Second)
-	err := e.storage.Close()
+	err = e.storage.Close()
 	if err != nil {
 		e.logger.Error("Could not stop db", log.ErrKey, err)
 		return err

--- a/go/enclave/evm/ethchainadapter/eth_chainadapter.go
+++ b/go/enclave/evm/ethchainadapter/eth_chainadapter.go
@@ -136,13 +136,13 @@ func NewLegacyPoolConfig() legacypool.Config {
 		NoLocals:     false,
 		Journal:      "",
 		Rejournal:    0,
-		PriceLimit:   0,
-		PriceBump:    0,
-		AccountSlots: 100,
-		GlobalSlots:  10000000,
-		AccountQueue: 100,
-		GlobalQueue:  10000000,
-		Lifetime:     0,
+		PriceLimit:   legacypool.DefaultConfig.PriceLimit,
+		PriceBump:    legacypool.DefaultConfig.PriceBump,
+		AccountSlots: legacypool.DefaultConfig.AccountSlots,
+		GlobalSlots:  legacypool.DefaultConfig.GlobalSlots,
+		AccountQueue: legacypool.DefaultConfig.AccountQueue,
+		GlobalQueue:  legacypool.DefaultConfig.GlobalQueue,
+		Lifetime:     legacypool.DefaultConfig.Lifetime,
 	}
 }
 

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -20,6 +20,8 @@ type NodeType interface {
 
 	// OnL1Block - performed after the block was processed
 	OnL1Block(block types.Block, result *components.BlockIngestionType) error
+
+	Close() error
 }
 
 type Sequencer interface {

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -449,3 +449,7 @@ func (s *sequencer) OnL1Block(_ types.Block, _ *components.BlockIngestionType) e
 	// nothing to do
 	return nil
 }
+
+func (s *sequencer) Close() error {
+	return s.mempool.Close()
+}

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -153,3 +153,7 @@ func (val *obsValidator) handleGenesis(batch *core.Batch) error {
 func (val *obsValidator) OnL1Block(_ types.Block, _ *components.BlockIngestionType) error {
 	return val.ExecuteStoredBatches()
 }
+
+func (val *obsValidator) Close() error {
+	return nil
+}

--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -75,3 +75,7 @@ func (t *TxPool) Add(transaction *common.L2Tx) error {
 func (t *TxPool) Running() bool {
 	return t.running
 }
+
+func (t *TxPool) Close() error {
+	return t.legacyPool.Close()
+}

--- a/go/enclave/txpool/txpool_test.go
+++ b/go/enclave/txpool/txpool_test.go
@@ -57,7 +57,7 @@ func TestTxPool_AddTransaction_Pending(t *testing.T) {
 	err = blockchain.IngestNewBlock(genesisBatch)
 	require.NoError(t, err)
 
-	txPool, err := NewTxPool(blockchain, big.NewInt(1))
+	txPool, err := NewTxPool(blockchain, big.NewInt(1), testlog.Logger())
 	require.NoError(t, err)
 
 	// Start the TxPool


### PR DESCRIPTION
### Why this change is needed

the geth mempool has a background go-routine, which must be closed.

We weren't closing it, which might explain the flakyness.

### What changes were made as part of this PR

- close the goroutine
- use the defaults from the geth mempool

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


