### PR TITLE
NOTICK Step to close ports to avoid lingering process bound to ports

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,10 +31,6 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
-          lowest_port=8000
-          highest_port=58000
-          additional_ports=(80 81 99)
-
           pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
           if [ -z "$pids" ]; then
             echo "No processes are listening on ports from $lowest_port to $highest_port"
@@ -60,6 +56,11 @@ jobs:
               done
             fi
           done
+        shell: bash
+        env:
+          lowest_port: 8000
+          highest_port: 58000
+          additional_ports: '80 81 99'
 
       - name: Test
         run: go test --failfast -v ./... -count=1 -timeout 5m

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -44,7 +44,7 @@ jobs:
             done
             for pid in $pids; do
               echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-              kill -9 $pid || true
+              kill $pid || true
             done
           fi
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,17 +31,15 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
-          lowest_port=8000  # Lowest starting port
-          highest_port=58000 # Highest port considering the offset
-          additional_ports=(80 81 99)  # Additional specific ports
+          lowest_port=8000
+          highest_port=58000
+          additional_ports=(80 81 99)
 
-          # Find processes listening on ports within the range and kill them
           for pid in $(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t); do
             echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-            kill $pid || true
+            kill -9 $pid || true
           done
 
-          # Close additional specific ports
           for port in "${additional_ports[@]}"; do
             for pid in $(lsof -ti TCP:$port); do
               echo "Killing process $pid on port $port"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,11 +28,16 @@ jobs:
       - name: Download eth2network binaries
         run: go test ./... -v -count=1 -run TestEnsureBinariesAreAvail
 
-      # Close specified ports using lsof before testing / local port list compiled from ./testnet/launcher/docker.go
-      - name: Close Ports
+      # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
+      - name: Close Integration Test Ports
         run: |
-          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000 52300; do
-            kill $(lsof -t -i :$port) || true
+          lowest_port=10000  # Lowest starting port
+          highest_port=58000 # Highest port considering the offset
+
+          # Find processes listening on ports within the range and kill them
+          for pid in $(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t); do
+            echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
+            kill $pid || true
           done
 
       - name: Test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Download eth2network binaries
         run: go test ./... -v -count=1 -run TestEnsureBinariesAreAvail
 
-      # Close processes on all ports
-      - name: Close All Ports
+      # Close specified ports using lsof before testing / local port list compiled from ./testnet/launcher/docker.go
+      - name: Close Ports
         run: |
-          for port in $(seq 1 65535); do
+          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000; do
             kill $(lsof -t -i :$port) || true
           done
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -30,37 +30,7 @@ jobs:
 
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
-        run: |
-          pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
-          if [ -z "$pids" ]; then
-            echo "No processes are listening on ports from $lowest_port to $highest_port"
-          else
-            for pid in $pids; do
-              echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
-            done
-            for pid in $pids; do
-              echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-              kill $pid || true
-            done
-          fi
-
-          echo "Additional ports: ${additional_ports[@]}"
-          for port in "${additional_ports[@]}"; do
-            pids=$(lsof -ti TCP:$port)
-            if [ -z "$pids" ]; then
-              echo "No processes are listening on port $port"
-            else
-              for pid in $pids; do
-                echo "Killing process $pid on port $port"
-                kill $pid || true
-              done
-            fi
-          done
-        shell: bash
-        env:
-          lowest_port: 8000
-          highest_port: 58000
-          additional_ports: '80 81 99'
+        run: ./.github/workflows/runner-scripts/close-ports.sh
 
       - name: Test
         run: go test --failfast -v ./... -count=1 -timeout 5m

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Download eth2network binaries
         run: go test ./... -v -count=1 -run TestEnsureBinariesAreAvail
 
+      # Close specified ports using lsof before testing / local port list compiled from ./testnet/launcher/docker.go
+      - name: Close Ports
+        run: |
+          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000; do
+            kill $(lsof -t -i :$port) || true
+          done
+
       - name: Test
         run: go test --failfast -v ./... -count=1 -timeout 5m
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Download eth2network binaries
         run: go test ./... -v -count=1 -run TestEnsureBinariesAreAvail
 
-      # Close specified ports using lsof before testing / local port list compiled from ./testnet/launcher/docker.go
-      - name: Close Ports
+      # Close processes on all ports
+      - name: Close All Ports
         run: |
