### PR TITLE
Ziga/fix gateway spammy logs

### DIFF
--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -160,6 +160,7 @@ func ethRequestHandler(walletExt *walletextension.WalletExtension, conn userconn
 	}
 
 	// Get userID
+	// TODO: @ziga - after removing old wallet extension endpoints we should prevent users doing anything without valid encryption token
 	hexUserID, err := getUserID(conn, 1)
 	if err != nil || !walletExt.UserExists(hexUserID) {
 		walletExt.Logger().Info("user not found in the query params: %w. Using the default user", log.ErrKey, err)

--- a/tools/walletextension/api/utils.go
+++ b/tools/walletextension/api/utils.go
@@ -138,7 +138,7 @@ func handleEthError(req *common.RPCRequest, conn userconn.UserConn, logger gethl
 }
 
 func handleError(conn userconn.UserConn, logger gethlog.Logger, err error) {
-	logger.Error("error processing request - Forwarding response to user", log.ErrKey, err)
+	logger.Warn("error processing request - Forwarding response to user", log.ErrKey, err)
 
 	if err = conn.WriteResponse([]byte(err.Error())); err != nil {
 		logger.Error("unable to write response back", log.ErrKey, err)

--- a/tools/walletextension/api/utils.go
+++ b/tools/walletextension/api/utils.go
@@ -25,14 +25,14 @@ func parseRequest(body []byte) (*common.RPCRequest, error) {
 	var method string
 	err = json.Unmarshal(reqJSONMap[common.JSONKeyMethod], &method)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal method string from JSON-RPC request body: %w", err)
+		return nil, fmt.Errorf("could not unmarshal method string from JSON-RPC request body: %s ; %w", string(body), err)
 	}
 
 	// we extract the params into a JSON list
 	var params []interface{}
 	err = json.Unmarshal(reqJSONMap[common.JSONKeyParams], &params)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal params list from JSON-RPC request body: %w", err)
+		return nil, fmt.Errorf("could not unmarshal params list from JSON-RPC request body: %s ; %w", string(body), err)
 	}
 
 	return &common.RPCRequest{

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -311,6 +311,7 @@ func (w *WalletExtension) UserExists(hexUserID string) bool {
 
 	// Check if user exists and don't log error if user doesn't exist, because we expect this to happen in case of
 	// user revoking encryption token or using different testnet.
+	// todo add a counter here in the future
 	key, err := w.storage.GetUserPrivateKey(userIDBytes)
 	if err != nil {
 		return false

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -309,9 +309,10 @@ func (w *WalletExtension) UserExists(hexUserID string) bool {
 		return false
 	}
 
+	// Check if user exists and don't log error if user doesn't exist, because we expect this to happen in case of
+	// user revoking encryption token or using different testnet.
 	key, err := w.storage.GetUserPrivateKey(userIDBytes)
 	if err != nil {
-		w.Logger().Error(fmt.Errorf("error getting user's private key (%s), %w", hexUserID, err).Error())
 		return false
 	}
 


### PR DESCRIPTION
### Why this change is needed

Currently logs in Datadog are spammy and we log some things as errors even if those things are expected to happen or users are calling it with wrong parameters.

### What changes were made as part of this PR

- Deleted one spammy log with an explanation
- Changed one Error to Warning (it turns out we probably call one of the endpoints in a wrong way and it results in those logs)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


