### PR TITLE
make WalletExtensionContainer.Start() non blocking

### DIFF
--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -156,18 +156,28 @@ func (w *WalletExtensionContainer) Start() error {
 
 	// Start a goroutine for handling HTTP server errors
 	go func() {
-		for err := range httpErrChan {
-			if !errors.Is(err, http.ErrServerClosed) {
-				w.logger.Error("HTTP server error: %v", err)
+		for {
+			select {
+			case err := <-httpErrChan:
+				if !errors.Is(err, http.ErrServerClosed) {
+					w.logger.Error("HTTP server error: %v", err)
+				}
+			case <-w.stopControl.Done():
+				return // Exit the goroutine when stop signal is received
 			}
 		}
 	}()
 
 	// Start a goroutine for handling WebSocket server errors
 	go func() {
-		for err := range wsErrChan {
-			if !errors.Is(err, http.ErrServerClosed) {
-				w.logger.Error("WebSocket server error: %v", err)
+		for {
+			select {
+			case err := <-wsErrChan:
+				if !errors.Is(err, http.ErrServerClosed) {
+					w.logger.Error("WebSocket server error: %v", err)
+				}
+			case <-w.stopControl.Done():
+				return // Exit the goroutine when stop signal is received
 			}
 		}
 	}()

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -154,7 +154,7 @@ func (w *WalletExtensionContainer) Start() error {
 	httpErrChan := w.httpServer.Start()
 	wsErrChan := w.wsServer.Start()
 
-	// Start a goroutine for handling HTTP server errors
+	// Start a goroutine for handling HTTP and WS server errors
 	go func() {
 		for {
 			select {
@@ -169,16 +169,6 @@ func (w *WalletExtensionContainer) Start() error {
 					// for other errors, we just log them
 					w.logger.Error("HTTP server error: %v", err)
 				}
-			case <-w.stopControl.Done():
-				return // Exit the goroutine when stop signal is received
-			}
-		}
-	}()
-
-	// Start a goroutine for handling WebSocket server errors
-	go func() {
-		for {
-			select {
 			case err := <-wsErrChan:
 				if errors.Is(err, http.ErrServerClosed) {
 					err = w.Stop() // Stop the container when the WS server is closed
@@ -195,7 +185,6 @@ func (w *WalletExtensionContainer) Start() error {
 			}
 		}
 	}()
-
 	return nil
 }
 

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -59,19 +59,12 @@ func main() {
 	logger := log.New(log.WalletExtCmp, int(logLvl), config.LogPath)
 
 	walletExtContainer := container.NewWalletExtensionContainerFromConfig(config, logger)
-	defer func() {
-		err := walletExtContainer.Start()
-		if err != nil {
-			fmt.Printf("error stopping WE - %s", err)
-		}
-	}()
 
-	go func() {
-		err := walletExtContainer.Start()
-		if err != nil {
-			fmt.Printf("error in WE - %s", err)
-		}
-	}()
+	// Start the wallet extension.
+	err := walletExtContainer.Start()
+	if err != nil {
+		fmt.Printf("error in WE - %s", err)
+	}
 
 	walletExtensionAddr := fmt.Sprintf("%s:%d", common.Localhost, config.WalletExtensionPortHTTP)
 	fmt.Printf("💡 Wallet extension started \n") // Some tests rely on seeing this message. Removed in next PR.


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/1994

WalletExtensionContainer.Start()  was blocking before, now I've made it non blocking.

### What changes were made as part of this PR

Wait for errors in separate go-routines and don't use `select` directly to block execution.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 

E2E tests passing: https://github.com/ten-protocol/ten-test/actions/runs/7338012346/job/19979846117

