### PR TITLE
Tenscan: update API domain

### DIFF
--- a/.github/workflows/manual-deploy-ten-scan.yml
+++ b/.github/workflows/manual-deploy-ten-scan.yml
@@ -63,7 +63,7 @@ jobs:
           name: ${{ github.event.inputs.testnet_type }}-fe-ten-scan
           location: "uksouth"
           restart-policy: "Never"
-          environment-variables: NEXT_PUBLIC_API_HOST=https://${{ github.event.inputs.testnet_type }}-api.obscuroscan.io NEXT_PUBLIC_FE_VERSION=${{ GITHUB.RUN_NUMBER }}-${{ GITHUB.SHA }}
+          environment-variables: NEXT_PUBLIC_API_HOST=https://${{ github.event.inputs.testnet_type }}-api.tenscan.io NEXT_PUBLIC_FE_VERSION=${{ GITHUB.RUN_NUMBER }}-${{ GITHUB.SHA }}
           command-line: npm run start-prod
           ports: "80"
           cpu: 2


### PR DESCRIPTION
### Why this change is needed

Update tenscan frontend to use tenscan.io domain for API service instead of obscuro domain.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


