### PR TITLE
remove check performed in the mempool

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1432,18 +1432,6 @@ func (e *revertError) ErrorData() interface{} {
 	return e.reason
 }
 
-func (e *enclaveImpl) checkGas(tx *types.Transaction) error {
-	txGasPrice := tx.GasPrice()
-	if txGasPrice == nil {
-		return fmt.Errorf("rejected transaction %s. No gas price was set", tx.Hash())
-	}
-	minGasPrice := e.config.MinGasPrice
-	if txGasPrice.Cmp(minGasPrice) == -1 {
-		return fmt.Errorf("rejected transaction %s. Gas price was only %d, wanted at least %d", tx.Hash(), txGasPrice, minGasPrice)
-	}
-	return nil
-}
-
 // Returns the params extracted from an eth_getLogs request.
 func extractGetLogsParams(paramList []interface{}) (*filters.FilterCriteria, *gethcommon.Address, error) {
 	// We extract the first param, the filter for the logs.

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -499,10 +499,6 @@ func (e *enclaveImpl) SubmitTx(tx common.EncryptedTx) (*responses.RawTx, common.
 	if e.crossChainProcessors.Local.IsSyntheticTransaction(*decryptedTx) {
 		return responses.AsPlaintextError(responses.ToInternalError(fmt.Errorf("synthetic transaction coming from external rpc"))), nil
 	}
-	if err = e.checkGas(decryptedTx); err != nil {
-		e.logger.Info("gas check failed", log.ErrKey, err.Error())
-		return responses.AsEncryptedError(err, vkHandler), nil
-	}
 
 	if err = e.service.SubmitTransaction(decryptedTx); err != nil {
 		e.logger.Debug("Could not submit transaction", log.TxKey, decryptedTx.Hash(), log.ErrKey, err)

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -166,7 +166,7 @@ func (s *sequencer) createGenesisBatch(block *common.L1Block) error {
 
 	// produce batch #2 which has the message bus and any other system contracts
 	cb, err := s.produceBatch(
-		batch.Header.SequencerOrderNo.Add(batch.Header.SequencerOrderNo, big.NewInt(1)),
+		big.NewInt(0).Add(batch.Header.SequencerOrderNo, big.NewInt(1)),
 		block.Hash(),
 		batch.Hash(),
 		common.L2Transactions{msgBusTx},


### PR DESCRIPTION
### Why this change is needed

- remove gas check that is done by the mempool as well to return a consistent error message with ethereum tooling
- fix major flakyness

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


