### PR TITLE
Ten gateway use http instead of ws

### DIFF
--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -264,7 +264,6 @@ func testSubscriptionTopics(t *testing.T, httpURL, wsURL string, w wallet.Wallet
 	// Transfer some funds to user1 to be able to make transactions
 	_, err = transferETHToAddress(user0.HTTPClient, user0.Wallets[0], user1.Wallets[0].Address(), amountToTransfer)
 	require.NoError(t, err)
-	time.Sleep(5 * time.Second)
 	_, err = transferETHToAddress(user0.HTTPClient, user0.Wallets[0], user1.Wallets[1].Address(), amountToTransfer)
 	require.NoError(t, err)
 

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -248,11 +248,9 @@ func testMultipleAccountsSubscription(t *testing.T, httpURL, wsURL string, w wal
 func testSubscriptionTopics(t *testing.T, httpURL, wsURL string, w wallet.Wallet) {
 	user0, err := NewUser([]wallet.Wallet{w}, httpURL, wsURL)
 	require.NoError(t, err)
-	fmt.Printf("Created user with encryption token: %s\n", user0.tgClient.UserID())
 
 	user1, err := NewUser([]wallet.Wallet{datagenerator.RandomWallet(integration.TenChainID), datagenerator.RandomWallet(integration.TenChainID)}, httpURL, wsURL)
 	require.NoError(t, err)
-	fmt.Printf("Created user with encryption token: %s\n", user0.tgClient.UserID())
 
 	// register all the accounts for that user
 	err = user0.RegisterAccounts()

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -291,7 +291,7 @@ func testSubscriptionTopics(t *testing.T, httpURL, wsURL string, w wallet.Wallet
 	contractReceipt, err := integrationCommon.AwaitReceiptEth(context.Background(), user0.HTTPClient, signedTx.Hash(), time.Minute)
 	require.NoError(t, err)
 
-	//user0 subscribes to all events from that smart contract, user1 only an event with a topic of his first account
+	// user0 subscribes to all events from that smart contract, user1 only an event with a topic of his first account
 	var user0logs []types.Log
 	var user1logs []types.Log
 	var topics [][]gethcommon.Hash
@@ -666,7 +666,7 @@ func transferETHToAddress(client *ethclient.Client, wallet wallet.Wallet, toAddr
 	return integrationCommon.AwaitReceiptEth(context.Background(), client, signedTx.Hash(), 20*time.Second)
 }
 
-func subscribeToEvents(addresses []gethcommon.Address, topics [][]gethcommon.Hash, client *ethclient.Client, logs *[]types.Log) ethereum.Subscription { //nolint:unparam
+func subscribeToEvents(addresses []gethcommon.Address, topics [][]gethcommon.Hash, client *ethclient.Client, logs *[]types.Log) ethereum.Subscription {
 	// Make a subscription
 	filterQuery := ethereum.FilterQuery{
 		Addresses: addresses,

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -301,12 +301,14 @@ func testSubscriptionTopics(t *testing.T, httpURL, wsURL string, w wallet.Wallet
 	subscribeToEvents([]gethcommon.Address{contractReceipt.ContractAddress}, nil, user0.WSClient, &user0logs)
 	subscribeToEvents([]gethcommon.Address{contractReceipt.ContractAddress}, topics, user1.WSClient, &user1logs)
 
-	// TODO: add a comment
+	// user0 calls setMessage on deployed smart contract with the account twice and expects two events
 	_, err = integrationCommon.InteractWithSmartContract(user0.HTTPClient, user0.Wallets[0], eventsContractABI, "setMessage", "user0Event1", contractReceipt.ContractAddress)
 	require.NoError(t, err)
 	_, err = integrationCommon.InteractWithSmartContract(user0.HTTPClient, user0.Wallets[0], eventsContractABI, "setMessage", "user0Event2", contractReceipt.ContractAddress)
 	require.NoError(t, err)
 
+	// user1 calls setMessage on deployed smart contract with two different accounts and expects only one event,
+	// because only the first address is in the topic filter of the subscription
 	_, err = integrationCommon.InteractWithSmartContract(user1.HTTPClient, user1.Wallets[0], eventsContractABI, "setMessage", "user1Event1", contractReceipt.ContractAddress)
 	require.NoError(t, err)
 	_, err = integrationCommon.InteractWithSmartContract(user1.HTTPClient, user1.Wallets[1], eventsContractABI, "setMessage", "user1Event2", contractReceipt.ContractAddress)

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -136,7 +136,7 @@ func (m *AccountManager) suggestSubscriptionClient(rpcReq *wecommon.RPCRequest) 
 	}
 
 	if len(rpcReq.Params) > 1 {
-		filteredAccounts, err := m.filterAccounts(rpcReq, accounts, userPrivateKey)
+		filteredAccounts, err := m.filterAccounts(rpcReq, accounts)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +150,7 @@ func (m *AccountManager) suggestSubscriptionClient(rpcReq *wecommon.RPCRequest) 
 }
 
 // filterClients checks if any of the accounts match the filter criteria and returns those accounts
-func (m *AccountManager) filterAccounts(rpcReq *wecommon.RPCRequest, accounts []wecommon.AccountDB, userPrivateKey []byte) ([]wecommon.AccountDB, error) {
+func (m *AccountManager) filterAccounts(rpcReq *wecommon.RPCRequest, accounts []wecommon.AccountDB) ([]wecommon.AccountDB, error) {
 	var filteredAccounts []wecommon.AccountDB
 	filterCriteriaJSON, err := json.Marshal(rpcReq.Params[1])
 	if err != nil {

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -142,7 +142,7 @@ func (m *AccountManager) suggestSubscriptionClient(rpcReq *wecommon.RPCRequest) 
 		}
 		// return filtered clients if we found any
 		if len(filteredAccounts) > 0 {
-			return m.createClientsForAccounts(filteredAccounts, userPrivateKey)
+			accounts = filteredAccounts
 		}
 	}
 	// create clients for all accounts if we didn't find any clients that match the filter or if no topics were provided

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -159,11 +159,7 @@ func (m *AccountManager) suggestSubscriptionClient(rpcReq *wecommon.RPCRequest) 
 			}
 		}
 		// Go through each topic filter and look for registered addresses
-		for i, topicCondition := range filterCriteria.Topics {
-			// the first topic is always the signature of the event, so it can't be an address
-			if i == 0 {
-				continue
-			}
+		for _, topicCondition := range filterCriteria.Topics {
 			for _, topic := range topicCondition {
 				potentialAddr := common.ExtractPotentialAddress(topic)
 				m.logger.Info(fmt.Sprintf("Potential address (%s) found for the request %s", potentialAddr, rpcReq))

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -37,6 +37,7 @@ const (
 	PathHealth                          = "/health/"
 	PathNetworkHealth                   = "/network-health/"
 	WSProtocol                          = "ws://"
+	HTTPProtocol                        = "http://"
 	DefaultUser                         = "defaultUser"
 	UserQueryParameter                  = "u"
 	EncryptedTokenQueryParameter        = "token"

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -85,7 +85,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 				os.Exit(1)
 			}
 			for _, account := range accounts {
-				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrHTTP, account.AccountAddress, user.PrivateKey, account.Signature, logger)
+				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrWS, account.AccountAddress, user.PrivateKey, account.Signature, logger)
 				if err != nil {
 					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 					os.Exit(1)

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -38,8 +38,9 @@ type WalletExtensionContainer struct {
 
 func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.Logger) *WalletExtensionContainer {
 	// create the account manager with a single unauthenticated connection
-	hostRPCBindAddr := wecommon.WSProtocol + config.NodeRPCWebsocketAddress
-	unAuthedClient, err := rpc.NewNetworkClient(hostRPCBindAddr)
+	hostRPCBindAddrWS := wecommon.WSProtocol + config.NodeRPCWebsocketAddress
+	hostRPCBindAddrHTTP := wecommon.HTTPProtocol + config.NodeRPCHTTPAddress
+	unAuthedClient, err := rpc.NewNetworkClient(hostRPCBindAddrHTTP)
 	if err != nil {
 		logger.Crit("unable to create temporary client for request ", log.ErrKey, err)
 		os.Exit(1)
@@ -51,7 +52,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 		logger.Crit("unable to create database to store viewing keys ", log.ErrKey, err)
 		os.Exit(1)
 	}
-	userAccountManager := useraccountmanager.NewUserAccountManager(unAuthedClient, logger, databaseStorage, hostRPCBindAddr)
+	userAccountManager := useraccountmanager.NewUserAccountManager(unAuthedClient, logger, databaseStorage, hostRPCBindAddrHTTP, hostRPCBindAddrWS)
 
 	// add default user (when no UserID is provided in the query parameter - for WE endpoints)
 	defaultUserAccountManager := userAccountManager.AddAndReturnAccountManager(hex.EncodeToString([]byte(wecommon.DefaultUser)))
@@ -84,7 +85,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 				os.Exit(1)
 			}
 			for _, account := range accounts {
-				encClient, err := wecommon.CreateEncClient(hostRPCBindAddr, account.AccountAddress, user.PrivateKey, account.Signature, logger)
+				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrHTTP, account.AccountAddress, user.PrivateKey, account.Signature, logger)
 				if err != nil {
 					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 					os.Exit(1)
@@ -109,14 +110,14 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 	}
 
 	stopControl := stopcontrol.New()
-	walletExt := walletextension.New(hostRPCBindAddr, &userAccountManager, databaseStorage, stopControl, version, logger, &config)
+	walletExt := walletextension.New(hostRPCBindAddrHTTP, hostRPCBindAddrWS, &userAccountManager, databaseStorage, stopControl, version, logger, &config)
 	httpRoutes := api.NewHTTPRoutes(walletExt)
 	httpServer := api.NewHTTPServer(fmt.Sprintf("%s:%d", config.WalletExtensionHost, config.WalletExtensionPortHTTP), httpRoutes)
 
 	wsRoutes := api.NewWSRoutes(walletExt)
 	wsServer := api.NewWSServer(fmt.Sprintf("%s:%d", config.WalletExtensionHost, config.WalletExtensionPortWS), wsRoutes)
 	return NewWalletExtensionContainer(
-		hostRPCBindAddr,
+		hostRPCBindAddrWS,
 		walletExt,
 		&userAccountManager,
 		databaseStorage,

--- a/tools/walletextension/useraccountmanager/user_account_manager_test.go
+++ b/tools/walletextension/useraccountmanager/user_account_manager_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAddingAndGettingUserAccountManagers(t *testing.T) {
 	unauthedClient, _ := rpc.NewNetworkClient("ws://test")
-	userAccountManager := NewUserAccountManager(unauthedClient, log.New(), nil, "ws://test")
+	userAccountManager := NewUserAccountManager(unauthedClient, log.New(), nil, "http://test", "ws://test")
 	userID1 := "4A6F686E20446F65"
 	userID2 := "7A65746F65A2676F"
 
@@ -50,7 +50,7 @@ func TestAddingAndGettingUserAccountManagers(t *testing.T) {
 
 func TestDeletingUserAccountManagers(t *testing.T) {
 	unauthedClient, _ := rpc.NewNetworkClient("ws://test")
-	userAccountManager := NewUserAccountManager(unauthedClient, log.New(), nil, "")
+	userAccountManager := NewUserAccountManager(unauthedClient, log.New(), nil, "", "")
 	userID := "user1"
 
 	// Add an account manager for the user


### PR DESCRIPTION
### Why this change is needed

We want to use http connections from the gateway to the validator. Having web socket connections open for a lot of users can cause gateway to crash. It is also problematic if we want to have it behind load balancer.
Websocket connections are still needed for subscriptions.

https://github.com/ten-protocol/ten-internal/issues/2505

### What changes were made as part of this PR

Changed ws connection to http, creating ws connections for subscriptions + added a test for subscription topics

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 

https://github.com/ten-protocol/ten-test/actions/runs/7504133752/job/20430444139