-          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000; do
+          for port in $(seq 1 65535); do
             kill $(lsof -t -i :$port) || true
           done
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -35,16 +35,30 @@ jobs:
           highest_port=58000
           additional_ports=(80 81 99)
 
-          for pid in $(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t); do
-            echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-            kill -9 $pid || true
-          done
-
-          for port in "${additional_ports[@]}"; do
-            for pid in $(lsof -ti TCP:$port); do
-              echo "Killing process $pid on port $port"
-              kill $pid || true
+          pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+          if [ -z "$pids" ]; then
+            echo "No processes are listening on ports from $lowest_port to $highest_port"
+          else
+            for pid in $pids; do
+              echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
             done
+            for pid in $pids; do
+              echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
+              kill -9 $pid || true
+            done
+          fi
+
+          echo "Additional ports: ${additional_ports[@]}"
+          for port in "${additional_ports[@]}"; do
+            pids=$(lsof -ti TCP:$port)
+            if [ -z "$pids" ]; then
+              echo "No processes are listening on port $port"
+            else
+              for pid in $pids; do
+                echo "Killing process $pid on port $port"
+                kill $pid || true
+              done
+            fi
           done
 
       - name: Test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,13 +31,22 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
-          lowest_port=10000  # Lowest starting port
+          lowest_port=8000  # Lowest starting port
           highest_port=58000 # Highest port considering the offset
+          additional_ports=(80 81 99)  # Additional specific ports
 
           # Find processes listening on ports within the range and kill them
           for pid in $(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t); do
             echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
             kill $pid || true
+          done
+
+          # Close additional specific ports
+          for port in "${additional_ports[@]}"; do
+            for pid in $(lsof -ti TCP:$port); do
+              echo "Killing process $pid on port $port"
+              kill $pid || true
+            done
           done
 
       - name: Test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,7 +31,7 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./testnet/launcher/docker.go
       - name: Close Ports
         run: |
-          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000; do
+          for port in 11000 80 81 15000 11010 13010 13011 15010 99 3000 3001 8025 9000 52300; do
             kill $(lsof -t -i :$port) || true
           done
 

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -3,11 +3,16 @@
 # Ensure any fail is loud
 set -euo pipefail
 
+echo "start script and set ports vars"
+
 lowest_port=8000
 highest_port=58000
 additional_ports=(80 81 99)
 
+echo "fetch pids"
 pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+
+echo "list pids $pids and process range first"
 if [ -z "$pids" ]; then
   echo "No processes are listening on ports from $lowest_port to $highest_port"
 else
@@ -16,10 +21,10 @@ else
   done
   for pid in $pids; do
     echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-    kill -9 $pid || true
+    kill $pid || true
   done
 fi
-
+echo "range done"
 echo "Additional ports: ${additional_ports[@]}"
 for port in "${additional_ports[@]}"; do
   pids=$(lsof -ti TCP:$port)

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -3,37 +3,62 @@
 # Ensure any fail is loud
 set -euo pipefail
 
+# Function to check if a command exists
+command_exists() {
+    type "$1" &> /dev/null
+}
+
 echo "start script and set ports vars"
 
 lowest_port=8000
 highest_port=58000
 additional_ports=(80 81 99)
 
+# Check if lsof command exists
+if ! command_exists lsof; then
+    echo "Error: lsof command not found. Please install lsof."
+    exit 1
+fi
+
 echo "fetch pids"
-pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+# Use || true to prevent script exit in case of command failure
+pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t) || true
+
+# Check if the lsof command was successful
+if [ -z "$pids" ] && [ $? -ne 0 ]; then
+    echo "lsof command failed. Check if you have the necessary permissions."
+    exit 1
+fi
 
 echo "list pids $pids and process range first"
 if [ -z "$pids" ]; then
-  echo "No processes are listening on ports from $lowest_port to $highest_port"
+    echo "No processes are listening on ports from $lowest_port to $highest_port"
 else
-  for pid in $pids; do
-    echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
-  done
-  for pid in $pids; do
-    echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-    kill $pid || true
-  done
+    for pid in $pids; do
+        echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
+    done
+    for pid in $pids; do
+        echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
+        kill $pid || echo "Failed to kill process $pid"
+    done
 fi
 echo "range done"
 echo "Additional ports: ${additional_ports[@]}"
 for port in "${additional_ports[@]}"; do
