### PR TITLE
Set retention to 7 days for deployer logs

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -118,7 +118,7 @@ jobs:
           name: deploy-l1-artifacts
           path: |
             deploy-l1-contracts.out
-          retention-days: 1
+          retention-days: 7
 
   deploy:
     needs: build
@@ -324,7 +324,7 @@ jobs:
           name: deploy-l2-artifacts
           path: |
             deploy-l2-contracts.out
-          retention-days: 1
+          retention-days: 7
 
   deploy-faucet:
     name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'


### PR DESCRIPTION
### Why this change is needed

On an L2 deploy the deployer logs are the only way to get all of the L1 and L2 contract addresses at the moment. On a new deploy the e2e tests need the new addresses to be able to run all tests. With a retention of 1 day, should a redeploy happen over the holidays the addresses may be lost, or difficult to access. As they are of very small size, increasing the retention to 7 days should not affect our git disk utilisation. 


