### PR TITLE
Add estimate optmisation that geth added

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -1252,6 +1252,12 @@ func (e *enclaveImpl) DoEstimateGas(args *gethapi.TransactionArgs, blkNumber *ge
 	// Execute the binary search and hone in on an isGasEnough gas limit
 	for lo+1 < hi {
 		mid := (hi + lo) / 2
+		if mid > lo*2 {
+			// Most txs don't need much higher gas limit than their gas used, and most txs don't
+			// require near the full block limit of gas, so the selection of where to bisect the
+			// range here is skewed to favor the low side.
+			mid = lo * 2
+		}
 		failed, _, err := e.isGasEnough(args, mid, blkNumber)
 		// If the error is not nil(consensus error), it means the provided message
 		// call or transaction will never be accepted no matter how much gas it is


### PR DESCRIPTION
### Why this change is needed

Our gas estimation method is lifted (copy-paste) from geth code. They added an optimisation to their binary search that means in average case it goes way quicker (e.g. 4 iterations instead of 37 in my testing).

https://github.com/ethereum/go-ethereum/blob/16ce7bf50fa71c907d1dc6504ed32a9161e71351/eth/gasestimator/gasestimator.go#L162 <-- is the code on their codebase.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


