### PR TITLE
[Batch Execution] Fix for desync issue.

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -182,11 +182,14 @@ func (executor *batchExecutor) ComputeBatch(context *BatchExecutionContext, fail
 
 	syntheticTransactions := append(xchainTxs, freeTransactions...)
 
+	// fromTxIndex - Here we start from the 0 index. This will be the same for a validator.
 	successfulTxs, excludedTxs, txReceipts, err := executor.processTransactions(batch, 0, transactionsToProcess, stateDB, context.ChainConfig, false)
 	if err != nil {
 		return nil, fmt.Errorf("could not process transactions. Cause: %w", err)
 	}
 
+	// fromTxIndex - Here we start from the len of the successful transactions; As long as we have the exact same successful transactions in a batch,
+	// we will start from the same place.
 	ccSuccessfulTxs, _, ccReceipts, err := executor.processTransactions(batch, len(successfulTxs), syntheticTransactions, stateDB, context.ChainConfig, true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Why this change is needed

The mix digest ends up being different between the sequencer and the validator as the sequencer treats the context differently due to the excluded transactions that have mutated it. This brings them back to acting identically.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


