### PR TITLE
Ziga/add personal sign authentication message

### DIFF
--- a/go/common/tracers/tracers.go
+++ b/go/common/tracers/tracers.go
@@ -1,7 +1,7 @@
 // Package tracers: This file was copied/adapted from geth - go-ethereum/eth/tracers
 //
 
-//nolint
+// nolint
 package tracers
 
 import (

--- a/go/common/tracers/tracers.go
+++ b/go/common/tracers/tracers.go
@@ -1,7 +1,7 @@
 // Package tracers: This file was copied/adapted from geth - go-ethereum/eth/tracers
 //
 
-// nolint
+//nolint
 package tracers
 
 import (

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -91,9 +91,7 @@ type ViewingKey struct {
 // every RPC request to a sensitive method, including Log subscriptions.
 // only the public key and the signature are required
 // the account address is sent as well to aid validation
-// todo - send the type of Message that was signed instead of the Account
 type RPCSignedViewingKey struct {
-	Account                 *gethcommon.Address
 	PublicKey               []byte
 	SignatureWithAccountKey []byte
 	SignatureType           SignatureType
@@ -342,15 +340,15 @@ func checkPersonalSignSignature(encryptionToken string, signature []byte, chainI
 }
 
 // CheckSignatureWithType TODO @Ziga - Refactor and simplify this function
-func CheckSignatureWithType(encryptionToken string, signature []byte, chainID int64, expectedAddress string, signatureType SignatureType) (*gethcommon.Address, error) {
+func CheckSignatureWithType(encryptionToken string, signature []byte, chainID int64, signatureType SignatureType) (*gethcommon.Address, error) {
 	if signatureType == PersonalSign {
 		addr, err := checkPersonalSignSignature(encryptionToken, signature, chainID)
-		if err == nil && addr.Hex() == expectedAddress {
+		if err == nil {
 			return addr, nil
 		}
 	} else if signatureType == EIP712Signature {
 		addr, err := checkEIP712Signature(encryptionToken, signature, chainID)
-		if err == nil && addr.Hex() == expectedAddress {
+		if err == nil {
 			return addr, nil
 		}
 	} else if signatureType == Legacy {

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -298,7 +298,6 @@ func CheckPersonalSignSignature(encryptionToken string, signature []byte, chainI
 	// create all possible hashes (for all the supported versions) of the message (needed for signature verification)
 	for _, version := range PersonalSignMessageSupportedVersions {
 		message := GeneratePersonalSignMessage(encryptionToken, chainID, version)
-		fmt.Println("recreated message: ", message)
 		prefixedMessage := fmt.Sprintf(PersonalSignMessagePrefix, len(message), message)
 		messageHash := crypto.Keccak256([]byte(prefixedMessage))
 
@@ -319,7 +318,6 @@ func CheckSignature(encryptionToken string, signature []byte, chainID int64, exp
 	if err == nil && addr.Hex() == expectedAddress {
 		return addr, nil
 	}
-	fmt.Println("Personal signature verification failed - checking PersonalSign signature")
 
 	addr, err = CheckEIP712Signature(encryptionToken, signature, chainID)
 	if err == nil && addr.Hex() == expectedAddress {

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -352,6 +352,15 @@ func CheckSignatureWithType(encryptionToken string, signature []byte, chainID in
 			return addr, nil
 		}
 	} else if signatureType == Legacy {
+		// todo - this part is only for the legacy format and will be removed once the legacy format is no longer supported
+		publicKey := []byte(encryptionToken)
+		msgToSignLegacy := GenerateSignMessage(publicKey)
+		recoveredAccountPublicKeyLegacy, err := crypto.SigToPub(accounts.TextHash([]byte(msgToSignLegacy)), signature)
+		if err != nil {
+			return nil, fmt.Errorf("failed to recover account public key from legacy signature: %w", err)
+		}
+		recoveredAccountAddressLegacy := crypto.PubkeyToAddress(*recoveredAccountPublicKeyLegacy)
+		return &recoveredAccountAddressLegacy, nil
 	}
 	return nil, fmt.Errorf("signature verification failed")
 }

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -42,7 +42,7 @@ const (
 	PersonalSignMessageFormat = "Token: %s on: %d version: v%d"
 	EIP712SignatureType       = 0
 	PersonalSignSignatureType = 1
-	//LegacySignatureType       = 2
+	LegacySignatureType       = 2
 )
 
 // EIP712EncryptionTokens is a list of all possible options for Encryption token name

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -40,6 +40,9 @@ const (
 	UserIDHexLength           = 40
 	PersonalSignMessagePrefix = "\x19Ethereum Signed Message:\n%d%s"
 	PersonalSignMessageFormat = "Token: %s on: %d version: v%d"
+	EIP712SignatureType       = 0
+	PersonalSignSignatureType = 1
+	//LegacySignatureType       = 2
 )
 
 // EIP712EncryptionTokens is a list of all possible options for Encryption token name
@@ -312,7 +315,7 @@ func CheckPersonalSignSignature(encryptionToken string, signature []byte, chainI
 }
 
 // CheckSignature checks if signature is valid for provided encryptionToken and chainID and return address or nil if not valid
-// TODO @Ziga - refactor this method when we have version of the signature
+// TODO @Ziga - DELETE THIS FUNCTION LATER...
 func CheckSignature(encryptionToken string, signature []byte, chainID int64, expectedAddress string) (*gethcommon.Address, error) {
 	addr, err := CheckPersonalSignSignature(encryptionToken, signature, chainID)
 	if err == nil && addr.Hex() == expectedAddress {
@@ -323,5 +326,22 @@ func CheckSignature(encryptionToken string, signature []byte, chainID int64, exp
 	if err == nil && addr.Hex() == expectedAddress {
 		return addr, nil
 	}
+	return nil, fmt.Errorf("signature verification failed")
+}
+
+// CheckSignatureWithType TODO @Ziga - Refactor and simplify this function
+func CheckSignatureWithType(encryptionToken string, signature []byte, chainID int64, expectedAddress string, messageType int) (*gethcommon.Address, error) {
+	if messageType == PersonalSignSignatureType {
+		addr, err := CheckPersonalSignSignature(encryptionToken, signature, chainID)
+		if err == nil && addr.Hex() == expectedAddress {
+			return addr, nil
+		}
+	} else if messageType == EIP712SignatureType {
+		addr, err := CheckEIP712Signature(encryptionToken, signature, chainID)
+		if err == nil && addr.Hex() == expectedAddress {
+			return addr, nil
+		}
+	}
+	// TODO: add also legacy signature type
 	return nil, fmt.Errorf("signature verification failed")
 }

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -26,25 +26,22 @@ import (
 const SignedMsgPrefix = "vk"
 
 const (
-	EIP712Domain                 = "EIP712Domain"
-	EIP712Type                   = "Authentication"
-	EIP712DomainName             = "name"
-	EIP712DomainVersion          = "version"
-	EIP712DomainChainID          = "chainId"
-	EIP712EncryptionToken        = "Encryption Token"
-	EIP712DomainNameValue        = "Ten"
-	EIP712DomainVersionValue     = "1.0"
-	UserIDHexLength              = 40
-	PersonalSignMessageFormat    = "Token: %s on chain: %d version:%d"
-	EIP712SignatureTypeInt       = 0
-	PersonalSignSignatureTypeInt = 1
-	LegacySignatureTypeInt       = 2
+	EIP712Domain              = "EIP712Domain"
+	EIP712Type                = "Authentication"
+	EIP712DomainName          = "name"
+	EIP712DomainVersion       = "version"
+	EIP712DomainChainID       = "chainId"
+	EIP712EncryptionToken     = "Encryption Token"
+	EIP712DomainNameValue     = "Ten"
+	EIP712DomainVersionValue  = "1.0"
+	UserIDHexLength           = 40
+	PersonalSignMessageFormat = "Token: %s on chain: %d version:%d"
 )
 
 const (
-	EIP712Signature SignatureType = "EIP712"
-	PersonalSign    SignatureType = "PersonalSign"
-	Legacy          SignatureType = "Legacy"
+	EIP712Signature SignatureType = 0
+	PersonalSign    SignatureType = 1
+	Legacy          SignatureType = 2
 )
 
 // EIP712EncryptionTokens is a list of all possible options for Encryption token name
@@ -56,24 +53,10 @@ var EIP712EncryptionTokens = [...]string{
 var PersonalSignMessageSupportedVersions = []int{1}
 
 // SignatureType is used to differentiate between different signature types (string is used, because int is not RLP-serializable)
-type SignatureType string
-
-// IntToSignatureType converts an int to a SignatureType
-func IntToSignatureType(signatureType int) SignatureType {
-	switch signatureType {
-	case EIP712SignatureTypeInt:
-		return EIP712Signature
-	case PersonalSignSignatureTypeInt:
-		return PersonalSign
-	case LegacySignatureTypeInt:
-		return Legacy
-	default:
-		return ""
-	}
-}
+type SignatureType uint8
 
 // ViewingKey encapsulates the signed viewing key for an account for use in encrypted communication with an enclave.
-// It is th client-side perspective of the viewing key used for decrypting incoming traffic.
+// It is the client-side perspective of the viewing key used for decrypting incoming traffic.
 type ViewingKey struct {
 	Account                 *gethcommon.Address // Account address that this Viewing Key is bound to - Users Pubkey address
 	PrivateKey              *ecies.PrivateKey   // ViewingKey private key to encrypt data to the enclave

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -35,7 +35,6 @@ const (
 	EIP712DomainNameValue        = "Ten"
 	EIP712DomainVersionValue     = "1.0"
 	UserIDHexLength              = 40
-	PersonalSignMessagePrefix    = "\x19Ethereum Signed Message:\n%d%s"
 	PersonalSignMessageFormat    = "Token: %s on chain: %d version:%d"
 	EIP712SignatureTypeInt       = 0
 	PersonalSignSignatureTypeInt = 1
@@ -318,8 +317,7 @@ func checkPersonalSignSignature(encryptionToken string, signature []byte, chainI
 	// create all possible hashes (for all the supported versions) of the message (needed for signature verification)
 	for _, version := range PersonalSignMessageSupportedVersions {
 		message := GeneratePersonalSignMessage(encryptionToken, chainID, version)
-		prefixedMessage := fmt.Sprintf(PersonalSignMessagePrefix, len(message), message)
-		messageHash := crypto.Keccak256([]byte(prefixedMessage))
+		messageHash := accounts.TextHash([]byte(message))
 
 		// current signature is valid - return account address
 		address, err := CheckSignatureAndReturnAccountAddress(messageHash, signature)

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -100,6 +100,7 @@ type SignatureChecker interface {
 type (
 	PersonalSignChecker struct{}
 	EIP712Checker       struct{}
+	LegacyChecker       struct{}
 )
 
 // CheckSignature checks if signature is valid for provided encryptionToken and chainID and return address or nil if not valid
@@ -157,10 +158,16 @@ func (e EIP712Checker) CheckSignature(encryptionToken string, signature []byte, 
 	return nil, errors.New("EIP 712 signature verification failed")
 }
 
+func (lsc LegacyChecker) CheckSignature(encryptionToken string, signature []byte, chainID int64) (*gethcommon.Address, error) {
+	legacyMessageHash := accounts.TextHash([]byte(encryptionToken))
+	return CheckSignatureAndReturnAccountAddress(legacyMessageHash, signature)
+}
+
 // SignatureChecker is a map of SignatureType to SignatureChecker
 var signatureCheckers = map[SignatureType]SignatureChecker{
 	PersonalSign:    PersonalSignChecker{},
 	EIP712Signature: EIP712Checker{},
+	Legacy:          LegacyChecker{},
 }
 
 // CheckSignature checks if signature is valid for provided encryptionToken and chainID and return address or nil if not valid

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -158,7 +158,7 @@ func (e EIP712Checker) CheckSignature(encryptionToken string, signature []byte, 
 	return nil, errors.New("EIP 712 signature verification failed")
 }
 
-func (lsc LegacyChecker) CheckSignature(encryptionToken string, signature []byte, chainID int64) (*gethcommon.Address, error) {
+func (lsc LegacyChecker) CheckSignature(encryptionToken string, signature []byte, _ int64) (*gethcommon.Address, error) {
 	legacyMessageHash := accounts.TextHash([]byte(encryptionToken))
 	return CheckSignatureAndReturnAccountAddress(legacyMessageHash, signature)
 }

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -92,7 +92,8 @@ type RPCSignedViewingKey struct {
 	SignatureType           SignatureType
 }
 
-// SignatureChecker is an interface for checking if signature is valid for provided encryptionToken and chainID and return address or nil if not valid
+// SignatureChecker is an interface for checking
+// if signature is valid for provided encryptionToken and chainID and return singing address or nil if not valid
 type SignatureChecker interface {
 	CheckSignature(encryptionToken string, signature []byte, chainID int64) (*gethcommon.Address, error)
 }

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -54,7 +54,7 @@ func checkViewingKeyAndRecoverAddress(vk *AuthenticatedViewingKey, chainID int64
 	vk.UserID = userID
 
 	// check signature and recover the address assuming the message was signed with EIP712
-	recoveredSignerAddress, err := viewingkey.CheckSignature(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.AccountAddress.Hex())
+	recoveredSignerAddress, err := viewingkey.CheckSignatureWithType(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.AccountAddress.Hex(), vk.rpcVK.SignatureType)
 	if err != nil {
 		// Signature failed
 		// Either it is invalid or it might have been using the legacy format

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -58,7 +58,7 @@ func checkViewingKeyAndRecoverAddress(vk *AuthenticatedViewingKey, chainID int64
 	}
 
 	// check the signature and recover the address assuming the message was signed with EIP712
-	recoveredSignerAddress, err := viewingkey.CheckSignatureWithType(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.rpcVK.SignatureType)
+	recoveredSignerAddress, err := viewingkey.CheckSignature(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.rpcVK.SignatureType)
 	if err != nil {
 		return nil, fmt.Errorf("signature verification failed %w", err)
 	}

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -54,7 +54,7 @@ func checkViewingKeyAndRecoverAddress(vk *AuthenticatedViewingKey, chainID int64
 	vk.UserID = userID
 
 	// check signature and recover the address assuming the message was signed with EIP712
-	recoveredSignerAddress, err := viewingkey.CheckEIP712Signature(userID, vk.rpcVK.SignatureWithAccountKey, chainID)
+	recoveredSignerAddress, err := viewingkey.CheckSignature(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.AccountAddress.Hex())
 	if err != nil {
 		// Signature failed
 		// Either it is invalid or it might have been using the legacy format

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -18,7 +18,6 @@ func TestVKHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	userAccAddress := crypto.PubkeyToAddress(userPrivKey.PublicKey)
 
 	// generate ViewingKey private Key
 	vkPrivKey, err := crypto.GenerateKey()
@@ -52,7 +51,6 @@ func TestVKHandler(t *testing.T) {
 
 			// Create a new vk Handler
 			_, err = VerifyViewingKey(&viewingkey.RPCSignedViewingKey{
-				Account:                 &userAccAddress,
 				PublicKey:               vkPubKeyBytes,
 				SignatureWithAccountKey: signature,
 				SignatureType:           viewingkey.EIP712Signature, // todo - fix this test

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -55,6 +55,7 @@ func TestVKHandler(t *testing.T) {
 				Account:                 &userAccAddress,
 				PublicKey:               vkPubKeyBytes,
 				SignatureWithAccountKey: signature,
+				SignatureType:           viewingkey.EIP712Signature, // todo - fix this test
 			}, chainID)
 			assert.NoError(t, err)
 		})

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -29,6 +29,8 @@ func TestVKHandler(t *testing.T) {
 	userID := viewingkey.CalculateUserIDHex(vkPubKeyBytes)
 	WEMessageFormatTestHash := accounts.TextHash([]byte(viewingkey.GenerateSignMessage(vkPubKeyBytes)))
 	EIP712MessageDataOptions, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)
+	PersonalSignMessage := viewingkey.GeneratePersonalSignMessage(userID, chainID, 1)
+	PersonalSignMessageHash := accounts.TextHash([]byte(PersonalSignMessage))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -38,8 +40,9 @@ func TestVKHandler(t *testing.T) {
 	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageDataOptions[0])
 
 	tests := map[string][]byte{
-		"WEMessageFormatTest":     WEMessageFormatTestHash,
-		"EIP712MessageFormatTest": EIP712MessageFormatTestHash,
+		"WEMessageFormatTest":           WEMessageFormatTestHash,
+		"EIP712MessageFormatTest":       EIP712MessageFormatTestHash,
+		"PersonalSignMessageFormatTest": PersonalSignMessageHash,
 	}
 
 	for testName, msgHashToSign := range tests {
@@ -79,10 +82,13 @@ func TestSignAndCheckSignature(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	EIP712MessageFormatTestHash := crypto.Keccak256(EIP712MessageData[0])
+	PersonalSignMessage := viewingkey.GeneratePersonalSignMessage(userID, chainID, 1)
+	PersonalSignMessageHash := accounts.TextHash([]byte(PersonalSignMessage))
 
 	tests := map[string][]byte{
-		"WEMessageFormatTest":     WEMessageFormatTestHash,
-		"EIP712MessageFormatTest": EIP712MessageFormatTestHash,
+		"WEMessageFormatTest":           WEMessageFormatTestHash,
+		"EIP712MessageFormatTest":       EIP712MessageFormatTestHash,
+		"PersonalSignMessageFormatTest": PersonalSignMessageHash,
 	}
 
 	for testName, msgHashToSign := range tests {

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -45,18 +45,6 @@ type MessageWithSignatureType struct {
 	SignatureType viewingkey.SignatureType
 }
 
-func TestAttack(t *testing.T) {
-	userPrivKey, _, userID, userAddress := generateRandomUserKeys()
-	fmt.Println("userAddress: ", userAddress.Hex())
-
-	PersonalSignMessageHash := accounts.TextHash([]byte(viewingkey.GeneratePersonalSignMessage(userID, chainID, viewingkey.PersonalSignMessageSupportedVersions[0])))
-	signature, _ := crypto.Sign(PersonalSignMessageHash, userPrivKey)
-	addr1, err := viewingkey.CheckSignature(userID, signature, chainID, viewingkey.PersonalSign)
-	fmt.Println("addr1: ", addr1.Hex(), "err: ", err)
-	addr2, err := viewingkey.CheckSignature(userID, signature, chainID, viewingkey.EIP712Signature)
-	fmt.Println("addr2: ", addr2.Hex(), "err: ", err)
-}
-
 func TestCheckSignature(t *testing.T) {
 	userPrivKey, _, userID, userAddress := generateRandomUserKeys()
 

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -45,6 +45,18 @@ type MessageWithSignatureType struct {
 	SignatureType viewingkey.SignatureType
 }
 
+func TestAttack(t *testing.T) {
+	userPrivKey, _, userID, userAddress := generateRandomUserKeys()
+	fmt.Println("userAddress: ", userAddress.Hex())
+
+	PersonalSignMessageHash := accounts.TextHash([]byte(viewingkey.GeneratePersonalSignMessage(userID, chainID, viewingkey.PersonalSignMessageSupportedVersions[0])))
+	signature, _ := crypto.Sign(PersonalSignMessageHash, userPrivKey)
+	addr1, err := viewingkey.CheckSignature(userID, signature, chainID, viewingkey.PersonalSign)
+	fmt.Println("addr1: ", addr1.Hex(), "err: ", err)
+	addr2, err := viewingkey.CheckSignature(userID, signature, chainID, viewingkey.EIP712Signature)
+	fmt.Println("addr2: ", addr2.Hex(), "err: ", err)
+}
+
 func TestCheckSignature(t *testing.T) {
 	userPrivKey, _, userID, userAddress := generateRandomUserKeys()
 

--- a/go/enclave/vkhandler/vk_handler_test.go
+++ b/go/enclave/vkhandler/vk_handler_test.go
@@ -84,7 +84,6 @@ func TestCheckSignature(t *testing.T) {
 
 func TestVerifyViewingKey(t *testing.T) {
 	userPrivKey, vkPrivKey, userID, userAddress := generateRandomUserKeys()
-	fmt.Println("User Address: ", userAddress.Hex())
 	// Generate all message types and create map with the corresponding signature type
 	// Test EIP712 message format
 	EIP712MessageDataOptions, err := viewingkey.GenerateAuthenticationEIP712RawDataOptions(userID, chainID)

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -173,6 +173,7 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 			PublicKey:               c.viewingKey.PublicKey,
 			SignatureWithAccountKey: c.viewingKey.SignatureWithAccountKey,
 			Account:                 c.Account(),
+			SignatureType:           c.viewingKey.SignatureType,
 		},
 	}
 
@@ -308,6 +309,7 @@ func (c *EncRPCClient) encryptArgs(args ...interface{}) ([]byte, error) {
 		Account:                 c.Account(),
 		PublicKey:               c.viewingKey.PublicKey,
 		SignatureWithAccountKey: c.viewingKey.SignatureWithAccountKey,
+		SignatureType:           c.viewingKey.SignatureType,
 	}
 	argsWithVK := &rpc.RequestWithVk{VK: &vk, Params: args}
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -172,7 +172,6 @@ func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*
 		ViewingKey: &viewingkey.RPCSignedViewingKey{
 			PublicKey:               c.viewingKey.PublicKey,
 			SignatureWithAccountKey: c.viewingKey.SignatureWithAccountKey,
-			Account:                 c.Account(),
 			SignatureType:           c.viewingKey.SignatureType,
 		},
 	}
@@ -306,7 +305,6 @@ func (c *EncRPCClient) encryptArgs(args ...interface{}) ([]byte, error) {
 		return nil, nil
 	}
 	vk := viewingkey.RPCSignedViewingKey{
-		Account:                 c.Account(),
 		PublicKey:               c.viewingKey.PublicKey,
 		SignatureWithAccountKey: c.viewingKey.SignatureWithAccountKey,
 		SignatureType:           c.viewingKey.SignatureType,

--- a/integration/obscurogateway/gateway_user.go
+++ b/integration/obscurogateway/gateway_user.go
@@ -51,11 +51,25 @@ func NewUser(wallets []wallet.Wallet, serverAddressHTTP string, serverAddressWS 
 
 func (u GatewayUser) RegisterAccounts() error {
 	for _, w := range u.Wallets {
+		fmt.Println("Registering account", w.Address().Hex())
 		err := u.tgClient.RegisterAccount(w.PrivateKey(), w.Address())
 		if err != nil {
 			return err
 		}
 		testlog.Logger().Info(fmt.Sprintf("Successfully registered address %s for user: %s.", w.Address().Hex(), u.tgClient.UserID()))
+	}
+
+	return nil
+}
+
+func (u GatewayUser) RegisterAccountsPersonalSign() error {
+	for _, w := range u.Wallets {
+		fmt.Println("Registering account with personal sign", w.Address().Hex())
+		err := u.tgClient.RegisterAccountPersonalSign(w.PrivateKey(), w.Address())
+		if err != nil {
+			return err
+		}
+		testlog.Logger().Info(fmt.Sprintf("Successfully registered address %s for user: %s. With personal sign message", w.Address().Hex(), u.tgClient.UserID()))
 	}
 
 	return nil

--- a/integration/obscurogateway/gateway_user.go
+++ b/integration/obscurogateway/gateway_user.go
@@ -51,7 +51,6 @@ func NewUser(wallets []wallet.Wallet, serverAddressHTTP string, serverAddressWS 
 
 func (u GatewayUser) RegisterAccounts() error {
 	for _, w := range u.Wallets {
-		fmt.Println("Registering account", w.Address().Hex())
 		err := u.tgClient.RegisterAccount(w.PrivateKey(), w.Address())
 		if err != nil {
 			return err
@@ -64,7 +63,6 @@ func (u GatewayUser) RegisterAccounts() error {
 
 func (u GatewayUser) RegisterAccountsPersonalSign() error {
 	for _, w := range u.Wallets {
-		fmt.Println("Registering account with personal sign", w.Address().Hex())
 		err := u.tgClient.RegisterAccountPersonalSign(w.PrivateKey(), w.Address())
 		if err != nil {
 			return err

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -95,13 +95,13 @@ func TestTenGateway(t *testing.T) {
 	// run the tests against the exis
 	for name, test := range map[string]func(*testing.T, string, string, wallet.Wallet){
 		//"testAreTxsMinted":            testAreTxsMinted, this breaks the other tests bc, enable once concurrency issues are fixed
-		//"testErrorHandling":                    testErrorHandling,
-		//"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
-		//"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
-		//"testUnsubscribe":                      testUnsubscribe,
-		//"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
-		//"testSubscriptionTopics":               testSubscriptionTopics,
-		"testDifferentMessagesOnRegister": testDifferentMessagesOnRegister,
+		"testErrorHandling":                    testErrorHandling,
+		"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
+		"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
+		"testUnsubscribe":                      testUnsubscribe,
+		"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
+		"testSubscriptionTopics":               testSubscriptionTopics,
+		"testDifferentMessagesOnRegister":      testDifferentMessagesOnRegister,
 	} {
 		t.Run(name, func(t *testing.T) {
 			test(t, httpURL, wsURL, w)

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -95,13 +95,13 @@ func TestTenGateway(t *testing.T) {
 	// run the tests against the exis
 	for name, test := range map[string]func(*testing.T, string, string, wallet.Wallet){
 		//"testAreTxsMinted":            testAreTxsMinted, this breaks the other tests bc, enable once concurrency issues are fixed
-		"testErrorHandling":                    testErrorHandling,
-		"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
-		"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
-		"testUnsubscribe":                      testUnsubscribe,
-		"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
-		"testSubscriptionTopics":               testSubscriptionTopics,
-		"testDifferentMessagesOnRegister":      testDifferentMessagesOnRegister,
+		//"testErrorHandling":                    testErrorHandling,
+		//"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
+		//"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
+		//"testUnsubscribe":                      testUnsubscribe,
+		//"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
+		//"testSubscriptionTopics":               testSubscriptionTopics,
+		"testDifferentMessagesOnRegister": testDifferentMessagesOnRegister,
 	} {
 		t.Run(name, func(t *testing.T) {
 			test(t, httpURL, wsURL, w)

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -95,12 +95,13 @@ func TestTenGateway(t *testing.T) {
 	// run the tests against the exis
 	for name, test := range map[string]func(*testing.T, string, string, wallet.Wallet){
 		//"testAreTxsMinted":            testAreTxsMinted, this breaks the other tests bc, enable once concurrency issues are fixed
-		"testErrorHandling":                    testErrorHandling,
-		"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
-		"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
-		"testUnsubscribe":                      testUnsubscribe,
-		"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
-		"testSubscriptionTopics":               testSubscriptionTopics,
+		//"testErrorHandling":                    testErrorHandling,
+		//"testMultipleAccountsSubscription":     testMultipleAccountsSubscription,
+		//"testErrorsRevertedArePassed":          testErrorsRevertedArePassed,
+		//"testUnsubscribe":                      testUnsubscribe,
+		//"testClosingConnectionWhileSubscribed": testClosingConnectionWhileSubscribed,
+		//"testSubscriptionTopics":               testSubscriptionTopics,
+		"testDifferentMessagesOnRegister": testDifferentMessagesOnRegister,
 	} {
 		t.Run(name, func(t *testing.T) {
 			test(t, httpURL, wsURL, w)
@@ -603,6 +604,20 @@ func testClosingConnectionWhileSubscribed(t *testing.T, httpURL, wsURL string, w
 
 	// Call unsubscribe (should handle it without issues even if it is already unsubscribed by closing the channel)
 	subscription.Unsubscribe()
+}
+
+func testDifferentMessagesOnRegister(t *testing.T, httpURL, wsURL string, w wallet.Wallet) {
+	user, err := NewUser([]wallet.Wallet{w, datagenerator.RandomWallet(integration.TenChainID)}, httpURL, wsURL)
+	require.NoError(t, err)
+	testlog.Logger().Info("Created user with encryption token: %s\n", user.tgClient.UserID())
+
+	// register all the accounts for the user with EIP-712 message format
+	err = user.RegisterAccounts()
+	require.NoError(t, err)
+
+	// register all the accounts for the user with personal sign message format
+	err = user.RegisterAccountsPersonalSign()
+	require.NoError(t, err)
 }
 
 func transferRandomAddr(t *testing.T, client *ethclient.Client, w wallet.Wallet) common.TxHash { //nolint: unused

--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -129,11 +129,11 @@ func testMultipleAccountsSubscription(t *testing.T, httpURL, wsURL string, w wal
 	testlog.Logger().Info("Created user with encryption token", "t", user2.tgClient.UserID())
 
 	// register all the accounts for that user
-	err = user0.RegisterAccounts()
+	err = user0.RegisterAccountsPersonalSign()
 	require.NoError(t, err)
-	err = user1.RegisterAccounts()
+	err = user1.RegisterAccountsPersonalSign()
 	require.NoError(t, err)
-	err = user2.RegisterAccounts()
+	err = user2.RegisterAccountsPersonalSign()
 	require.NoError(t, err)
 
 	var amountToTransfer int64 = 1_000_000_000_000_000_000

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -186,7 +186,7 @@ func (m *AccountManager) filterAccounts(rpcReq *wecommon.RPCRequest, accounts []
 func (m *AccountManager) createClientsForAccounts(accounts []wecommon.AccountDB, userPrivateKey []byte) ([]rpc.Client, error) {
 	clients := make([]rpc.Client, 0, len(accounts))
 	for _, account := range accounts {
-		encClient, err := wecommon.CreateEncClient(m.hostRPCBindAddrWS, account.AccountAddress, userPrivateKey, account.Signature, m.logger)
+		encClient, err := wecommon.CreateEncClient(m.hostRPCBindAddrWS, account.AccountAddress, userPrivateKey, account.Signature, account.SignatureType, m.logger)
 		if err != nil {
 			m.logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 			continue

--- a/tools/walletextension/accountmanager/account_manager.go
+++ b/tools/walletextension/accountmanager/account_manager.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ten-protocol/go-ten/go/common"
 
@@ -186,7 +188,7 @@ func (m *AccountManager) filterAccounts(rpcReq *wecommon.RPCRequest, accounts []
 func (m *AccountManager) createClientsForAccounts(accounts []wecommon.AccountDB, userPrivateKey []byte) ([]rpc.Client, error) {
 	clients := make([]rpc.Client, 0, len(accounts))
 	for _, account := range accounts {
-		encClient, err := wecommon.CreateEncClient(m.hostRPCBindAddrWS, account.AccountAddress, userPrivateKey, account.Signature, account.SignatureType, m.logger)
+		encClient, err := wecommon.CreateEncClient(m.hostRPCBindAddrWS, account.AccountAddress, userPrivateKey, account.Signature, viewingkey.SignatureType(account.SignatureType), m.logger)
 		if err != nil {
 			m.logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 			continue

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -38,7 +38,6 @@ func NewHTTPRoutes(walletExt *walletextension.WalletExtension) []Route {
 			Name: common.PathGenerateViewingKey,
 			Func: httpHandler(walletExt, generateViewingKeyRequestHandler),
 		},
-
 		{
 			Name: common.PathSubmitViewingKey,
 			Func: httpHandler(walletExt, submitViewingKeyRequestHandler),
@@ -324,14 +323,11 @@ func authenticateRequestHandler(walletExt *walletextension.WalletExtension, conn
 		messageTypeValue = typeFromRequest
 	}
 
-	fmt.Println("messageTypeValue", messageTypeValue)
 	// check if message type is valid
 	messageType, ok := common.TypeMap[messageTypeValue]
 	if !ok {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid message type + %s", messageTypeValue))
 	}
-
-	fmt.Println("messageType", messageType)
 
 	// read userID from query params
 	hexUserID, err := getUserID(conn, 2)

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -324,9 +324,9 @@ func authenticateRequestHandler(walletExt *walletextension.WalletExtension, conn
 	}
 
 	// check if message type is valid
-	messageType, ok := common.TypeMap[messageTypeValue]
+	messageType, ok := common.SignatureTypeMap[messageTypeValue]
 	if !ok {
-		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid message type + %s", messageTypeValue))
+		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid message type: %s", messageTypeValue))
 	}
 
 	// read userID from query params

--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -44,6 +44,7 @@ func CreateEncClient(
 	addressBytes []byte,
 	privateKeyBytes []byte,
 	signature []byte,
+	signatureType int,
 	logger gethlog.Logger,
 ) (*rpc.EncRPCClient, error) {
 	privateKey, err := BytesToPrivateKey(privateKeyBytes)
@@ -58,6 +59,7 @@ func CreateEncClient(
 		PrivateKey:              privateKey,
 		PublicKey:               PrivateKeyToCompressedPubKey(privateKey),
 		SignatureWithAccountKey: signature,
+		SignatureType:           viewingkey.IntToSignatureType(signatureType),
 	}
 	encClient, err := rpc.NewEncNetworkClient(hostRPCBindAddr, vk, logger)
 	if err != nil {

--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -59,7 +59,7 @@ func CreateEncClient(
 		PrivateKey:              privateKey,
 		PublicKey:               PrivateKeyToCompressedPubKey(privateKey),
 		SignatureWithAccountKey: signature,
-		SignatureType:           viewingkey.SignatureType(signatureType),
+		SignatureType:           signatureType,
 	}
 	encClient, err := rpc.NewEncNetworkClient(hostRPCBindAddr, vk, logger)
 	if err != nil {

--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -44,7 +44,7 @@ func CreateEncClient(
 	addressBytes []byte,
 	privateKeyBytes []byte,
 	signature []byte,
-	signatureType int,
+	signatureType viewingkey.SignatureType,
 	logger gethlog.Logger,
 ) (*rpc.EncRPCClient, error) {
 	privateKey, err := BytesToPrivateKey(privateKeyBytes)
@@ -59,7 +59,7 @@ func CreateEncClient(
 		PrivateKey:              privateKey,
 		PublicKey:               PrivateKeyToCompressedPubKey(privateKey),
 		SignatureWithAccountKey: signature,
-		SignatureType:           viewingkey.IntToSignatureType(signatureType),
+		SignatureType:           viewingkey.SignatureType(signatureType),
 	}
 	encClient, err := rpc.NewEncNetworkClient(hostRPCBindAddr, vk, logger)
 	if err != nil {

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -58,7 +58,7 @@ const (
 
 var ReaderHeadTimeout = 10 * time.Second
 
-var TypeMap = map[string]int{
-	"EIP712":   viewingkey.EIP712SignatureType,
-	"Personal": viewingkey.PersonalSignSignatureType,
+var SignatureTypeMap = map[string]int{
+	"EIP712":   viewingkey.EIP712SignatureTypeInt,
+	"Personal": viewingkey.PersonalSignSignatureTypeInt,
 }

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"time"
 )
 
@@ -21,6 +22,7 @@ const (
 	JSONKeySubscription = "subscription"
 	JSONKeyCode         = "code"
 	JSONKeyMessage      = "message"
+	JSONKeyType         = "type"
 )
 
 const (
@@ -50,6 +52,12 @@ const (
 	MethodEthSubscription               = "eth_subscription"
 	PathVersion                         = "/version/"
 	DeduplicationBufferSize             = 20
+	DefaultGatewayAuthMessageType       = "EIP712"
 )
 
 var ReaderHeadTimeout = 10 * time.Second
+
+var TypeMap = map[string]int{
+	"EIP712":   viewingkey.EIP712SignatureType,
+	"Personal": viewingkey.PersonalSignSignatureType,
+}

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"time"
+
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 )
 
 const (

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -58,7 +58,7 @@ const (
 
 var ReaderHeadTimeout = 10 * time.Second
 
-var SignatureTypeMap = map[string]int{
-	"EIP712":   viewingkey.EIP712SignatureTypeInt,
-	"Personal": viewingkey.PersonalSignSignatureTypeInt,
+var SignatureTypeMap = map[string]viewingkey.SignatureType{
+	"EIP712":   viewingkey.EIP712Signature,
+	"Personal": viewingkey.PersonalSign,
 }

--- a/tools/walletextension/common/types.go
+++ b/tools/walletextension/common/types.go
@@ -3,6 +3,7 @@ package common
 type AccountDB struct {
 	AccountAddress []byte
 	Signature      []byte
+	SignatureType  int
 }
 
 type UserDB struct {

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -85,7 +85,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 				os.Exit(1)
 			}
 			for _, account := range accounts {
-				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrWS, account.AccountAddress, user.PrivateKey, account.Signature, logger)
+				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrWS, account.AccountAddress, user.PrivateKey, account.Signature, account.SignatureType, logger)
 				if err != nil {
 					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 					os.Exit(1)

--- a/tools/walletextension/container/walletextension_container.go
+++ b/tools/walletextension/container/walletextension_container.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -85,7 +87,7 @@ func NewWalletExtensionContainerFromConfig(config config.Config, logger gethlog.
 				os.Exit(1)
 			}
 			for _, account := range accounts {
-				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrWS, account.AccountAddress, user.PrivateKey, account.Signature, account.SignatureType, logger)
+				encClient, err := wecommon.CreateEncClient(hostRPCBindAddrWS, account.AccountAddress, user.PrivateKey, account.Signature, viewingkey.SignatureType(account.SignatureType), logger)
 				if err != nil {
 					logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 					os.Exit(1)

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -5,10 +5,11 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts"
 
 	"github.com/ten-protocol/go-ten/integration"
 

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -96,7 +96,6 @@ func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) e
 func (o *TGLib) RegisterAccountPersonalSign(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
 	personalSignMessage := viewingkey.GeneratePersonalSignMessage(string(o.userID), integration.TenChainID, 1)
-	fmt.Println("personalSignMessage: ", personalSignMessage)
 	prefixedMessage := fmt.Sprintf(viewingkey.PersonalSignMessagePrefix, len(personalSignMessage), personalSignMessage)
 	messageHash := crypto.Keccak256([]byte(prefixedMessage))
 
@@ -106,8 +105,7 @@ func (o *TGLib) RegisterAccountPersonalSign(pk *ecdsa.PrivateKey, addr gethcommo
 	}
 	sig[64] += 27
 	signature := "0x" + hex.EncodeToString(sig)
-	fmt.Println("signature: ", signature)
-	payload := fmt.Sprintf("{\"signature\": \"%s\", \"address\": \"%s\"}", signature, addr.Hex())
+	payload := fmt.Sprintf("{\"signature\": \"%s\", \"address\": \"%s\", \"type\": \"%s\"}", signature, addr.Hex(), "Personal")
 
 	// issue the registration message
 	req, err := http.NewRequestWithContext(

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -93,6 +93,52 @@ func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) e
 	return nil
 }
 
+func (o *TGLib) RegisterAccountPersonalSign(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
+	// create the registration message
+	personalSignMessage := viewingkey.GeneratePersonalSignMessage(string(o.userID), integration.TenChainID, 1)
+	fmt.Println("personalSignMessage: ", personalSignMessage)
+	prefixedMessage := fmt.Sprintf(viewingkey.PersonalSignMessagePrefix, len(personalSignMessage), personalSignMessage)
+	messageHash := crypto.Keccak256([]byte(prefixedMessage))
+
+	sig, err := crypto.Sign(messageHash, pk)
+	if err != nil {
+		return fmt.Errorf("failed to sign message: %w", err)
+	}
+	sig[64] += 27
+	signature := "0x" + hex.EncodeToString(sig)
+	fmt.Println("signature: ", signature)
+	payload := fmt.Sprintf("{\"signature\": \"%s\", \"address\": \"%s\"}", signature, addr.Hex())
+
+	// issue the registration message
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		o.httpURL+"/v1/authenticate/?token="+string(o.userID),
+		strings.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create request - %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+
+	client := &http.Client{}
+	response, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to issue request - %w", err)
+	}
+
+	defer response.Body.Close()
+	r, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("unable to read response - %w", err)
+	}
+	if string(r) != "success" {
+		return fmt.Errorf("expected success, got %s", string(r))
+	}
+	return nil
+}
+
 func (o *TGLib) HTTP() string {
 	return fmt.Sprintf("%s/v1/?token=%s", o.httpURL, o.userID)
 }

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"github.com/ethereum/go-ethereum/accounts"
 	"io"
 	"net/http"
 	"strings"
@@ -96,8 +97,7 @@ func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) e
 func (o *TGLib) RegisterAccountPersonalSign(pk *ecdsa.PrivateKey, addr gethcommon.Address) error {
 	// create the registration message
 	personalSignMessage := viewingkey.GeneratePersonalSignMessage(string(o.userID), integration.TenChainID, 1)
-	prefixedMessage := fmt.Sprintf(viewingkey.PersonalSignMessagePrefix, len(personalSignMessage), personalSignMessage)
-	messageHash := crypto.Keccak256([]byte(prefixedMessage))
+	messageHash := accounts.TextHash([]byte(personalSignMessage))
 
 	sig, err := crypto.Sign(messageHash, pk)
 	if err != nil {

--- a/tools/walletextension/storage/database/mariadb/003_add_signature_type.sql
+++ b/tools/walletextension/storage/database/mariadb/003_add_signature_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ogdb.accounts
+ADD COLUMN signature_type INT DEFAULT 0;

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -101,7 +101,7 @@ func (m *MariaDB) AddAccount(userID []byte, accountAddress []byte, signature []b
 }
 
 func (m *MariaDB) GetAccounts(userID []byte) ([]common.AccountDB, error) {
-	rows, err := m.db.Query("SELECT account_address, signature FROM accounts WHERE user_id = ?", userID)
+	rows, err := m.db.Query("SELECT account_address, signature, signature_type FROM accounts WHERE user_id = ?", userID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (m *MariaDB) GetAccounts(userID []byte) ([]common.AccountDB, error) {
 	var accounts []common.AccountDB
 	for rows.Next() {
 		var account common.AccountDB
-		if err := rows.Scan(&account.AccountAddress, &account.Signature); err != nil {
+		if err := rows.Scan(&account.AccountAddress, &account.Signature, &account.SignatureType); err != nil {
 			return nil, err
 		}
 		accounts = append(accounts, account)

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -85,14 +85,14 @@ func (m *MariaDB) GetUserPrivateKey(userID []byte) ([]byte, error) {
 	return privateKey, nil
 }
 
-func (m *MariaDB) AddAccount(userID []byte, accountAddress []byte, signature []byte) error {
-	stmt, err := m.db.Prepare("INSERT INTO accounts(user_id, account_address, signature) VALUES (?, ?, ?)")
+func (m *MariaDB) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error {
+	stmt, err := m.db.Prepare("INSERT INTO accounts(user_id, account_address, signature, signature_type) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(userID, accountAddress, signature)
+	_, err = stmt.Exec(userID, accountAddress, signature, signatureType)
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ethereum/go-ethereum/crypto"
 
 	_ "github.com/go-sql-driver/mysql" // Importing MariaDB driver
@@ -85,14 +87,14 @@ func (m *MariaDB) GetUserPrivateKey(userID []byte) ([]byte, error) {
 	return privateKey, nil
 }
 
-func (m *MariaDB) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error {
+func (m *MariaDB) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType viewingkey.SignatureType) error {
 	stmt, err := m.db.Prepare("INSERT INTO accounts(user_id, account_address, signature, signature_type) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(userID, accountAddress, signature, signatureType)
+	_, err = stmt.Exec(userID, accountAddress, signature, int(signatureType))
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -138,7 +138,7 @@ func (s *Database) AddAccount(userID []byte, accountAddress []byte, signature []
 }
 
 func (s *Database) GetAccounts(userID []byte) ([]common.AccountDB, error) {
-	rows, err := s.db.Query("SELECT account_address, signature FROM accounts WHERE user_id = ?", userID)
+	rows, err := s.db.Query("SELECT account_address, signature, signature_type FROM accounts WHERE user_id = ?", userID)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (s *Database) GetAccounts(userID []byte) ([]common.AccountDB, error) {
 	var accounts []common.AccountDB
 	for rows.Next() {
 		var account common.AccountDB
-		if err := rows.Scan(&account.AccountAddress, &account.Signature); err != nil {
+		if err := rows.Scan(&account.AccountAddress, &account.Signature, &account.SignatureType); err != nil {
 			return nil, err
 		}
 		accounts = append(accounts, account)

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -54,6 +54,7 @@ func NewSqliteDatabase(dbPath string) (*Database, error) {
 		user_id binary(20),
 		account_address binary(20),
 		signature binary(65),
+		signature_type int,
     	FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
 	);`)
 
@@ -121,14 +122,14 @@ func (s *Database) GetUserPrivateKey(userID []byte) ([]byte, error) {
 	return privateKey, nil
 }
 
-func (s *Database) AddAccount(userID []byte, accountAddress []byte, signature []byte) error {
-	stmt, err := s.db.Prepare("INSERT INTO accounts(user_id, account_address, signature) VALUES (?, ?, ?)")
+func (s *Database) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error {
+	stmt, err := s.db.Prepare("INSERT INTO accounts(user_id, account_address, signature, signature_type) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(userID, accountAddress, signature)
+	_, err = stmt.Exec(userID, accountAddress, signature, signatureType)
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ethereum/go-ethereum/crypto"
 
 	_ "github.com/mattn/go-sqlite3" // sqlite driver for sql.Open()
@@ -122,14 +124,14 @@ func (s *Database) GetUserPrivateKey(userID []byte) ([]byte, error) {
 	return privateKey, nil
 }
 
-func (s *Database) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error {
+func (s *Database) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType viewingkey.SignatureType) error {
 	stmt, err := s.db.Prepare("INSERT INTO accounts(user_id, account_address, signature, signature_type) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(userID, accountAddress, signature, signatureType)
+	_, err = stmt.Exec(userID, accountAddress, signature, int(signatureType))
 	if err != nil {
 		return err
 	}

--- a/tools/walletextension/storage/storage.go
+++ b/tools/walletextension/storage/storage.go
@@ -13,7 +13,7 @@ type Storage interface {
 	AddUser(userID []byte, privateKey []byte) error
 	DeleteUser(userID []byte) error
 	GetUserPrivateKey(userID []byte) ([]byte, error)
-	AddAccount(userID []byte, accountAddress []byte, signature []byte) error
+	AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error
 	GetAccounts(userID []byte) ([]common.AccountDB, error)
 	GetAllUsers() ([]common.UserDB, error)
 	StoreTransaction(rawTx string, userID []byte) error

--- a/tools/walletextension/storage/storage.go
+++ b/tools/walletextension/storage/storage.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ten-protocol/go-ten/tools/walletextension/storage/database/mariadb"
 	"github.com/ten-protocol/go-ten/tools/walletextension/storage/database/sqlite"
 
@@ -13,7 +15,7 @@ type Storage interface {
 	AddUser(userID []byte, privateKey []byte) error
 	DeleteUser(userID []byte) error
 	GetUserPrivateKey(userID []byte) ([]byte, error)
-	AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType int) error
+	AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType viewingkey.SignatureType) error
 	GetAccounts(userID []byte) ([]common.AccountDB, error)
 	GetAllUsers() ([]common.UserDB, error)
 	StoreTransaction(rawTx string, userID []byte) error

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"errors"
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = storage.AddAccount(userID, accountAddress1, signature1)
+	err = storage.AddAccount(userID, accountAddress1, signature1, viewingkey.EIP712SignatureType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +68,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 	accountAddress2 := []byte("accountAddress2")
 	signature2 := []byte("signature2")
 
-	err = storage.AddAccount(userID, accountAddress2, signature2)
+	err = storage.AddAccount(userID, accountAddress2, signature2, viewingkey.EIP712SignatureType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -3,8 +3,9 @@ package storage
 import (
 	"bytes"
 	"errors"
-	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"testing"
+
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ten-protocol/go-ten/go/common/errutil"

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -61,7 +61,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = storage.AddAccount(userID, accountAddress1, signature1, viewingkey.EIP712SignatureType)
+	err = storage.AddAccount(userID, accountAddress1, signature1, viewingkey.EIP712SignatureTypeInt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 	accountAddress2 := []byte("accountAddress2")
 	signature2 := []byte("signature2")
 
-	err = storage.AddAccount(userID, accountAddress2, signature2, viewingkey.EIP712SignatureType)
+	err = storage.AddAccount(userID, accountAddress2, signature2, viewingkey.EIP712SignatureTypeInt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -61,7 +61,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = storage.AddAccount(userID, accountAddress1, signature1, viewingkey.EIP712SignatureTypeInt)
+	err = storage.AddAccount(userID, accountAddress1, signature1, viewingkey.EIP712Signature)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 	accountAddress2 := []byte("accountAddress2")
 	signature2 := []byte("signature2")
 
-	err = storage.AddAccount(userID, accountAddress2, signature2, viewingkey.EIP712SignatureTypeInt)
+	err = storage.AddAccount(userID, accountAddress2, signature2, viewingkey.EIP712Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -178,6 +178,7 @@ func (api *DummyAPI) reEncryptParams(encryptedParams []byte) (*responses.Enclave
 		Account:                 api.address,
 		PublicKey:               api.viewingKey,
 		SignatureWithAccountKey: api.signature,
+		SignatureType:           viewingkey.Legacy, // todo - is this correct
 	}, l2ChainIDDecimal)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create vk encryption for request - %w", err)

--- a/tools/walletextension/test/apis.go
+++ b/tools/walletextension/test/apis.go
@@ -175,7 +175,6 @@ func (api *DummyAPI) reEncryptParams(encryptedParams []byte) (*responses.Enclave
 	}
 
 	encryptor, err := vkhandler.VerifyViewingKey(&viewingkey.RPCSignedViewingKey{
-		Account:                 api.address,
 		PublicKey:               api.viewingKey,
 		SignatureWithAccountKey: api.signature,
 		SignatureType:           viewingkey.Legacy, // todo - is this correct

--- a/tools/walletextension/useraccountmanager/user_account_manager.go
+++ b/tools/walletextension/useraccountmanager/user_account_manager.go
@@ -96,7 +96,7 @@ func (m *UserAccountManager) GetUserAccountManager(userID string) (*accountmanag
 		}
 
 		// create a new client
-		encClient, err := wecommon.CreateEncClient(m.hostRPCBinAddrWS, account.AccountAddress, userPrivateKey, account.Signature, m.logger)
+		encClient, err := wecommon.CreateEncClient(m.hostRPCBinAddrWS, account.AccountAddress, userPrivateKey, account.Signature, account.SignatureType, m.logger)
 		if err != nil {
 			m.logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 		}

--- a/tools/walletextension/useraccountmanager/user_account_manager.go
+++ b/tools/walletextension/useraccountmanager/user_account_manager.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+
 	"github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/go/rpc"
@@ -96,7 +98,7 @@ func (m *UserAccountManager) GetUserAccountManager(userID string) (*accountmanag
 		}
 
 		// create a new client
-		encClient, err := wecommon.CreateEncClient(m.hostRPCBinAddrWS, account.AccountAddress, userPrivateKey, account.Signature, account.SignatureType, m.logger)
+		encClient, err := wecommon.CreateEncClient(m.hostRPCBinAddrWS, account.AccountAddress, userPrivateKey, account.Signature, viewingkey.SignatureType(account.SignatureType), m.logger)
 		if err != nil {
 			m.logger.Error(fmt.Errorf("error creating new client, %w", err).Error())
 		}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -247,7 +247,7 @@ func (w *WalletExtension) SubmitViewingKey(address gethcommon.Address, signature
 
 	defaultAccountManager.AddClient(address, client)
 
-	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignatureWithAccountKey)
+	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignatureWithAccountKey, viewingkey.LegacySignatureType)
 	if err != nil {
 		return fmt.Errorf("error saving account %s for user %s", vk.Account.Hex(), common.DefaultUser)
 	}
@@ -291,11 +291,11 @@ func (w *WalletExtension) GenerateAndStoreNewUser() (string, error) {
 }
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
-func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte, messageType int) error {
+func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte, signatureType int) error {
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), address, messageType)
+	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), address, signatureType)
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}
@@ -306,7 +306,7 @@ func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, sig
 		w.Logger().Error(fmt.Errorf("error decoding string (%s), %w", hexUserID[2:], err).Error())
 		return errors.New("error decoding userID. It should be in hex format")
 	}
-	err = w.storage.AddAccount(userIDBytes, addressFromMessage.Bytes(), signature)
+	err = w.storage.AddAccount(userIDBytes, addressFromMessage.Bytes(), signature, signatureType)
 	if err != nil {
 		w.Logger().Error(fmt.Errorf("error while storing account (%s) for user (%s): %w", addressFromMessage.Hex(), hexUserID, err).Error())
 		return err

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -295,13 +295,9 @@ func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, sig
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	sigAddrs, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), address)
+	_, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), address)
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
-	}
-
-	if sigAddrs.Hex() != address {
-		return fmt.Errorf("signature is not valid. Signature address %s!=%s ", sigAddrs, address)
 	}
 
 	// register the account for that viewing key

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -296,7 +296,7 @@ func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, sig
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), viewingkey.IntToSignatureType(signatureType))
+	_, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), viewingkey.IntToSignatureType(signatureType))
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -295,7 +295,7 @@ func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, sig
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	sigAddrs, err := viewingkey.CheckEIP712Signature(hexUserID, signature, int64(w.config.TenChainID))
+	sigAddrs, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), address)
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -291,11 +291,11 @@ func (w *WalletExtension) GenerateAndStoreNewUser() (string, error) {
 }
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
-func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte) error {
+func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte, messageType int) error {
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	_, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), address)
+	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), address, messageType)
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -296,7 +296,7 @@ func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, sig
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), address, viewingkey.IntToSignatureType(signatureType))
+	_, err := viewingkey.CheckSignatureWithType(hexUserID, signature, int64(w.config.TenChainID), viewingkey.IntToSignatureType(signatureType))
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}

--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -248,7 +248,7 @@ func (w *WalletExtension) SubmitViewingKey(address gethcommon.Address, signature
 
 	defaultAccountManager.AddClient(address, client)
 
-	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignatureWithAccountKey, viewingkey.LegacySignatureTypeInt)
+	err = w.storage.AddAccount([]byte(common.DefaultUser), vk.Account.Bytes(), vk.SignatureWithAccountKey, viewingkey.Legacy)
 	if err != nil {
 		return fmt.Errorf("error saving account %s for user %s", vk.Account.Hex(), common.DefaultUser)
 	}
@@ -292,11 +292,11 @@ func (w *WalletExtension) GenerateAndStoreNewUser() (string, error) {
 }
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
-func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte, signatureType int) error {
+func (w *WalletExtension) AddAddressToUser(hexUserID string, address string, signature []byte, signatureType viewingkey.SignatureType) error {
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
-	_, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), viewingkey.IntToSignatureType(signatureType))
+	_, err := viewingkey.CheckSignature(hexUserID, signature, int64(w.config.TenChainID), signatureType)
 	if err != nil {
 		return fmt.Errorf("signature is not valid: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

We want to use Rainbowkit (https://www.rainbowkit.com/) in the future and they don't support EIP-712 messages yet.
To use them we need to add personal sign message, because it is impossible to overwrite signer there.
In order to avoid confusion I also refactored and simplified parts of code for signature verification and introduced signatureType.

### What changes were made as part of this PR

- Added new personal sign message and methods to verify it.
- Refactored code around verifying signatures
- Added signature type
- Refactored viewing key tests

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


