### PR TITLE
adjust port offset

### DIFF
--- a/integration/constants.go
+++ b/integration/constants.go
@@ -25,9 +25,9 @@ const (
 	DefaultEnclaveOffset            = 700 // The default offset between a Geth nodes port and the enclave ports. Used in Socket Simulations.
 	DefaultHostRPCHTTPOffset        = 800 // The default offset for the host's RPC HTTP port
 	DefaultHostRPCWSOffset          = 900 // The default offset for the host's RPC websocket port
-	DefaultTenscanHTTPPortOffset    = 1000
-	DefaultTenGatewayHTTPPortOffset = 1001
-	DefaultTenGatewayWSPortOffset   = 1002
+	DefaultTenscanHTTPPortOffset    = 950
+	DefaultTenGatewayHTTPPortOffset = 951
+	DefaultTenGatewayWSPortOffset   = 952
 )
 
 const (


### PR DESCRIPTION
### Why this change is needed

ports were colliding because the offsets were higher than the main increment


