### PR TITLE
Host: Drop transactions received when enclave not ready

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -182,7 +182,9 @@ func (g *Guardian) HandleBatch(batch *common.ExtBatch) {
 }
 
 func (g *Guardian) HandleTransaction(tx common.EncryptedTx) {
-	if g.GetEnclaveState().status == Disconnected || g.GetEnclaveState().status == Unavailable {
+	if g.GetEnclaveState().status == Disconnected ||
+		g.GetEnclaveState().status == Unavailable ||
+		g.GetEnclaveState().status == AwaitingSecret {
 		g.logger.Info("Enclave is not ready yet, dropping transaction.")
 		return // ignore transactions when enclave unavailable
 	}

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -182,9 +182,9 @@ func (g *Guardian) HandleBatch(batch *common.ExtBatch) {
 }
 
 func (g *Guardian) HandleTransaction(tx common.EncryptedTx) {
-	if !g.state.IsUpToDate() {
-		g.logger.Info("Enclave is not up-to-date, dropping received transaction.")
-		return // ignore transactions until we're up-to-date
+	if g.GetEnclaveState().status == Disconnected || g.GetEnclaveState().status == Unavailable {
+		g.logger.Info("Enclave is not ready yet, dropping transaction.")
+		return // ignore transactions when enclave unavailable
 	}
 	resp, sysError := g.enclaveClient.SubmitTx(tx)
 	if sysError != nil {

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -182,6 +182,10 @@ func (g *Guardian) HandleBatch(batch *common.ExtBatch) {
 }
 
 func (g *Guardian) HandleTransaction(tx common.EncryptedTx) {
+	if !g.state.IsUpToDate() {
+		g.logger.Info("Enclave is not up-to-date, dropping received transaction.")
+		return // ignore transactions until we're up-to-date
+	}
 	resp, sysError := g.enclaveClient.SubmitTx(tx)
 	if sysError != nil {
 		g.logger.Warn("could not submit transaction due to sysError", log.ErrKey, sysError)


### PR DESCRIPTION
### Why this change is needed

We sometimes see enclave failures when it receives transactions before it is ready.

### What changes were made as part of this PR

Only send transactions to an enclave when it is live (up-to-date).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


