### PR TITLE
statedb revert to snapshot for ignored batches

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -168,6 +168,7 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
+	snap := stateDB.Snapshot()
 
 	var messages common.CrossChainMessages
 	var transfers common.ValueTransferEvents
@@ -217,6 +218,8 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 		len(crossChainTransactions) == 0 &&
 		len(messages) == 0 &&
 		len(transfers) == 0 {
+		// revert any unexpected mutation to the statedb
+		stateDB.RevertToSnapshot(snap)
 		return nil, ErrNoTransactionsToProcess
 	}
 


### PR DESCRIPTION
### Why this change is needed

to avoid unexpected statedb mutations, revert to snapshot for ignored batches

