### PR TITLE
create a shallow copy of a map before modifying it

### DIFF
--- a/tools/walletextension/wallet_extension.go
+++ b/tools/walletextension/wallet_extension.go
@@ -113,12 +113,18 @@ func (w *WalletExtension) ProxyEthRequest(request *common.RPCRequest, conn userc
 	// in case of cache hit return the response from the cache
 	if isCacheable {
 		if value, ok := w.cache.Get(key); ok {
+			// do a shallow copy of the map to avoid concurrent map iteration and map write
+			returnValue := make(map[string]interface{})
+			for k, v := range value {
+				returnValue[k] = v
+			}
+
 			requestEndTime := time.Now()
 			duration := requestEndTime.Sub(requestStartTime)
-			w.fileLogger.Info(fmt.Sprintf("Request method: %s, request params: %s, encryptionToken of sender: %s, response: %s, duration: %d ", request.Method, request.Params, hexUserID, value, duration.Milliseconds()))
 			// adjust requestID
-			value[common.JSONKeyID] = request.ID
-			return value, nil
+			returnValue[common.JSONKeyID] = request.ID
+			w.fileLogger.Info(fmt.Sprintf("Request method: %s, request params: %s, encryptionToken of sender: %s, response: %s, duration: %d ", request.Method, request.Params, hexUserID, returnValue, duration.Milliseconds()))
+			return returnValue, nil
 		}
 	}
 


### PR DESCRIPTION
### Why this change is needed

The gateway was crashing because of modifying of requestID values after returning from cache

### What changes were made as part of this PR

creating shallow copy of return value before modifying and returning it

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


