### PR TITLE
Fix the enclave stream reconnect

### DIFF
--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -491,7 +491,8 @@ func (c *Client) StreamL2Updates() (chan common.StreamL2UpdatesResponse, func())
 		c.logger.Error("Error opening batch stream.", log.ErrKey, err)
 		cancel()
 		close(batchChan)
-		return nil, nil
+		// return closed channel and no-op cancel func
+		return batchChan, func() {}
 	}
 
 	stopIt := func() {


### PR DESCRIPTION
### Why this change is needed

Fix the reconnecting to live batch streaming from the enclave after a disconnect.

Currently there's a bug where the guardian receives back a nil channel if the reconnect fails, which it blocks on forever so it will never try to reconnect.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


