### PR TITLE
Deploy scripts: enable debug api on upgrades

### DIFF
--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -171,6 +171,7 @@ jobs:
               -host_p2p_port=10000 \
               -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
               -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
+              -is_debug_namespace_enabled=true \
               -log_level=${{ github.event.inputs.log_level }} \
               -batch_interval=${{ vars.L2_BATCH_INTERVAL }} \
               -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \


### PR DESCRIPTION
### Why this change is needed

Flag is set on deployment to true but needs to be set on upgrade as well.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


