### PR TITLE
Loggers: use log format rather than terminal format for files

### DIFF
--- a/go/common/log/log.go
+++ b/go/common/log/log.go
@@ -58,7 +58,7 @@ func New(component string, level int, out string, ctx ...interface{}) gethlog.Lo
 	if out == SysOut {
 		s = gethlog.StreamHandler(os.Stdout, gethlog.TerminalFormat(false))
 	} else {
-		s1, err := gethlog.FileHandler(out, gethlog.TerminalFormat(false))
+		s1, err := gethlog.FileHandler(out, gethlog.LogfmtFormat())
 		if err != nil {
 			panic(err)
 		}

--- a/integration/common/testlog/testlog.go
+++ b/integration/common/testlog/testlog.go
@@ -45,7 +45,7 @@ func Setup(cfg *Cfg) *os.File {
 	}
 	logFile = f.Name()
 	// hardcode geth log level to error only
-	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(cfg.LogLevel, gethlog.StreamHandler(f, gethlog.TerminalFormat(false))))
+	gethlog.Root().SetHandler(gethlog.LvlFilterHandler(cfg.LogLevel, gethlog.StreamHandler(f, gethlog.LogfmtFormat())))
 	testlog = gethlog.Root().New(log.CmpKey, log.TestLogCmp)
 	return f
 }


### PR DESCRIPTION
### Why this change is needed

I'm getting frustrated fairly regularly by shortened hashes, like the tx hash in this log msg:
```
INFO [01-17|11:36:12.973] Host issuing l1 tx                       node_id=0xE09a37ABc1A63441404007019E5BC7517bE2c43f component=host     tx=27cb85..41b663 size=6 retries=0
```
It means you can't do a lookup by hash for whatever the item is. And it's happening automatically because we use a Terminal log formatter even for loggers that write to files.

### What changes were made as part of this PR

Changes the formatter to log formatter unless it's streaming to SysOut.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


