### PR TITLE
Contract deployers: configure signer for address publishing (#1676)

### DIFF
--- a/contracts/deployment_scripts/messenger/layer1/001_deploy_cross_chain_messenger.ts
+++ b/contracts/deployment_scripts/messenger/layer1/001_deploy_cross_chain_messenger.ts
@@ -36,12 +36,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     // get management contract and write the cross chain messenger address to it
     const mgmtContract = (await hre.ethers.getContractFactory('ManagementContract')).attach(mgmtContractAddress)
-    const tx = await mgmtContract.SetImportantContractAddress("L1CrossChainMessenger", crossChainDeployment.address);
-    const receipt = await tx.wait();
-    if (receipt.status !== 1) {
-        console.log("Failed to set L1CrossChainMessenger in management contract");
+    const tx = await mgmtContract.populateTransaction.SetImportantContractAddress("L1CrossChainMessenger", crossChainDeployment.address);
+    const receipt = await hre.companionNetworks.layer1.deployments.rawTx({
+        from: deployer,
+        to: mgmtContractAddress,
+        data: tx.data,
+        log: true,
+        waitConfirmations: 1,
+    });
+    if (receipt.events?.length === 0) {
+        console.log(`Failed to set L1CrossChainMessenger=${crossChainDeployment.address} on management contract.`);
+    } else {
+        console.log(`L1CrossChainMessenger=${crossChainDeployment.address}`);
     }
-    console.log(`L1CrossChainMessenger=${crossChainDeployment.address}`);
 };
 
 export default func;

--- a/contracts/deployment_scripts/messenger/layer2/001_deploy_cross_chain_messenger.ts
+++ b/contracts/deployment_scripts/messenger/layer2/001_deploy_cross_chain_messenger.ts
@@ -19,6 +19,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     // Get the prefunded L2 deployer account to use for deploying.
     const {deployer} = await getNamedAccounts();
+    const l1Accounts = await companionNetworks.layer1.getNamedAccounts();
 
     console.log(`Script: 001_deploy_cross_chain_messenger.ts - address used: ${deployer}`);
 
@@ -40,12 +41,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     });
     // get L1 management contract and write the cross chain messenger address to it
     const mgmtContract = (await hre.ethers.getContractFactory('ManagementContract')).attach(mgmtContractAddress);
-    const tx = await mgmtContract.SetImportantContractAddress("L2CrossChainMessenger", crossChainDeployment.address);
-    const receipt = await tx.wait();
-    if (receipt.status !== 1) {
-        console.log("Failed to set L2CrossChainMessenger in management contract");
+    const tx = await mgmtContract.populateTransaction.SetImportantContractAddress("L2CrossChainMessenger", crossChainDeployment.address);
+    const receipt = await companionNetworks.layer1.deployments.rawTx({
+        from: l1Accounts.deployer,
+        to: mgmtContractAddress,
+        data: tx.data,
+        log: true,
+        waitConfirmations: 1,
+    });
+    if (receipt.events?.length === 0) {
+        console.log(`Failed to set L2CrossChainMessenger=${crossChainDeployment.address} on management contract.`);
+    } else {
+        console.log(`L2CrossChainMessenger=${crossChainDeployment.address}`);
     }
-    console.log(`L2CrossChainMessenger=${crossChainDeployment.address}`);
 };
 
 export default func;


### PR DESCRIPTION
### Why this change is needed

Port https://github.com/ten-protocol/go-ten/pull/1676 so we have contract addresses available.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


