### PR TITLE
Host: Drop transactions received when enclave not ready (#1762)

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -182,6 +182,12 @@ func (g *Guardian) HandleBatch(batch *common.ExtBatch) {
 }
 
 func (g *Guardian) HandleTransaction(tx common.EncryptedTx) {
+	if g.GetEnclaveState().status == Disconnected ||
+		g.GetEnclaveState().status == Unavailable ||
+		g.GetEnclaveState().status == AwaitingSecret {
+		g.logger.Info("Enclave is not ready yet, dropping transaction.")
+		return // ignore transactions when enclave unavailable
+	}
 	resp, sysError := g.enclaveClient.SubmitTx(tx)
 	if sysError != nil {
 		g.logger.Warn("could not submit transaction due to sysError", log.ErrKey, sysError)


### PR DESCRIPTION
### Why this change is needed

Cherry-pick https://github.com/ten-protocol/go-ten/pull/1762 to release branch (host should not send tx to enclave when enclave unavailable).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


