### PR TITLE
Batch limit: increase max to 36kb

### DIFF
--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -80,7 +80,7 @@ func DefaultEnclaveConfig() *config.EnclaveConfig {
 		SequencerID:               gethcommon.BytesToAddress([]byte("")),
 		ObscuroGenesis:            "",
 		DebugNamespaceEnabled:     false,
-		MaxBatchSize:              1024 * 32,
+		MaxBatchSize:              1024 * 36,
 		MaxRollupSize:             1024 * 64,
 		GasPaymentAddress:         gethcommon.HexToAddress("0xd6C9230053f45F873Cb66D8A02439380a37A4fbF"),
 		BaseFee:                   new(big.Int).SetUint64(params.InitialBaseFee),

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -178,7 +178,7 @@ func (n *InMemNodeOperator) createEnclaveContainer() *enclavecontainer.EnclaveCo
 		MessageBusAddress:         n.l1Data.MessageBusAddr,
 		SqliteDBPath:              n.enclaveDBFilepath,
 		DebugNamespaceEnabled:     true,
-		MaxBatchSize:              1024 * 32,
+		MaxBatchSize:              1024 * 36,
 		MaxRollupSize:             1024 * 64,
 		BaseFee:                   defaultCfg.BaseFee, // todo @siliev:: fix test transaction builders so this can be different
 		GasBatchExecutionLimit:    defaultCfg.GasBatchExecutionLimit,

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -91,7 +91,7 @@ func createInMemObscuroNode(
 		MinGasPrice:               gethcommon.Big1,
 		MessageBusAddress:         l1BusAddress,
 		ManagementContractAddress: *mgtContractAddress,
-		MaxBatchSize:              1024 * 32,
+		MaxBatchSize:              1024 * 36,
 		MaxRollupSize:             1024 * 64,
 		BaseFee:                   big.NewInt(1), // todo @siliev:: fix test transaction builders so this can be different
 		GasLocalExecutionCapFlag:  params.MaxGasLimit / 2,


### PR DESCRIPTION
### Why this change is needed

Chimp exchange and others have contract creation txs bigger than 32kb. We want to remove the limit eventually but this small increase should be safe and solve the immediate issue.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


