### PR TITLE
Adjusts gateway VM deployment to use static ip address.

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and Push Docker Image
         run: |
-          DOCKER_BUILDKIT=1 docker build --build-arg TESTNET_TYPE=${{ github.event.inputs.testnet_type }} -t ${{ vars.DOCKER_BUILD_TAG_GATEWAY }} -f ./tools/walletextension/Dockerfile . 
+          DOCKER_BUILDKIT=1 docker build --build-arg TESTNET_TYPE=${{ github.event.inputs.testnet_type }} -t ${{ vars.DOCKER_BUILD_TAG_GATEWAY }} -f ./tools/walletextension/Dockerfile .
           docker push ${{ vars.DOCKER_BUILD_TAG_GATEWAY }}
 
       # This will fail some deletions due to resource dependencies ( ie. you must first delete the vm before deleting the disk)
@@ -68,7 +68,21 @@ jobs:
         with:
           inlineScript: |
             $(az resource list --tag ${{ vars.AZURE_DEPLOY_GROUP_GATEWAY }}=true --query '[]."id"' -o tsv | xargs -n1 az resource delete --verbose -g Testnet --ids) || true
-            
+
+      - name: 'Ensure VM Static Public IP Exists'
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az network public-ip show -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-static" || az network public-ip create -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-static" --allocation-method Static --sku Standard
+
+      - name: 'Assign/Update DNS Name for Public IP'
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            existing_dns_name=$(az network public-ip show -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-static" --query dnsSettings.domainNameLabel -o tsv)
+            if [ -z "$existing_dns_name" ]; then
+              az network public-ip update -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-static" --dns-name "obscurogateway-${{ github.event.inputs.testnet_type }}"
+            fi
 
       - name: 'Create VM for Gateway node on Azure'
         uses: azure/CLI@v1
@@ -76,11 +90,11 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscurogateway-${{ github.event.inputs.testnet_type }}" \
+            --public-ip-address "${{ github.event.inputs.testnet_type }}-OG-static" \
             --tags deploygroup=ObscuroGateway-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_GATEWAY }}=true \
             --vnet-name ObscuroGateway-${{ github.event.inputs.testnet_type }}-01VNET --subnet ObscuroGateway-${{ github.event.inputs.testnet_type }}-01Subnet \
             --size 	Standard_D4_v5 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest \
-            --public-ip-sku Basic --authentication-type password
+            --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'
         uses: azure/CLI@v1


### PR DESCRIPTION
### Why this change is needed

We have intermittent issues with the Gateway not being accessible on redeploy from what is believed to be DNS delay from the dynamic IP. Static IPs on the VM will solve this.

Note: originally I had planned to introduce a LoadBalancer, but decided against as the backend pools will balance as well and  the static IPs will be more cost effective. (however this will be deprecated when migration to terraform is in place as the below workflow doesn't accommodate multiple instances / horizontal scaled gateways.

### What changes were made as part of this PR

- check/create a static ip for use
- assigns the vm the existing ip

### PR checks pre-merging

**N/A for workflow** 


