### PR TITLE
Host: Fix bug causing unnecessary multiplier on L1 gas fees

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -259,8 +259,9 @@ func (e *gethRPCClient) PrepareTransactionToRetry(txData types.TxData, from geth
 	}
 
 	// it should never happen but to avoid any risk of repeated price increases we cap the possible retry price bumps to 5
-	retryFloat := math.Max(_maxRetryPriceIncreases, float64(retryNumber))
+	retryFloat := math.Min(_maxRetryPriceIncreases, float64(retryNumber))
 	// we apply a 20% gas price increase for each retry (retrying with similar price gets rejected by mempool)
+	// Retry '0' is the first attempt, gives multiplier of 1.0
 	multiplier := math.Pow(_retryPriceMultiplier, retryFloat)
 
 	gasPriceFloat := new(big.Float).SetInt(gasPrice)


### PR DESCRIPTION
### Why this change is needed

I put Max instead of Min to cap the gas multiplier after repeated retries. This meant it was always doing max multiplier from the first attempt.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


