### PR TITLE
cache fixes for e2e tests

### DIFF
--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -25,15 +25,15 @@ var cacheableRPCMethods = map[string]time.Duration{
 	"eth_chainId":              longCacheTTL,
 
 	// Ethereum JSON-RPC methods that can be cached short time
-	"eth_blockNumber":           shortCacheTTL,
-	"eth_getCode":               shortCacheTTL,
-	"eth_getBalance":            shortCacheTTL,
+	"eth_blockNumber": shortCacheTTL,
+	"eth_getCode":     shortCacheTTL,
+	// "eth_getBalance":            shortCacheTTL,// excluded for test: gen_cor_059
 	"eth_getTransactionReceipt": shortCacheTTL,
 	"eth_call":                  shortCacheTTL,
 	"eth_gasPrice":              shortCacheTTL,
-	"eth_getTransactionCount":   shortCacheTTL,
-	"eth_estimateGas":           shortCacheTTL,
-	"eth_feeHistory":            shortCacheTTL,
+	// "eth_getTransactionCount": shortCacheTTL, // excluded for test: gen_cor_009
+	"eth_estimateGas": shortCacheTTL,
+	"eth_feeHistory":  shortCacheTTL,
 }
 
 type Cache interface {

--- a/tools/walletextension/cache/cache_test.go
+++ b/tools/walletextension/cache/cache_test.go
@@ -67,7 +67,7 @@ func testNonCacheableMethods(t *testing.T) {
 
 // testMethodsWithLatestOrPendingParameter tests if the methods with latest or pending parameter are cacheable
 func testMethodsWithLatestOrPendingParameter(t *testing.T) {
-	methods := []string{"eth_getCode", "eth_getBalance", "eth_getTransactionCount", "eth_estimateGas", "eth_call"}
+	methods := []string{"eth_getCode", "eth_estimateGas", "eth_call"}
 	for _, method := range methods {
 		key := &common.RPCRequest{Method: method, Params: []interface{}{"0x123", "latest"}}
 		_, _, ttl := IsCacheable(key)
@@ -110,7 +110,7 @@ func testResultsAreCached(cache Cache, t *testing.T) {
 
 // testCacheTTL tests if the cache TTL is working as expected
 func testCacheTTL(cache Cache, t *testing.T) {
-	req := &common.RPCRequest{Method: "eth_getBalance", Params: []interface{}{"0x123"}}
+	req := &common.RPCRequest{Method: "eth_blockNumber", Params: []interface{}{"0x123"}}
 	res := map[string]interface{}{"result": "100"}
 	isCacheable, key, ttl := IsCacheable(req)
 

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -99,7 +99,6 @@ func (w *WalletExtension) Logger() gethlog.Logger {
 
 // ProxyEthRequest proxys an incoming user request to the enclave
 func (w *WalletExtension) ProxyEthRequest(request *common.RPCRequest, conn userconn.UserConn, hexUserID string) (map[string]interface{}, error) {
-
 	response := map[string]interface{}{}
 	// all responses must contain the request id. Both successful and unsuccessful.
 	response[common.JSONKeyRPCVersion] = jsonrpc.Version

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -99,6 +99,12 @@ func (w *WalletExtension) Logger() gethlog.Logger {
 
 // ProxyEthRequest proxys an incoming user request to the enclave
 func (w *WalletExtension) ProxyEthRequest(request *common.RPCRequest, conn userconn.UserConn, hexUserID string) (map[string]interface{}, error) {
+
+	response := map[string]interface{}{}
+	// all responses must contain the request id. Both successful and unsuccessful.
+	response[common.JSONKeyRPCVersion] = jsonrpc.Version
+	response[common.JSONKeyID] = request.ID
+
 	// start measuring time for request
 	requestStartTime := time.Now()
 
@@ -111,14 +117,11 @@ func (w *WalletExtension) ProxyEthRequest(request *common.RPCRequest, conn userc
 			requestEndTime := time.Now()
 			duration := requestEndTime.Sub(requestStartTime)
 			w.fileLogger.Info(fmt.Sprintf("Request method: %s, request params: %s, encryptionToken of sender: %s, response: %s, duration: %d ", request.Method, request.Params, hexUserID, value, duration.Milliseconds()))
+			// adjust requestID
+			value[common.JSONKeyID] = request.ID
 			return value, nil
 		}
 	}
-
-	response := map[string]interface{}{}
-	// all responses must contain the request id. Both successful and unsuccessful.
-	response[common.JSONKeyRPCVersion] = jsonrpc.Version
-	response[common.JSONKeyID] = request.ID
 
 	// proxyRequest will find the correct client to proxy the request (or try them all if appropriate)
 	var rpcResp interface{}


### PR DESCRIPTION
### Why this change is needed

Some e2e tests were failing because of caching. 

### What changes were made as part of this PR

- Exclude caching of:  "eth_getTransactionCount" and  "eth_getBalance".
- Fix to return the correct request ID

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


