### PR TITLE
add maxDbPoolSize for edglessdb

### DIFF
--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -97,7 +97,7 @@ const (
 	initFile = "001_init.sql"
 
 	// maximum number of database connections maintained in the tx pool
-	maxDbPoolSize = 100
+	maxDBPoolSize = 100
 )
 
 var (
@@ -470,9 +470,9 @@ func connectToEdgelessDB(edbHost string, tlsCfg *tls.Config, logger gethlog.Logg
 	dsn := cfg.FormatDSN()
 	logger.Info(fmt.Sprintf("Configuring mysql connection: %s", dsn))
 	db, err := sql.Open("mysql", dsn)
-	db.SetMaxOpenConns(maxDbPoolSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize mysql connection to edb - %w", err)
 	}
+	db.SetMaxOpenConns(maxDBPoolSize)
 	return db, nil
 }


### PR DESCRIPTION
### Why this change is needed

edglessdb is started with a maximum number of accepted connections. (probably 200)

This makes sure we don't try to open more.