-  pids=$(lsof -ti TCP:$port)
-  if [ -z "$pids" ]; then
-    echo "No processes are listening on port $port"
-  else
-    for pid in $pids; do
-      echo "Killing process $pid on port $port"
-      kill $pid || true
-    done
-  fi
+    pids=$(lsof -ti TCP:$port) || true
+
+    # Check if the lsof command was successful
+    if [ -z "$pids" ] && [ $? -ne 0 ]; then
+        echo "lsof command failed for port $port. Check if you have the necessary permissions."
+        continue
+    fi
+
+    if [ -z "$pids" ]; then
+        echo "No processes are listening on port $port"
+    else
+        for pid in $pids; do
+            echo "Killing process $pid on port $port"
+            kill $pid || echo "Failed to kill process $pid"
+        done
+    fi
 done

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -23,7 +23,7 @@ fi
 echo "fetch pids"
 # Use || true to prevent script exit in case of command failure
 echo "cmd: lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t"
-pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+pids=$(sudo lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
 
 # Check if the lsof command was successful
 if [ -z "$pids" ] && [ $? -ne 0 ]; then
@@ -40,14 +40,14 @@ else
     done
     for pid in $pids; do
         echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-        kill $pid || echo "Failed to kill process $pid"
+        sudo kill $pid || echo "Failed to kill process $pid"
     done
 fi
 echo "range done"
 echo "Additional ports: ${additional_ports[@]}"
 for port in "${additional_ports[@]}"; do
     echo "cmd: lsof -ti TCP:$port"
-    pids=$(lsof -ti TCP:$port)
+    pids=$(sudo lsof -ti TCP:$port)
 
     # Check if the lsof command was successful
     if [ -z "$pids" ] && [ $? -ne 0 ]; then
@@ -60,7 +60,7 @@ for port in "${additional_ports[@]}"; do
     else
         for pid in $pids; do
             echo "Killing process $pid on port $port"
-            kill $pid || echo "Failed to kill process $pid"
+            sudo kill $pid || echo "Failed to kill process $pid"
         done
     fi
 done

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Ensure any fail is loud
+set -euo pipefail
+
+lowest_port=8000
+highest_port=58000
+additional_ports=(80 81 99)
+
+pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+if [ -z "$pids" ]; then
+  echo "No processes are listening on ports from $lowest_port to $highest_port"
+else
+  for pid in $pids; do
+    echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
+  done
+  for pid in $pids; do
+    echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
+    kill -9 $pid || true
+  done
+fi
+
+echo "Additional ports: ${additional_ports[@]}"
+for port in "${additional_ports[@]}"; do
+  pids=$(lsof -ti TCP:$port)
+  if [ -z "$pids" ]; then
+    echo "No processes are listening on port $port"
+  else
+    for pid in $pids; do
+      echo "Killing process $pid on port $port"
+      kill $pid || true
+    done
+  fi
+done

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -26,12 +26,13 @@ if [ $lsof_exit_status -eq 0 ]; then
             kill $pid || echo "Failed to kill process $pid"
         done
     fi
+elif [ $lsof_exit_status -eq 1 ]; then # lsof returns 1 if no processes are found
+    echo "No processes found on ports from $lowest_port to $highest_port, which is expected."
 else
     echo "lsof command failed with exit status $lsof_exit_status"
 fi
 echo "range done"
 
-# Similar handling for the additional ports
 echo "Additional ports: ${additional_ports[@]}"
 for port in "${additional_ports[@]}"; do
     pids=$(lsof -ti TCP:$port)
@@ -46,6 +47,8 @@ for port in "${additional_ports[@]}"; do
                 kill $pid || echo "Failed to kill process $pid"
             done
         fi
+    elif [ $lsof_exit_status -eq 1 ]; then # lsof returns 1 if no processes are found
+        echo "No processes found on port $port, which is expected."
     else
         echo "lsof command for port $port failed with exit status $lsof_exit_status"
     fi

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
-# Ensure any fail is loud
-set -euo pipefail
-
-# Function to check if a command exists
-command_exists() {
-    type "$1" &> /dev/null
-}
+# Ensure unset variables cause an exit and that a pipeline fails if any command fails
+set -uo pipefail
 
 echo "start script and set ports vars"
 
@@ -14,53 +9,44 @@ lowest_port=8000
 highest_port=58000
 additional_ports=(80 81 99)
 
-# Check if lsof command exists
-if ! command_exists lsof; then
-    echo "Error: lsof command not found. Please install lsof."
-    exit 1
-fi
-
 echo "fetch pids"
-# Use || true to prevent script exit in case of command failure
-echo "cmd: lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t"
-pids=$(sudo lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
-
-# Check if the lsof command was successful
-if [ -z "$pids" ] && [ $? -ne 0 ]; then
-    echo "lsof command failed. Check if you have the necessary permissions."
-    exit 1
-fi
+pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
+lsof_exit_status=$?
 
 echo "list pids $pids and process range first"
-if [ -z "$pids" ]; then
-    echo "No processes are listening on ports from $lowest_port to $highest_port"
-else
-    for pid in $pids; do
-        echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
-    done
-    for pid in $pids; do
-        echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
-        sudo kill $pid || echo "Failed to kill process $pid"
-    done
-fi
-echo "range done"
-echo "Additional ports: ${additional_ports[@]}"
-for port in "${additional_ports[@]}"; do
-    echo "cmd: lsof -ti TCP:$port"
-    pids=$(sudo lsof -ti TCP:$port)
-
-    # Check if the lsof command was successful
-    if [ -z "$pids" ] && [ $? -ne 0 ]; then
-        echo "lsof command failed for port $port. Check if you have the necessary permissions."
-        continue
-    fi
-
+if [ $lsof_exit_status -eq 0 ]; then
     if [ -z "$pids" ]; then
-        echo "No processes are listening on port $port"
+        echo "No processes are listening on ports from $lowest_port to $highest_port"
     else
         for pid in $pids; do
-            echo "Killing process $pid on port $port"
-            sudo kill $pid || echo "Failed to kill process $pid"
+            echo "Process $pid is listening on one of the ports from $lowest_port to $highest_port"
         done
+        for pid in $pids; do
+            echo "Killing process $pid on one of the ports from $lowest_port to $highest_port"
+            kill $pid || echo "Failed to kill process $pid"
+        done
+    fi
+else
+    echo "lsof command failed with exit status $lsof_exit_status"
+fi
+echo "range done"
+
+# Similar handling for the additional ports
+echo "Additional ports: ${additional_ports[@]}"
+for port in "${additional_ports[@]}"; do
+    pids=$(lsof -ti TCP:$port)
+    lsof_exit_status=$?
+
+    if [ $lsof_exit_status -eq 0 ]; then
+        if [ -z "$pids" ]; then
+            echo "No processes are listening on port $port"
+        else
+            for pid in $pids; do
+                echo "Killing process $pid on port $port"
+                kill $pid || echo "Failed to kill process $pid"
+            done
+        fi
+    else
+        echo "lsof command for port $port failed with exit status $lsof_exit_status"
     fi
 done

--- a/.github/workflows/runner-scripts/close-ports.sh
+++ b/.github/workflows/runner-scripts/close-ports.sh
@@ -22,7 +22,8 @@ fi
 
 echo "fetch pids"
 # Use || true to prevent script exit in case of command failure
-pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t) || true
+echo "cmd: lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t"
+pids=$(lsof -iTCP:$lowest_port-$highest_port -sTCP:LISTEN -t)
 
 # Check if the lsof command was successful
 if [ -z "$pids" ] && [ $? -ne 0 ]; then
@@ -45,7 +46,8 @@ fi
 echo "range done"
 echo "Additional ports: ${additional_ports[@]}"
 for port in "${additional_ports[@]}"; do
-    pids=$(lsof -ti TCP:$port) || true
+    echo "cmd: lsof -ti TCP:$port"
+    pids=$(lsof -ti TCP:$port)
 
     # Check if the lsof command was successful
     if [ -z "$pids" ] && [ $? -ne 0 ]; then


### PR DESCRIPTION
### Why this change is needed

Some `go Test` iterations failing intermittently when a prior test on the agent fails, and processes remain bound to ports. This adds a Close ports step to the workflow

### What changes were made as part of this PR

- add step that closes ports prior to testing.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


