### PR TITLE
statedb revert to snapshot for ignored batches

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -172,7 +172,7 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 	if err != nil {
 		return nil, fmt.Errorf("could not create stateDB. Cause: %w", err)
 	}
-	// snap := stateDB.Snapshot()
+	snap := stateDB.Snapshot()
 
 	var messages common.CrossChainMessages
 	var transfers common.ValueTransferEvents
@@ -222,9 +222,10 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 		len(crossChainTransactions) == 0 &&
 		len(messages) == 0 &&
 		len(transfers) == 0 {
-		// todo review why this is failing deployment with "panic: revision id 0 cannot be reverted" - https://github.com/ten-protocol/ten-internal/issues/2654
-		//// revert any unexpected mutation to the statedb
-		//stateDB.RevertToSnapshot(snap)
+		if snap > 0 {
+			//// revert any unexpected mutation to the statedb
+			stateDB.RevertToSnapshot(snap)
+		}
 		return nil, ErrNoTransactionsToProcess
 	}
 


### PR DESCRIPTION
### Why this change is needed

- revert any statedb changes performed by the sequencer speculatively when it turns out the batch will not get published

### What changes were made as part of this PR

- revert to a snapshot

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


