### PR TITLE
NetworkTests: add options for test users to use gateway

### DIFF
--- a/integration/networktest/actions/context.go
+++ b/integration/networktest/actions/context.go
@@ -16,18 +16,18 @@ var KeyNumberOfTestUsers = ActionKey("numberOfTestUsers")
 // ActionKey is the type for all test data stored in the context. Go documentation recommends using a typed key rather than string to avoid conflicts.
 type ActionKey string
 
-func storeTestUser(ctx context.Context, userNumber int, user *userwallet.UserWallet) context.Context {
+func storeTestUser(ctx context.Context, userNumber int, user userwallet.User) context.Context {
 	return context.WithValue(ctx, userKey(userNumber), user)
 }
 
-func FetchTestUser(ctx context.Context, userNumber int) (*userwallet.UserWallet, error) {
+func FetchTestUser(ctx context.Context, userNumber int) (userwallet.User, error) {
 	u := ctx.Value(userKey(userNumber))
 	if u == nil {
-		return nil, fmt.Errorf("no UserWallet found in context for userNumber=%d", userNumber)
+		return nil, fmt.Errorf("no userWallet found in context for userNumber=%d", userNumber)
 	}
-	user, ok := u.(*userwallet.UserWallet)
+	user, ok := u.(userwallet.User)
 	if !ok {
-		return nil, fmt.Errorf("user retrieved from context was not of expected type UserWallet for userNumber=%d type=%T", userNumber, u)
+		return nil, fmt.Errorf("user retrieved from context was not of expected type userWallet for userNumber=%d type=%T", userNumber, u)
 	}
 	return user, nil
 }

--- a/integration/networktest/actions/native_fund_actions.go
+++ b/integration/networktest/actions/native_fund_actions.go
@@ -18,7 +18,7 @@ type SendNativeFunds struct {
 	GasLimit   *big.Int
 	SkipVerify bool
 
-	user   *userwallet.UserWallet
+	user   userwallet.User
 	txHash *common.Hash
 }
 

--- a/integration/networktest/actions/native_fund_actions.go
+++ b/integration/networktest/actions/native_fund_actions.go
@@ -35,7 +35,7 @@ func (s *SendNativeFunds) Run(ctx context.Context, _ networktest.NetworkConnecto
 	if err != nil {
 		return ctx, err
 	}
-	txHash, err := user.SendFunds(ctx, target.Address(), s.Amount)
+	txHash, err := user.SendFunds(ctx, target.Wallet().Address(), s.Amount)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/networktest/actions/node_actions.go
+++ b/integration/networktest/actions/node_actions.go
@@ -141,7 +141,7 @@ func (w *waitForValidatorHealthCheckAction) Run(ctx context.Context, network net
 	validator := network.GetValidatorNode(w.validatorIdx)
 	// poll the health check until success or timeout
 	err := retry.Do(func() error {
-		return networktest.NodeHealthCheck(validator.HostRPCAddress())
+		return networktest.NodeHealthCheck(validator.HostRPCWSAddress())
 	}, retry.NewTimeoutStrategy(w.maxWait, 1*time.Second))
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func WaitForSequencerHealthCheck(maxWait time.Duration) networktest.Action {
 		sequencer := network.GetSequencerNode()
 		// poll the health check until success or timeout
 		err := retry.Do(func() error {
-			return networktest.NodeHealthCheck(sequencer.HostRPCAddress())
+			return networktest.NodeHealthCheck(sequencer.HostRPCWSAddress())
 		}, retry.NewTimeoutStrategy(maxWait, 1*time.Second))
 		if err != nil {
 			return nil, err

--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -30,13 +30,13 @@ func (c *CreateTestUser) Run(ctx context.Context, network networktest.NetworkCon
 		if err != nil {
 			return ctx, fmt.Errorf("failed to get required gateway URL: %w", err)
 		}
-		user, err = userwallet.NewGatewayUser(wal.PrivateKey(), gwURL, logger)
+		user, err = userwallet.NewGatewayUser(wal, gwURL, logger)
 		if err != nil {
 			return ctx, fmt.Errorf("failed to create gateway user: %w", err)
 		}
 	} else {
 		// traffic sim users are round robin-ed onto the validators for now (todo (@matt) - make that overridable)
-		user = userwallet.NewUserWallet(wal.PrivateKey(), network.ValidatorRPCAddress(c.UserID%network.NumValidators()), logger)
+		user = userwallet.NewUserWallet(wal, network.ValidatorRPCAddress(c.UserID%network.NumValidators()), logger)
 	}
 	return storeTestUser(ctx, c.UserID, user), nil
 }
@@ -58,7 +58,7 @@ func (a *AllocateFaucetFunds) Run(ctx context.Context, network networktest.Netwo
 	if err != nil {
 		return ctx, err
 	}
-	return ctx, network.AllocateFaucetFunds(ctx, user.Address())
+	return ctx, network.AllocateFaucetFunds(ctx, user.Wallet().Address())
 }
 
 func (a *AllocateFaucetFunds) Verify(_ context.Context, _ networktest.NetworkConnector) error {

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -11,6 +11,7 @@ func SepoliaTestnet() networktest.Environment {
 		[]string{"http://erpc.sepolia-testnet.ten.xyz:80"},
 		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"https://rpc.sepolia.org/",
+		"https://testnet.ten.xyz", // :81 for websocket
 	)
 	return &testnetEnv{connector}
 }
@@ -21,6 +22,7 @@ func UATTestnet() networktest.Environment {
 		[]string{"http://erpc.uat-testnet.ten.xyz:80"},
 		"http://uat-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://uat-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
+		"https://uat-testnet.ten.xyz",
 	)
 	return &testnetEnv{connector}
 }
@@ -31,6 +33,7 @@ func DevTestnet() networktest.Environment {
 		[]string{"http://erpc.dev-testnet.ten.xyz:80"},
 		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
+		"https://dev-testnet.ten.xyz",
 	)
 	return &testnetEnv{connector}
 }
@@ -42,6 +45,7 @@ func LongRunningLocalNetwork(l1WSURL string) networktest.Environment {
 		[]string{"ws://127.0.0.1:37901"},
 		genesis.TestnetPrefundedPK,
 		l1WSURL,
+		"",
 	)
 	return &testnetEnv{connector}
 }

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -51,10 +51,11 @@ func NewTestnetConnectorWithFaucetAccount(seqRPCAddr string, validatorRPCAddress
 	if err != nil {
 		panic(err)
 	}
+	wal := wallet.NewInMemoryWalletFromPK(big.NewInt(integration.TenChainID), ecdsaKey, testlog.Logger())
 	return &testnetConnector{
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
-		faucetWallet:          userwallet.NewUserWallet(ecdsaKey, validatorRPCAddressses[0], testlog.Logger(), userwallet.WithChainID(big.NewInt(integration.TenChainID))),
+		faucetWallet:          userwallet.NewUserWallet(wal, validatorRPCAddressses[0], testlog.Logger()),
 		l1RPCURL:              l1RPCAddress,
 		tenGatewayURL:         tenGatewayURL,
 	}

--- a/integration/networktest/interfaces.go
+++ b/integration/networktest/interfaces.go
@@ -25,6 +25,7 @@ type NetworkConnector interface {
 	GetValidatorNode(idx int) NodeOperator
 	GetL1Client() (ethadapter.EthClient, error)
 	GetMCOwnerWallet() (wallet.Wallet, error) // wallet that owns the management contract (network admin)
+	GetGatewayURL() (string, error)
 }
 
 // Action is any step in a test, they will typically be either minimally small steps in the test or they will be containers
@@ -62,5 +63,6 @@ type NodeOperator interface {
 	StartHost() error
 	StopHost() error
 
-	HostRPCAddress() string
+	HostRPCHTTPAddress() string
+	HostRPCWSAddress() string
 }

--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -23,7 +23,7 @@ func TestGatewayHappyPath(t *testing.T) {
 	networktest.Run(
 		"gateway-happy-path",
 		t,
-		env.SepoliaTestnet(),
+		env.LocalDevNetwork(env.WithTenGateway()),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0, UseGateway: true},
 			&actions.CreateTestUser{UserID: 1, UseGateway: true},

--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+	"github.com/ten-protocol/go-ten/integration/networktest/env"
+)
+
+var _transferAmount = big.NewInt(100_000_000)
+
+// TestGatewayHappyPath tests ths same functionality as the smoke_test but with the gateway:
+// 1. Create two test users
+// 2. Allocate funds to the first user
+// 3. Send funds from the first user to the second
+// 4. Verify the second user has the funds
+// 5. Verify the first user has the funds deducted
+// To run this test with a local network use the flag to start it with the gateway enabled.
+func TestGatewayHappyPath(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"gateway-happy-path",
+		t,
+		env.SepoliaTestnet(),
+		actions.Series(
+			&actions.CreateTestUser{UserID: 0, UseGateway: true},
+			&actions.CreateTestUser{UserID: 1, UseGateway: true},
+			actions.SetContextValue(actions.KeyNumberOfTestUsers, 2),
+
+			&actions.AllocateFaucetFunds{UserID: 0},
+			actions.SnapshotUserBalances(actions.SnapAfterAllocation), // record user balances (we have no guarantee on how much the network faucet allocates)
+
+			&actions.SendNativeFunds{FromUser: 0, ToUser: 1, Amount: _transferAmount},
+
+			&actions.VerifyBalanceAfterTest{UserID: 1, ExpectedBalance: _transferAmount},
+			&actions.VerifyBalanceDiffAfterTest{UserID: 0, Snapshot: actions.SnapAfterAllocation, ExpectedDiff: big.NewInt(0).Neg(_transferAmount)},
+		),
+	)
+}

--- a/integration/networktest/tests/helpful/availability_test.go
+++ b/integration/networktest/tests/helpful/availability_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
 )
 
-const _testTimeSpan = 120 * time.Second
+const _testTimeSpan = 30 * time.Second
 
 // basic test that verifies it can connect the L1 client and L2 client and sees block numbers increasing (useful to sanity check testnet issues etc.)
 func TestNetworkAvailability(t *testing.T) {
@@ -21,7 +21,7 @@ func TestNetworkAvailability(t *testing.T) {
 	networktest.Run(
 		"network-availability",
 		t,
-		env.DevTestnet(),
+		env.SepoliaTestnet(),
 		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 			client, err := network.GetL1Client()
 			if err != nil {

--- a/integration/networktest/tests/nodescenario/restart_network_test.go
+++ b/integration/networktest/tests/nodescenario/restart_network_test.go
@@ -56,10 +56,6 @@ func TestRestartNetwork(t *testing.T) {
 			// 	This needs investigating but it suggests to me that the health check is succeeding prematurely
 			actions.SleepAction(5*time.Second), // allow time for re-sync
 
-			// resubmit user viewing keys (all users will have lost their "session")
-			// todo: get rid of this once the enclave persists viewing keys correctly
-			actions.AuthenticateAllUsers(),
-
 			// another load test, check that the network is still working
 			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 60*time.Second),
 		),

--- a/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
+++ b/integration/networktest/tests/nodescenario/restart_validator_enclave_test.go
@@ -32,10 +32,6 @@ func TestRestartValidatorEnclave(t *testing.T) {
 			// 	This needs investigating but it suggests to me that the health check is succeeding prematurely
 			actions.SleepAction(5*time.Second), // allow time for re-sync
 
-			// resubmit user viewing keys (any users attached to the restarted node will have lost their "session")
-			// todo (@matt) - get rid of this once the enclave persists viewing keys correctly
-			actions.AuthenticateAllUsers(),
-
 			// another load test (important that at least one of the users will be using the validator with restarted enclave)
 			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 10*time.Second),
 		),

--- a/integration/networktest/tests/nodescenario/restart_validator_test.go
+++ b/integration/networktest/tests/nodescenario/restart_validator_test.go
@@ -38,10 +38,6 @@ func TestRestartValidatorNode(t *testing.T) {
 			// 	This needs investigating but it suggests to me that the health check is succeeding prematurely
 			actions.SleepAction(5*time.Second), // allow time for re-sync
 
-			// resubmit user viewing keys (any users attached to the restarted node will have lost their "session")
-			// todo (@matt) - get rid of this once the enclave persists viewing keys correctly
-			actions.AuthenticateAllUsers(),
-
 			// another load test (important that at least one of the users will be using the validator with restarted enclave)
 			actions.GenerateUsersRandomisedTransferActionsInParallel(4, 10*time.Second),
 		),

--- a/integration/networktest/userwallet/gateway.go
+++ b/integration/networktest/userwallet/gateway.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ten-protocol/go-ten/tools/walletextension/lib"
 )
 
-type gatewayUser struct {
+type GatewayUser struct {
 	privateKey     *ecdsa.PrivateKey
 	publicKey      *ecdsa.PublicKey
 	accountAddress gethcommon.Address
@@ -35,7 +35,7 @@ type gatewayUser struct {
 	logger gethlog.Logger
 }
 
-func NewGatewayUser(pk *ecdsa.PrivateKey, gatewayURL string, logger gethlog.Logger) (*gatewayUser, error) {
+func NewGatewayUser(pk *ecdsa.PrivateKey, gatewayURL string, logger gethlog.Logger) (*GatewayUser, error) {
 	publicKeyECDSA, ok := pk.Public().(*ecdsa.PublicKey)
 	if !ok {
 		// this shouldn't happen
@@ -60,7 +60,7 @@ func NewGatewayUser(pk *ecdsa.PrivateKey, gatewayURL string, logger gethlog.Logg
 
 	fmt.Printf("Registered acc with TenGateway: %s (%s)\n", crypto.PubkeyToAddress(*publicKeyECDSA).Hex(), gwLib.HTTP())
 
-	wal := &gatewayUser{
+	wal := &GatewayUser{
 		privateKey:     pk,
 		publicKey:      publicKeyECDSA,
 		accountAddress: crypto.PubkeyToAddress(*publicKeyECDSA),
@@ -73,7 +73,7 @@ func NewGatewayUser(pk *ecdsa.PrivateKey, gatewayURL string, logger gethlog.Logg
 	return wal, nil
 }
 
-func (g *gatewayUser) SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error) {
+func (g *GatewayUser) SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error) {
 	txData := &types.LegacyTx{
 		Nonce: g.nonce,
 		Value: value,
@@ -101,10 +101,12 @@ func (g *gatewayUser) SendFunds(ctx context.Context, addr gethcommon.Address, va
 		return nil, fmt.Errorf("unable to send transaction - %w", err)
 	}
 	txHash := signedTx.Hash()
+	// transaction has been sent, we increment the nonce
+	g.nonce++
 	return &txHash, nil
 }
 
-func (g *gatewayUser) AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error) {
+func (g *GatewayUser) AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error) {
 	var receipt *types.Receipt
 	var err error
 	err = retry.Do(func() error {
@@ -120,38 +122,38 @@ func (g *gatewayUser) AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash)
 	return receipt, nil
 }
 
-func (g *gatewayUser) NativeBalance(ctx context.Context) (*big.Int, error) {
+func (g *GatewayUser) NativeBalance(ctx context.Context) (*big.Int, error) {
 	return g.client.BalanceAt(ctx, g.accountAddress, nil)
 }
 
-func (g *gatewayUser) Address() gethcommon.Address {
+func (g *GatewayUser) Address() gethcommon.Address {
 	return g.accountAddress
 }
 
-func (g *gatewayUser) SignTransaction(tx types.TxData) (*types.Transaction, error) {
+func (g *GatewayUser) SignTransaction(tx types.TxData) (*types.Transaction, error) {
 	return g.SignTransactionForChainID(tx, g.chainID)
 }
 
-func (g *gatewayUser) SignTransactionForChainID(tx types.TxData, chainID *big.Int) (*types.Transaction, error) {
+func (g *GatewayUser) SignTransactionForChainID(tx types.TxData, chainID *big.Int) (*types.Transaction, error) {
 	return types.SignNewTx(g.privateKey, types.NewLondonSigner(chainID), tx)
 }
 
-func (g *gatewayUser) SetNonce(nonce uint64) {
-	panic("gatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
+func (g *GatewayUser) SetNonce(nonce uint64) {
+	panic("GatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
 }
 
-func (g *gatewayUser) GetNonceAndIncrement() uint64 {
-	panic("gatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
+func (g *GatewayUser) GetNonceAndIncrement() uint64 {
+	panic("GatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
 }
 
-func (g *gatewayUser) GetNonce() uint64 {
+func (g *GatewayUser) GetNonce() uint64 {
 	return g.nonce
 }
 
-func (g *gatewayUser) ChainID() *big.Int {
+func (g *GatewayUser) ChainID() *big.Int {
 	return g.chainID
 }
 
-func (g *gatewayUser) PrivateKey() *ecdsa.PrivateKey {
+func (g *GatewayUser) PrivateKey() *ecdsa.PrivateKey {
 	return g.privateKey
 }

--- a/integration/networktest/userwallet/gateway.go
+++ b/integration/networktest/userwallet/gateway.go
@@ -138,7 +138,7 @@ func (g *GatewayUser) SignTransactionForChainID(tx types.TxData, chainID *big.In
 	return types.SignNewTx(g.privateKey, types.NewLondonSigner(chainID), tx)
 }
 
-func (g *GatewayUser) SetNonce(nonce uint64) {
+func (g *GatewayUser) SetNonce(_ uint64) {
 	panic("GatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
 }
 

--- a/integration/networktest/userwallet/gateway.go
+++ b/integration/networktest/userwallet/gateway.go
@@ -1,0 +1,157 @@
+package userwallet
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/ten-protocol/go-ten/go/common/retry"
+	"github.com/ten-protocol/go-ten/go/rpc"
+	"github.com/ten-protocol/go-ten/integration"
+	"github.com/ten-protocol/go-ten/tools/walletextension/lib"
+)
+
+type gatewayUser struct {
+	privateKey     *ecdsa.PrivateKey
+	publicKey      *ecdsa.PublicKey
+	accountAddress gethcommon.Address
+	chainID        *big.Int
+
+	gwLib  *lib.TGLib // TenGateway utility
+	client *ethclient.Client
+
+	// state managed by the wallet
+	nonce uint64
+
+	logger gethlog.Logger
+}
+
+func NewGatewayUser(pk *ecdsa.PrivateKey, gatewayURL string, logger gethlog.Logger) (*gatewayUser, error) {
+	publicKeyECDSA, ok := pk.Public().(*ecdsa.PublicKey)
+	if !ok {
+		// this shouldn't happen
+		logger.Crit("error casting public key to ECDSA")
+	}
+
+	gwLib := lib.NewTenGatewayLibrary(gatewayURL, "") // not providing wsURL for now, add if we need it
+
+	err := gwLib.Join()
+	if err != nil {
+		return nil, fmt.Errorf("failed to join TenGateway: %w", err)
+	}
+	err = gwLib.RegisterAccount(pk, crypto.PubkeyToAddress(*publicKeyECDSA))
+	if err != nil {
+		return nil, fmt.Errorf("failed to register account with TenGateway: %w", err)
+	}
+
+	client, err := ethclient.Dial(gwLib.HTTP())
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial TenGateway HTTP: %w", err)
+	}
+
+	fmt.Printf("Registered acc with TenGateway: %s (%s)\n", crypto.PubkeyToAddress(*publicKeyECDSA).Hex(), gwLib.HTTP())
+
+	wal := &gatewayUser{
+		privateKey:     pk,
+		publicKey:      publicKeyECDSA,
+		accountAddress: crypto.PubkeyToAddress(*publicKeyECDSA),
+		chainID:        big.NewInt(integration.TenChainID),
+		gwLib:          gwLib,
+		client:         client,
+		logger:         logger,
+	}
+
+	return wal, nil
+}
+
+func (g *gatewayUser) SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error) {
+	txData := &types.LegacyTx{
+		Nonce: g.nonce,
+		Value: value,
+		To:    &addr,
+	}
+	gasPrice, err := g.client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to suggest gas price - %w", err)
+	}
+	txData.GasPrice = gasPrice
+	gasLimit, err := g.client.EstimateGas(ctx, ethereum.CallMsg{
+		From: g.accountAddress,
+		To:   &addr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to estimate gas - %w", err)
+	}
+	txData.Gas = gasLimit
+	signedTx, err := g.SignTransaction(txData)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign transaction - %w", err)
+	}
+	err = g.client.SendTransaction(ctx, signedTx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to send transaction - %w", err)
+	}
+	txHash := signedTx.Hash()
+	return &txHash, nil
+}
+
+func (g *gatewayUser) AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error) {
+	var receipt *types.Receipt
+	var err error
+	err = retry.Do(func() error {
+		receipt, err = g.client.TransactionReceipt(ctx, *txHash)
+		if !errors.Is(err, rpc.ErrNilResponse) {
+			return retry.FailFast(err)
+		}
+		return err
+	}, retry.NewTimeoutStrategy(20*time.Second, 1*time.Second))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get receipt - %w", err)
+	}
+	return receipt, nil
+}
+
+func (g *gatewayUser) NativeBalance(ctx context.Context) (*big.Int, error) {
+	return g.client.BalanceAt(ctx, g.accountAddress, nil)
+}
+
+func (g *gatewayUser) Address() gethcommon.Address {
+	return g.accountAddress
+}
+
+func (g *gatewayUser) SignTransaction(tx types.TxData) (*types.Transaction, error) {
+	return g.SignTransactionForChainID(tx, g.chainID)
+}
+
+func (g *gatewayUser) SignTransactionForChainID(tx types.TxData, chainID *big.Int) (*types.Transaction, error) {
+	return types.SignNewTx(g.privateKey, types.NewLondonSigner(chainID), tx)
+}
+
+func (g *gatewayUser) SetNonce(nonce uint64) {
+	panic("gatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
+}
+
+func (g *gatewayUser) GetNonceAndIncrement() uint64 {
+	panic("gatewayUser is designed to manage its own nonce - this method exists to support legacy interface methods")
+}
+
+func (g *gatewayUser) GetNonce() uint64 {
+	return g.nonce
+}
+
+func (g *gatewayUser) ChainID() *big.Int {
+	return g.chainID
+}
+
+func (g *gatewayUser) PrivateKey() *ecdsa.PrivateKey {
+	return g.privateKey
+}

--- a/integration/networktest/userwallet/user.go
+++ b/integration/networktest/userwallet/user.go
@@ -1,0 +1,23 @@
+package userwallet
+
+import (
+	"context"
+	"math/big"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ten-protocol/go-ten/go/wallet"
+)
+
+// User - abstraction for networktest users -  two implementations initially:
+// 1. AuthClientUser - a user that uses the auth client to talk to the network
+// 2. GatewayUser - a user that uses the gateway to talk to the network
+//
+// This abstraction allows us to use the same tests for both types of users
+type User interface {
+	SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error)
+	AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error)
+	NativeBalance(ctx context.Context) (*big.Int, error)
+	SignTransaction(tx types.TxData) (*types.Transaction, error)
+	wallet.Wallet
+}

--- a/integration/networktest/userwallet/user.go
+++ b/integration/networktest/userwallet/user.go
@@ -15,9 +15,8 @@ import (
 //
 // This abstraction allows us to use the same tests for both types of users
 type User interface {
+	Wallet() wallet.Wallet
 	SendFunds(ctx context.Context, addr gethcommon.Address, value *big.Int) (*gethcommon.Hash, error)
 	AwaitReceipt(ctx context.Context, txHash *gethcommon.Hash) (*types.Receipt, error)
 	NativeBalance(ctx context.Context) (*big.Int, error)
-	SignTransaction(tx types.TxData) (*types.Transaction, error)
-	wallet.Wallet
 }

--- a/integration/simulation/devnetwork/config.go
+++ b/integration/simulation/devnetwork/config.go
@@ -36,7 +36,7 @@ type ObscuroConfig struct {
 }
 
 // DefaultDevNetwork provides an off-the-shelf default config for a sim network
-func DefaultDevNetwork() *InMemDevNetwork {
+func DefaultDevNetwork(tenGateway bool) *InMemDevNetwork {
 	numNodes := 4 // Default sim currently uses 4 L1 nodes. Obscuro nodes: 1 seq, 3 validators
 	networkWallets := params.NewSimWallets(0, numNodes, integration.EthereumChainID, integration.TenChainID)
 	l1Config := &L1Config{
@@ -57,7 +57,8 @@ func DefaultDevNetwork() *InMemDevNetwork {
 			L1BlockTime:       15 * time.Second,
 			SequencerID:       networkWallets.NodeWallets[0].Address(),
 		},
-		faucetLock: sync.Mutex{},
+		tenGatewayEnabled: tenGateway,
+		faucetLock:        sync.Mutex{},
 	}
 }
 

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -234,7 +234,12 @@ func (s *InMemDevNetwork) CleanUp() {
 	}()
 	go s.l1Network.CleanUp()
 	if s.tenGatewayContainer != nil {
-		go s.tenGatewayContainer.Stop()
+		go func() {
+			err := s.tenGatewayContainer.Stop()
+			if err != nil {
+				fmt.Println("failed to stop ten gateway", err.Error())
+			}
+		}()
 	}
 
 	s.logger.Info("Waiting for servers to stop.")

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -183,7 +183,7 @@ func (s *InMemDevNetwork) startNodes() {
 			}
 		}(v)
 	}
-	s.faucet = userwallet.NewUserWallet(s.networkWallets.L2FaucetWallet.PrivateKey(), s.SequencerRPCAddress(), s.logger)
+	s.faucet = userwallet.NewUserWallet(s.networkWallets.L2FaucetWallet, s.SequencerRPCAddress(), s.logger)
 }
 
 func (s *InMemDevNetwork) startTenGateway() {

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -200,9 +200,14 @@ func (n *InMemNodeOperator) Stop() error {
 	return nil
 }
 
-func (n *InMemNodeOperator) HostRPCAddress() string {
+func (n *InMemNodeOperator) HostRPCWSAddress() string {
 	hostPort := n.config.PortStart + integration.DefaultHostRPCWSOffset + n.operatorIdx
 	return fmt.Sprintf("ws://%s:%d", network.Localhost, hostPort)
+}
+
+func (n *InMemNodeOperator) HostRPCHTTPAddress() string {
+	hostPort := n.config.PortStart + integration.DefaultHostRPCHTTPOffset + n.operatorIdx
+	return fmt.Sprintf("http://%s:%d", network.Localhost, hostPort)
 }
 
 func (n *InMemNodeOperator) StopEnclave() error {

--- a/tools/walletextension/api/utils.go
+++ b/tools/walletextension/api/utils.go
@@ -30,9 +30,15 @@ func parseRequest(body []byte) (*common.RPCRequest, error) {
 
 	// we extract the params into a JSON list
 	var params []interface{}
-	err = json.Unmarshal(reqJSONMap[common.JSONKeyParams], &params)
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal params list from JSON-RPC request body: %s ; %w", string(body), err)
+	// params key is optional in JSON-RPC request
+	_, exists := reqJSONMap[common.JSONKeyParams]
+	if exists {
+		err = json.Unmarshal(reqJSONMap[common.JSONKeyParams], &params)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal params list from JSON-RPC request body: %s ; %w", string(body), err)
+		}
+	} else {
+		params = []interface{}{}
 	}
 
 	return &common.RPCRequest{


### PR DESCRIPTION
### Why this change is needed

The network tests are useful for end-to-end testing from the IDE against a local network or against the testnet environments.

But they could only test the direct to node 'AuthClient' connections and so they couldn't be used to debug or test GW issues.

### What changes were made as part of this PR

- Add `WithGateway()` option to the LocalDevNetwork so it starts a (debuggable) gateway process alongside the network nodes.
- Add `UseGateway` boolean option to the `CreateTestUser` action to allow users to be created that would register and communicate with the gateway instead of directly. (Create User abstraction so both types of user can be used in all tests).
- Fix issue in the gateway where it was expecting params key to always be set even for methods like eth_gasPrice that have no params. This is an issue because the geth client does not send that key for that method.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


