### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -44,6 +44,7 @@ jobs:
             integration/.build/faucet/*
             integration/.build/obscuroscan/*
             integration/.build/tengateway/*
+            integration/.build/smartcontracts/*
           retention-days: 1
 
 

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -122,7 +122,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         return l2Network.deployments.execute("CrossChainMessenger", {
             from: l2Accounts.deployer, 
             log: true,
-            gasLimit: 2_500_000
+            gasLimit: 3_000_000
         }, "relayMessage", msg);
     };
 

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -122,7 +122,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         return l2Network.deployments.execute("CrossChainMessenger", {
             from: l2Accounts.deployer, 
             log: true,
-            gasLimit: 3_000_000
+            gasLimit: 5_000_000
         }, "relayMessage", msg);
     };
 

--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -62,7 +62,7 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	UseInMemoryDBFlag:             flag.NewBoolFlag(UseInMemoryDBFlag, true, "Whether the enclave will use an in-memory DB rather than persist data"),
 	ProfilerEnabledFlag:           flag.NewBoolFlag(ProfilerEnabledFlag, false, "Runs a profiler instance (Defaults to false)"),
 	DebugNamespaceEnabledFlag:     flag.NewBoolFlag(DebugNamespaceEnabledFlag, false, "Whether the debug namespace is enabled"),
-	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 5_000_000, "Max gas usage when executing local transactions"),
+	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 6_000_000, "Max gas usage when executing local transactions"),
 }
 
 // enclaveRestrictedFlags are the flags that the enclave can receive ONLY over the Ego signed enclave.json

--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -55,14 +55,14 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	MaxRollupSizeFlag:             flag.NewUint64Flag(MaxRollupSizeFlag, 1024*64, "The maximum size a rollup is allowed to reach"),
 	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, 1, ""),
 	L2CoinbaseFlag:                flag.NewStringFlag(L2CoinbaseFlag, "0xd6C9230053f45F873Cb66D8A02439380a37A4fbF", ""),
-	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 10_000_000, "Max gas that can be executed in a single batch"),
+	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 30_000_000, "Max gas that can be executed in a single batch"),
 	ObscuroGenesisFlag:            flag.NewStringFlag(ObscuroGenesisFlag, "", "The json string with the obscuro genesis"),
 	L1ChainIDFlag:                 flag.NewInt64Flag(L1ChainIDFlag, 1337, "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)"),
 	ObscuroChainIDFlag:            flag.NewInt64Flag(ObscuroChainIDFlag, 443, "An integer representing the unique chain id of the Obscuro chain (default 443)"),
 	UseInMemoryDBFlag:             flag.NewBoolFlag(UseInMemoryDBFlag, true, "Whether the enclave will use an in-memory DB rather than persist data"),
 	ProfilerEnabledFlag:           flag.NewBoolFlag(ProfilerEnabledFlag, false, "Runs a profiler instance (Defaults to false)"),
 	DebugNamespaceEnabledFlag:     flag.NewBoolFlag(DebugNamespaceEnabledFlag, false, "Whether the debug namespace is enabled"),
-	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 12_000_000, "Max gas usage when executing local transactions"),
+	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 40_000_000, "Max gas usage when executing local transactions"),
 }
 
 // enclaveRestrictedFlags are the flags that the enclave can receive ONLY over the Ego signed enclave.json

--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -55,14 +55,14 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	MaxRollupSizeFlag:             flag.NewUint64Flag(MaxRollupSizeFlag, 1024*64, "The maximum size a rollup is allowed to reach"),
 	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, 1, ""),
 	L2CoinbaseFlag:                flag.NewStringFlag(L2CoinbaseFlag, "0xd6C9230053f45F873Cb66D8A02439380a37A4fbF", ""),
-	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 3_000_000, "Max gas that can be executed in a single batch"),
+	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 5_000_000, "Max gas that can be executed in a single batch"),
 	ObscuroGenesisFlag:            flag.NewStringFlag(ObscuroGenesisFlag, "", "The json string with the obscuro genesis"),
 	L1ChainIDFlag:                 flag.NewInt64Flag(L1ChainIDFlag, 1337, "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)"),
 	ObscuroChainIDFlag:            flag.NewInt64Flag(ObscuroChainIDFlag, 443, "An integer representing the unique chain id of the Obscuro chain (default 443)"),
 	UseInMemoryDBFlag:             flag.NewBoolFlag(UseInMemoryDBFlag, true, "Whether the enclave will use an in-memory DB rather than persist data"),
 	ProfilerEnabledFlag:           flag.NewBoolFlag(ProfilerEnabledFlag, false, "Runs a profiler instance (Defaults to false)"),
 	DebugNamespaceEnabledFlag:     flag.NewBoolFlag(DebugNamespaceEnabledFlag, false, "Whether the debug namespace is enabled"),
-	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 3_000_000, "Max gas usage when executing local transactions"),
+	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 5_000_000, "Max gas usage when executing local transactions"),
 }
 
 // enclaveRestrictedFlags are the flags that the enclave can receive ONLY over the Ego signed enclave.json

--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -55,14 +55,14 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	MaxRollupSizeFlag:             flag.NewUint64Flag(MaxRollupSizeFlag, 1024*64, "The maximum size a rollup is allowed to reach"),
 	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, 1, ""),
 	L2CoinbaseFlag:                flag.NewStringFlag(L2CoinbaseFlag, "0xd6C9230053f45F873Cb66D8A02439380a37A4fbF", ""),
-	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 5_000_000, "Max gas that can be executed in a single batch"),
+	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 10_000_000, "Max gas that can be executed in a single batch"),
 	ObscuroGenesisFlag:            flag.NewStringFlag(ObscuroGenesisFlag, "", "The json string with the obscuro genesis"),
 	L1ChainIDFlag:                 flag.NewInt64Flag(L1ChainIDFlag, 1337, "An integer representing the unique chain id of the Ethereum chain used as an L1 (default 1337)"),
 	ObscuroChainIDFlag:            flag.NewInt64Flag(ObscuroChainIDFlag, 443, "An integer representing the unique chain id of the Obscuro chain (default 443)"),
 	UseInMemoryDBFlag:             flag.NewBoolFlag(UseInMemoryDBFlag, true, "Whether the enclave will use an in-memory DB rather than persist data"),
 	ProfilerEnabledFlag:           flag.NewBoolFlag(ProfilerEnabledFlag, false, "Runs a profiler instance (Defaults to false)"),
 	DebugNamespaceEnabledFlag:     flag.NewBoolFlag(DebugNamespaceEnabledFlag, false, "Whether the debug namespace is enabled"),
-	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 6_000_000, "Max gas usage when executing local transactions"),
+	GasLocalExecutionCapFlag:      flag.NewUint64Flag(GasLocalExecutionCapFlag, 12_000_000, "Max gas usage when executing local transactions"),
 }
 
 // enclaveRestrictedFlags are the flags that the enclave can receive ONLY over the Ego signed enclave.json

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -86,7 +86,7 @@ func (m *MessageBusManager) GenerateMessageBusDeployTx() (*common.L2Tx, error) {
 	tx := &types.LegacyTx{
 		Nonce:    0, // The first transaction of the owner identity should always be deploying the contract
 		Value:    gethcommon.Big0,
-		Gas:      2_000_000,       // It's quite the expensive contract.
+		Gas:      4_000_000,
 		GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 		Data:     gethcommon.FromHex(MessageBus.MessageBusMetaData.Bin),
 		To:       nil, // Geth requires nil instead of gethcommon.Address{} which equates to zero address in order to return receipt.
@@ -219,7 +219,7 @@ func (m *MessageBusManager) CreateSyntheticTransactions(messages common.CrossCha
 		tx := &types.LegacyTx{
 			Nonce:    startingNonce + uint64(idx),
 			Value:    gethcommon.Big0,
-			Gas:      2_000_000,
+			Gas:      4_900_000,
 			GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 			Data:     data,
 			To:       m.messageBusAddress,

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -86,7 +86,7 @@ func (m *MessageBusManager) GenerateMessageBusDeployTx() (*common.L2Tx, error) {
 	tx := &types.LegacyTx{
 		Nonce:    0, // The first transaction of the owner identity should always be deploying the contract
 		Value:    gethcommon.Big0,
-		Gas:      4_000_000,       // It's quite the expensive contract.
+		Gas:      5_000_000,       // It's quite the expensive contract.
 		GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 		Data:     gethcommon.FromHex(MessageBus.MessageBusMetaData.Bin),
 		To:       nil, // Geth requires nil instead of gethcommon.Address{} which equates to zero address in order to return receipt.
@@ -219,7 +219,7 @@ func (m *MessageBusManager) CreateSyntheticTransactions(messages common.CrossCha
 		tx := &types.LegacyTx{
 			Nonce:    startingNonce + uint64(idx),
 			Value:    gethcommon.Big0,
-			Gas:      4_000_000,
+			Gas:      5_000_000,
 			GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 			Data:     data,
 			To:       m.messageBusAddress,

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -86,7 +86,7 @@ func (m *MessageBusManager) GenerateMessageBusDeployTx() (*common.L2Tx, error) {
 	tx := &types.LegacyTx{
 		Nonce:    0, // The first transaction of the owner identity should always be deploying the contract
 		Value:    gethcommon.Big0,
-		Gas:      4_000_000,
+		Gas:      4_000_000,       // It's quite the expensive contract.
 		GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 		Data:     gethcommon.FromHex(MessageBus.MessageBusMetaData.Bin),
 		To:       nil, // Geth requires nil instead of gethcommon.Address{} which equates to zero address in order to return receipt.
@@ -219,7 +219,7 @@ func (m *MessageBusManager) CreateSyntheticTransactions(messages common.CrossCha
 		tx := &types.LegacyTx{
 			Nonce:    startingNonce + uint64(idx),
 			Value:    gethcommon.Big0,
-			Gas:      4_900_000,
+			Gas:      4_000_000,
 			GasPrice: gethcommon.Big0, // Synthetic transactions are on the house. Or the house.
 			Data:     data,
 			To:       m.messageBusAddress,

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -685,15 +685,18 @@ func (e *enclaveImpl) GetTransactionCount(encryptedParams common.EncryptedParams
 	}
 
 	var nonce uint64
-	l2Head, err := e.storage.FetchBatchBySeqNo(e.registry.HeadBatchSeq().Uint64())
-	if err == nil {
-		// todo - we should return an error when head state is not available, but for current test situations with race
-		//  conditions we allow it to return zero while head state is uninitialized
-		s, err := e.storage.CreateStateDB(l2Head.Hash())
-		if err != nil {
-			return nil, responses.ToInternalError(err)
+	headBatch := e.registry.HeadBatchSeq()
+	if headBatch != nil {
+		l2Head, err := e.storage.FetchBatchBySeqNo(headBatch.Uint64())
+		if err == nil {
+			// todo - we should return an error when head state is not available, but for current test situations with race
+			//  conditions we allow it to return zero while head state is uninitialized
+			s, err := e.storage.CreateStateDB(l2Head.Hash())
+			if err != nil {
+				return nil, responses.ToInternalError(err)
+			}
+			nonce = s.GetNonce(address)
 		}
-		nonce = s.GetNonce(address)
 	}
 
 	encoded := hexutil.EncodeUint64(nonce)

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -163,6 +163,7 @@ func (s *sequencer) createGenesisBatch(block *common.L1Block) error {
 		return err
 	}
 
+	time.Sleep(5 * time.Second)
 	// produce batch #2 which has the message bus and any other system contracts
 	cb, err := s.produceBatch(
 		big.NewInt(0).Add(batch.Header.SequencerOrderNo, big.NewInt(1)),

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -163,6 +163,8 @@ func (s *sequencer) createGenesisBatch(block *common.L1Block) error {
 		return err
 	}
 
+        // errors in unit test seem to suggest that batch 2 was received before batch 1
+        // this ensures that there is enough gap so that batch 1 is issued before batch 2
 	time.Sleep(time.Second)
 	// produce batch #2 which has the message bus and any other system contracts
 	cb, err := s.produceBatch(

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -163,8 +163,8 @@ func (s *sequencer) createGenesisBatch(block *common.L1Block) error {
 		return err
 	}
 
-        // errors in unit test seem to suggest that batch 2 was received before batch 1
-        // this ensures that there is enough gap so that batch 1 is issued before batch 2
+	// errors in unit test seem to suggest that batch 2 was received before batch 1
+	// this ensures that there is enough gap so that batch 1 is issued before batch 2
 	time.Sleep(time.Second)
 	// produce batch #2 which has the message bus and any other system contracts
 	cb, err := s.produceBatch(

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -163,7 +163,7 @@ func (s *sequencer) createGenesisBatch(block *common.L1Block) error {
 		return err
 	}
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(time.Second)
 	// produce batch #2 which has the message bus and any other system contracts
 	cb, err := s.produceBatch(
 		big.NewInt(0).Add(batch.Header.SequencerOrderNo, big.NewInt(1)),

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -83,7 +83,7 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		MaxRollupSize:             1024 * 64,
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(1),
-		GasLocalExecutionCapFlag:  3_000_000,
-		GasBatchExecutionLimit:    3_000_000,
+		GasLocalExecutionCapFlag:  5_000_000,
+		GasBatchExecutionLimit:    5_000_000,
 	}
 }

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -83,7 +83,7 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		MaxRollupSize:             1024 * 64,
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(1),
-		GasLocalExecutionCapFlag:  5_000_000,
-		GasBatchExecutionLimit:    6_000_000,
+		GasLocalExecutionCapFlag:  10_000_000,
+		GasBatchExecutionLimit:    12_000_000,
 	}
 }

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -83,7 +83,7 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		MaxRollupSize:             1024 * 64,
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(1),
-		GasLocalExecutionCapFlag:  10_000_000,
-		GasBatchExecutionLimit:    12_000_000,
+		GasLocalExecutionCapFlag:  40_000_000,
+		GasBatchExecutionLimit:    30_000_000,
 	}
 }

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -84,6 +84,6 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(1),
 		GasLocalExecutionCapFlag:  5_000_000,
-		GasBatchExecutionLimit:    5_000_000,
+		GasBatchExecutionLimit:    6_000_000,
 	}
 }

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -83,7 +83,7 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		MaxRollupSize:             1024 * 64,
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(1),
-		GasLocalExecutionCapFlag:  40_000_000,
 		GasBatchExecutionLimit:    30_000_000,
+		GasLocalExecutionCapFlag:  40_000_000,
 	}
 }

--- a/integration/common/utils.go
+++ b/integration/common/utils.go
@@ -99,7 +99,7 @@ func PrefundWallets(ctx context.Context, faucetWallet wallet.Wallet, faucetClien
 		tx := &types.LegacyTx{
 			Nonce:    startingNonce + uint64(idx),
 			Value:    alloc,
-			Gas:      uint64(1_000_000),
+			Gas:      uint64(100_000),
 			GasPrice: gethcommon.Big1,
 			To:       &destAddr,
 		}

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -3,17 +3,17 @@ package integration
 // Tracks the start ports handed out to different tests, in a bid to minimise conflicts.
 const (
 	StartPortEth2NetworkTests        = 31000
-	StartPortNodeRunnerTest          = 32000
-	StartPortSimulationGethInMem     = 34000
-	StartPortSimulationInMem         = 35000
-	StartPortSimulationFullNetwork   = 37000
-	StartPortSmartContractTests      = 38000
-	StartPortContractDeployerTest    = 39000
-	StartPortWalletExtensionUnitTest = 40000
-	StartPortFaucetUnitTest          = 41000
-	StartPortFaucetHTTPUnitTest      = 42000
-	StartPortTenscanUnitTest         = 43000
-	StartPortTenGatewayUnitTest      = 44000
+	StartPortNodeRunnerTest          = 33000
+	StartPortSimulationGethInMem     = 35000
+	StartPortSimulationInMem         = 37000
+	StartPortSimulationFullNetwork   = 39000
+	StartPortSmartContractTests      = 41000
+	StartPortContractDeployerTest    = 43000
+	StartPortWalletExtensionUnitTest = 45000
+	StartPortFaucetUnitTest          = 47000
+	StartPortFaucetHTTPUnitTest      = 49000
+	StartPortTenscanUnitTest         = 51000
+	StartPortTenGatewayUnitTest      = 53000
 
 	DefaultGethWSPortOffset         = 100
 	DefaultGethAUTHPortOffset       = 200
@@ -24,9 +24,9 @@ const (
 	DefaultEnclaveOffset            = 700 // The default offset between a Geth nodes port and the enclave ports. Used in Socket Simulations.
 	DefaultHostRPCHTTPOffset        = 800 // The default offset for the host's RPC HTTP port
 	DefaultHostRPCWSOffset          = 900 // The default offset for the host's RPC websocket port
-	DefaultTenscanHTTPPortOffset    = 910
-	DefaultTenGatewayHTTPPortOffset = 930
-	DefaultTenGatewayWSPortOffset   = 940
+	DefaultTenscanHTTPPortOffset    = 1000
+	DefaultTenGatewayHTTPPortOffset = 1100
+	DefaultTenGatewayWSPortOffset   = 1200
 )
 
 const (

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -2,18 +2,18 @@ package integration
 
 // Tracks the start ports handed out to different tests, in a bid to minimise conflicts.
 const (
-	StartPortEth2NetworkTests        = 31000
-	StartPortNodeRunnerTest          = 33000
-	StartPortSimulationGethInMem     = 35000
-	StartPortSimulationInMem         = 37000
-	StartPortSimulationFullNetwork   = 39000
-	StartPortSmartContractTests      = 41000
-	StartPortContractDeployerTest    = 43000
-	StartPortWalletExtensionUnitTest = 45000
-	StartPortFaucetUnitTest          = 47000
-	StartPortFaucetHTTPUnitTest      = 49000
-	StartPortTenscanUnitTest         = 51000
-	StartPortTenGatewayUnitTest      = 53000
+	StartPortEth2NetworkTests        = 10000
+	StartPortNodeRunnerTest          = 14000
+	StartPortSimulationGethInMem     = 18000
+	StartPortSimulationInMem         = 22000
+	StartPortSimulationFullNetwork   = 26000
+	StartPortSmartContractTests      = 30000
+	StartPortContractDeployerTest    = 34000
+	StartPortWalletExtensionUnitTest = 38000
+	StartPortFaucetUnitTest          = 42000
+	StartPortFaucetHTTPUnitTest      = 48000
+	StartPortTenscanUnitTest         = 52000
+	StartPortTenGatewayUnitTest      = 56000
 
 	DefaultGethWSPortOffset         = 100
 	DefaultGethAUTHPortOffset       = 200
@@ -25,8 +25,8 @@ const (
 	DefaultHostRPCHTTPOffset        = 800 // The default offset for the host's RPC HTTP port
 	DefaultHostRPCWSOffset          = 900 // The default offset for the host's RPC websocket port
 	DefaultTenscanHTTPPortOffset    = 1000
-	DefaultTenGatewayHTTPPortOffset = 1100
-	DefaultTenGatewayWSPortOffset   = 1200
+	DefaultTenGatewayHTTPPortOffset = 1001
+	DefaultTenGatewayWSPortOffset   = 1002
 )
 
 const (

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ten-protocol/go-ten/integration/datagenerator"
 	"golang.org/x/sync/errgroup"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -205,6 +207,10 @@ func NewEth2Network(
 func (n *Impl) Start() error {
 	startTime := time.Now()
 	var eg errgroup.Group
+
+	if err := n.ensureNoDuplicatedNetwork(); err != nil {
+		return err
+	}
 
 	// initialize the genesis data on the nodes
 	for _, nodeDataDir := range n.dataDirs {
@@ -506,6 +512,11 @@ func (n *Impl) waitForMergeEvent(startTime time.Time) error {
 	}
 
 	fmt.Printf("Reached the merge block after %s\n", time.Since(startTime))
+
+	if err = n.prefundedBalancesActive(dial); err != nil {
+		fmt.Printf("Error prefunding accounts %s\n", err.Error())
+		return err
+	}
 	return nil
 }
 
@@ -585,6 +596,31 @@ func (n *Impl) gethImportEnodes(enodes []string) error {
 			}
 		}
 		time.Sleep(time.Second)
+	}
+	return nil
+}
+
+func (n *Impl) prefundedBalancesActive(client *ethclient.Client) error {
+	for _, addr := range n.preFundedMinerAddrs {
+		balance, err := client.BalanceAt(context.Background(), gethcommon.HexToAddress(addr), nil)
+		if err != nil {
+			return fmt.Errorf("unable to check balance for account %s - %w", addr, err)
+		}
+		if balance.Cmp(gethcommon.Big0) == 0 {
+			return fmt.Errorf("unexpected %s balance for account %s", balance.String(), addr)
+		}
+		fmt.Printf("Account %s prefunded with %s", addr, balance.String())
+	}
+
+	return nil
+}
+
+func (n *Impl) ensureNoDuplicatedNetwork() error {
+	for nodeIdx, port := range n.gethWSPorts {
+		_, err := ethclient.Dial(fmt.Sprintf("ws://127.0.0.1:%d", port))
+		if err == nil {
+			return fmt.Errorf("unexpected geth node %d is active before the network is started", nodeIdx)
+		}
 	}
 	return nil
 }

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -609,7 +609,7 @@ func (n *Impl) prefundedBalancesActive(client *ethclient.Client) error {
 		if balance.Cmp(gethcommon.Big0) == 0 {
 			return fmt.Errorf("unexpected %s balance for account %s", balance.String(), addr)
 		}
-		fmt.Printf("Account %s prefunded with %s", addr, balance.String())
+		fmt.Printf("Account %s prefunded with %s\n", addr, balance.String())
 	}
 
 	return nil

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -227,7 +227,7 @@ func (s *Simulation) deployObscuroERC20s() {
 
 			deployContractTx := types.DynamicFeeTx{
 				Nonce:     NextNonce(s.ctx, s.RPCHandles, owner),
-				Gas:       4_000_000,
+				Gas:       2_900_000,
 				GasFeeCap: gethcommon.Big1, // This field is used to derive the gas price for dynamic fee transactions.
 				Data:      contractBytes,
 				GasTipCap: gethcommon.Big1,

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -227,7 +227,7 @@ func (s *Simulation) deployObscuroERC20s() {
 
 			deployContractTx := types.DynamicFeeTx{
 				Nonce:     NextNonce(s.ctx, s.RPCHandles, owner),
-				Gas:       2_900_000,
+				Gas:       4_000_000,
 				GasFeeCap: gethcommon.Big1, // This field is used to derive the gas price for dynamic fee transactions.
 				Data:      contractBytes,
 				GasTipCap: gethcommon.Big1,

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -227,7 +227,7 @@ func (s *Simulation) deployObscuroERC20s() {
 
 			deployContractTx := types.DynamicFeeTx{
 				Nonce:     NextNonce(s.ctx, s.RPCHandles, owner),
-				Gas:       4_000_000,
+				Gas:       5_000_000,
 				GasFeeCap: gethcommon.Big1, // This field is used to derive the gas price for dynamic fee transactions.
 				Data:      contractBytes,
 				GasTipCap: gethcommon.Big1,

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -227,7 +227,7 @@ func (s *Simulation) deployObscuroERC20s() {
 
 			deployContractTx := types.DynamicFeeTx{
 				Nonce:     NextNonce(s.ctx, s.RPCHandles, owner),
-				Gas:       2_000_000,
+				Gas:       4_000_000,
 				GasFeeCap: gethcommon.Big1, // This field is used to derive the gas price for dynamic fee transactions.
 				Data:      contractBytes,
 				GasTipCap: gethcommon.Big1,

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -38,7 +38,7 @@ var testLogs = "../.build/noderunner/"
 func init() { //nolint:gochecknoinits
 	testlog.Setup(&testlog.Cfg{
 		LogDir:      testLogs,
-		TestType:    "noderunner",
+		TestType:    "smartcontracts",
 		TestSubtype: "test",
 		LogLevel:    log.LvlInfo,
 	})

--- a/tools/hardhatdeployer/contract_deployer.go
+++ b/tools/hardhatdeployer/contract_deployer.go
@@ -92,7 +92,7 @@ func (cd *contractDeployer) run() (string, error) {
 	deployContractTx := types.LegacyTx{
 		Nonce:    cd.wallet.GetNonceAndIncrement(),
 		GasPrice: big.NewInt(1),
-		Gas:      uint64(2_000_000),
+		Gas:      uint64(4_000_000), // todo @pedro review this
 		Data:     cd.contractCode,
 	}
 

--- a/tools/hardhatdeployer/contract_deployer.go
+++ b/tools/hardhatdeployer/contract_deployer.go
@@ -92,7 +92,7 @@ func (cd *contractDeployer) run() (string, error) {
 	deployContractTx := types.LegacyTx{
 		Nonce:    cd.wallet.GetNonceAndIncrement(),
 		GasPrice: big.NewInt(1),
-		Gas:      uint64(4_000_000), // todo @pedro review this
+		Gas:      uint64(2_900_000),
 		Data:     cd.contractCode,
 	}
 

--- a/tools/hardhatdeployer/contract_deployer.go
+++ b/tools/hardhatdeployer/contract_deployer.go
@@ -92,7 +92,7 @@ func (cd *contractDeployer) run() (string, error) {
 	deployContractTx := types.LegacyTx{
 		Nonce:    cd.wallet.GetNonceAndIncrement(),
 		GasPrice: big.NewInt(1),
-		Gas:      uint64(4_000_000),
+		Gas:      uint64(5_000_000),
 		Data:     cd.contractCode,
 	}
 

--- a/tools/hardhatdeployer/contract_deployer.go
+++ b/tools/hardhatdeployer/contract_deployer.go
@@ -92,7 +92,7 @@ func (cd *contractDeployer) run() (string, error) {
 	deployContractTx := types.LegacyTx{
 		Nonce:    cd.wallet.GetNonceAndIncrement(),
 		GasPrice: big.NewInt(1),
-		Gas:      uint64(2_900_000),
+		Gas:      uint64(4_000_000),
 		Data:     cd.contractCode,
 	}
 


### PR DESCRIPTION
### Why this change is needed

There are a bunch of latent issues that seem to creep up when the gas limits are added.
I have a few guesses on what might be happening, mainly relating with contract sizes being large, and blocks getting filled faster than the testing is used to. However I think this needs to be more carefully inspected.

This PR addresses the following:
- Re-adds all reverted PRs:
https://github.com/ten-protocol/go-ten/pull/1682
https://github.com/ten-protocol/go-ten/pull/1710
https://github.com/ten-protocol/go-ten/pull/1715

- Adds missing log folders ( faucet, obscuroscan, tengateway, smartcontracts )
- Fixes gas limits on calls on both go code and HardHat
- Bump gas values to 30M ( Re-opened the ticket to reduce max batch size to 2.5M )
- Bump ports - now have a 2k distance between them
- Adds 1 sec delay between Genesis and Batch #2 ( producing 2 batches so close together was leading the synthetic contract deployment to be all screwy leading to complaints on the nonce and then to an unreliable batch state)
- Added `ensureNoDuplicatedNetwork` for geth to ensure no lingering network is running when it shouldnt
- Added `prefundedBalancesActive` making sure the prefunded balances are ok at the end of the eth2network start cycle

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


