### PR TITLE
Reorder Deploy L2 jobs, loadbalancer must follow check-obscuro-is-healthy

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -251,36 +251,6 @@ jobs:
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
                start'
 
-
-  update-loadbalancer:
-    needs:
-      - build
-      - deploy
-    runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.event.inputs.testnet_type }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: 'Login via Azure CLI'
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: 'Remove existing backend nodes from the load balancer'
-        run: ./.github/workflows/runner-scripts/testnet-clear-loadbalancer.sh ${{ github.event.inputs.testnet_type }}
-
-      - name: 'Add load balancer address pool to the IP configuration'
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az network nic ip-config address-pool add \
-              --address-pool ${{ github.event.inputs.testnet_type }}-backend-pool \
-              --ip-config-name ipconfig${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }} \
-              --nic-name ${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }}VMNic \
-              --resource-group Testnet \
-              --lb-name ${{ github.event.inputs.testnet_type }}-loadbalancer
-
   check-obscuro-is-healthy:
     needs:
       - build
@@ -336,6 +306,36 @@ jobs:
           path: |
             deploy-l2-contracts.out
           retention-days: 7
+
+  update-loadbalancer:
+    needs:
+      - build
+      - deploy
+      - check-obscuro-is-healthy
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.testnet_type }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: 'Remove existing backend nodes from the load balancer'
+        run: ./.github/workflows/runner-scripts/testnet-clear-loadbalancer.sh ${{ github.event.inputs.testnet_type }}
+
+      - name: 'Add load balancer address pool to the IP configuration'
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az network nic ip-config address-pool add \
+              --address-pool ${{ github.event.inputs.testnet_type }}-backend-pool \
+              --ip-config-name ipconfig${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }} \
+              --nic-name ${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }}VMNic \
+              --resource-group Testnet \
+              --lb-name ${{ github.event.inputs.testnet_type }}-loadbalancer
 
   deploy-faucet:
     name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -309,8 +309,6 @@ jobs:
 
   update-loadbalancer:
     needs:
-      - build
-      - deploy
       - check-obscuro-is-healthy
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -194,8 +194,6 @@ jobs:
 #
 #  update-loadbalancer:
 #    needs:
-#      - build
-#      - deploy
 #      - check-obscuro-is-healthy
 #    runs-on: ubuntu-latest
 #    environment:

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -196,6 +196,7 @@ jobs:
 #    needs:
 #      - build
 #      - deploy
+#      - check-obscuro-is-healthy
 #    runs-on: ubuntu-latest
 #    environment:
 #      name: ${{ github.event.inputs.testnet_type }}


### PR DESCRIPTION
### Why this change is needed

L2 deployment workflows currently parallelize jobs for load balancer update with osbscuro-node-healthcheck. In cases where requests are processed via the LB prior to the node-persistence init, calls such as `getTransactionCount` throw `nil` exception.

On the deployment side, correct ordering should be be maintained.

ten-protocol/ten-internal/issues/2828

### What changes were made as part of this PR

- Job `update-loadbalancer` in workflows given "needs: check-obscuro-is-healthy` to enforce ordering.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed (run but fail - on issue unrelated to commit.. https://github.com/ten-protocol/ten-test/actions/runs/7658145094)


