### PR TITLE
more flakyness fixes

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,9 +31,9 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
-          killall -9 geth-v1.12.2 
-          killall -9 beacon-chain-v4.0.6 
-          killall -9 validator-v4.0.6 
+          killall -9 geth-v1.12.2 || true
+          killall -9 beacon-chain-v4.0.6 || true
+          killall -9 validator-v4.0.6 || true
           
           lowest_port=8000  # Lowest starting port
           highest_port=58000 # Highest port considering the offset

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,6 +31,10 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
+          killall -9 geth-v1.12.2 
+          killall -9 beacon-chain-v4.0.6 
+          killall -9 validator-v4.0.6 
+          
           lowest_port=8000  # Lowest starting port
           highest_port=58000 # Highest port considering the offset
           additional_ports=(80 81 99)  # Additional specific ports

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -243,6 +243,7 @@ func (n *Impl) Start() error {
 			if err != nil {
 				panic(err)
 			}
+			time.Sleep(time.Second)
 		}()
 	}
 

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -326,25 +326,16 @@ func (n *Impl) Start() error {
 // Stop stops the network
 func (n *Impl) Stop() error {
 	for i := 0; i < len(n.dataDirs); i++ {
-		err := kill(n.gethProcesses[i].Process)
-		if err != nil {
-			fmt.Printf("unable to kill geth node - %s\n", err.Error())
-		}
-		err = kill(n.prysmBeaconProcesses[i].Process)
-		if err != nil {
-			fmt.Printf("unable to kill prysm beacon node - %s\n", err.Error())
-		}
-		err = kill(n.prysmValidatorProcesses[i].Process)
-		if err != nil {
-			fmt.Printf("unable to kill prysm validator node - %s\n", err.Error())
-		}
+		kill(n.gethProcesses[i].Process)
+		kill(n.prysmBeaconProcesses[i].Process)
+		kill(n.prysmValidatorProcesses[i].Process)
 	}
 	// wait a second for the kill signal
 	time.Sleep(time.Second)
 	return nil
 }
 
-func kill(p *os.Process) error {
+func kill(p *os.Process) {
 	killErr := p.Kill()
 	if killErr != nil {
 		fmt.Printf("Error killing process %s", killErr)
@@ -354,7 +345,6 @@ func kill(p *os.Process) error {
 	if err != nil {
 		fmt.Printf("Error releasing process %s", err)
 	}
-	return nil
 }
 
 // GethGenesis returns the Genesis used in geth to boot up the network

--- a/integration/eth2network/eth2_network.go
+++ b/integration/eth2network/eth2_network.go
@@ -540,7 +540,7 @@ func (n *Impl) waitForNodeUp(nodeID int, timeout time.Duration) error {
 			return nil
 		}
 	}
-	fmt.Printf("Geth node error:\n%s", n.gethProcesses[nodeID].Stderr)
+	fmt.Printf("Geth node error:\n%s\n", n.gethProcesses[nodeID].Stderr)
 	return fmt.Errorf("node not responsive after %s", timeout)
 }
 

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -31,18 +31,18 @@ const (
 func SetUpGethNetwork(wallets *params.SimWallets, startPort int, nrNodes int, blockDurationSeconds int) (*params.L1SetupData, []ethadapter.EthClient, eth2network.Eth2Network) {
 	eth2Network, err := StartGethNetwork(wallets, startPort, blockDurationSeconds)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("error starting geth network %w", err))
 	}
 
 	// connect to the first host to deploy
 	tmpEthClient, err := ethadapter.NewEthClient(Localhost, uint(startPort+100), DefaultL1RPCTimeout, common.HexToAddress("0x0"), testlog.Logger())
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("error connecting to te first host %w", err))
 	}
 
 	l1Data, err := DeployObscuroNetworkContracts(tmpEthClient, wallets, true)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("error deploying obscuro contract %w", err))
 	}
 
 	ethClients := make([]ethadapter.EthClient, nrNodes)

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -120,7 +120,8 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, _ *stats.Stat
 			if errCheck != nil {
 				testlog.Logger().Warn("no port found on error", log.ErrKey, err)
 			}
-			testlog.Logger().Crit("unable to start obscuro node ", log.ErrKey, err)
+			fmt.Printf("unable to start obscuro node: %s", err)
+			testlog.Logger().Error("unable to start obscuro node ", log.ErrKey, err)
 		}
 	}
 


### PR DESCRIPTION
### Why this change is needed

to make our tests more stable

### What changes were made as part of this PR

- use microseconds instead of millis to reduce the chance of a folder collision
- "Release" the os.Process for the ethereum node

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


