### PR TITLE
Network test: local network QoL

### DIFF
--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -67,7 +67,6 @@ func (a *AllocateFaucetFunds) Run(ctx context.Context, network networktest.Netwo
 			return ctx, err
 		}
 		acc = user.Wallet().Address()
-
 	}
 	return ctx, network.AllocateFaucetFunds(ctx, acc)
 }

--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ten-protocol/go-ten/integration"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/datagenerator"
@@ -45,8 +46,11 @@ func (c *CreateTestUser) Verify(_ context.Context, _ networktest.NetworkConnecto
 	return nil
 }
 
+// AllocateFaucetFunds is an action that allocates funds from the network faucet to a user,
+// either UserID or Account must be set (not both) to fund a test user or a specific account respectively
 type AllocateFaucetFunds struct {
-	UserID int
+	UserID  int
+	Account *common.Address
 }
 
 func (a *AllocateFaucetFunds) String() string {
@@ -54,11 +58,18 @@ func (a *AllocateFaucetFunds) String() string {
 }
 
 func (a *AllocateFaucetFunds) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
-	user, err := FetchTestUser(ctx, a.UserID)
-	if err != nil {
-		return ctx, err
+	var acc common.Address
+	if a.Account != nil {
+		acc = *a.Account
+	} else {
+		user, err := FetchTestUser(ctx, a.UserID)
+		if err != nil {
+			return ctx, err
+		}
+		acc = user.Wallet().Address()
+
 	}
-	return ctx, network.AllocateFaucetFunds(ctx, user.Wallet().Address())
+	return ctx, network.AllocateFaucetFunds(ctx, acc)
 }
 
 func (a *AllocateFaucetFunds) Verify(_ context.Context, _ networktest.NetworkConnector) error {

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -41,8 +41,8 @@ func DevTestnet() networktest.Environment {
 // LongRunningLocalNetwork is a local network, the l1WSURL is optional (can be empty string), only required if testing L1 interactions
 func LongRunningLocalNetwork(l1WSURL string) networktest.Environment {
 	connector := NewTestnetConnectorWithFaucetAccount(
-		"ws://127.0.0.1:37900",
-		[]string{"ws://127.0.0.1:37901"},
+		"ws://127.0.0.1:26900",
+		[]string{"ws://127.0.0.1:26901"},
 		genesis.TestnetPrefundedPK,
 		l1WSURL,
 		"",

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ten-protocol/go-ten/integration/networktest"
 )
 
-var _defaultFaucetAmount = big.NewInt(750_000_000_000_000)
+var _defaultFaucetAmount = big.NewInt(5_000_000_000_000_000)
 
 type testnetConnector struct {
 	seqRPCAddress         string

--- a/integration/networktest/tests/helpful/accs_and_contracts_test.go
+++ b/integration/networktest/tests/helpful/accs_and_contracts_test.go
@@ -1,0 +1,23 @@
+package helpful
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+	"github.com/ten-protocol/go-ten/integration/networktest/env"
+)
+
+var _accountToFund = common.HexToAddress("0xD19f62b5A721747A04b969C90062CBb85D4aAaA8")
+
+// Run this test to fund an account with native funds
+func TestSendFaucetFunds(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"send-faucet-funds",
+		t,
+		env.LongRunningLocalNetwork(""),
+		&actions.AllocateFaucetFunds{Account: &_accountToFund},
+	)
+}

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -32,7 +32,7 @@ const (
 func TestRunLocalNetwork(t *testing.T) {
 	networktest.TestOnlyRunsInIDE(t)
 	networktest.EnsureTestLogsSetUp("local-geth-network")
-	networkConnector, cleanUp, err := env.LocalDevNetwork().Prepare()
+	networkConnector, cleanUp, err := env.LocalDevNetwork(env.WithTenGateway()).Prepare()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,12 +80,19 @@ func checkBalance(walDesc string, wal wallet.Wallet, rpcAddress string) {
 }
 
 func keepRunning(networkConnector networktest.NetworkConnector) {
+	gatewayURL, err := networkConnector.GetGatewayURL()
+	hasGateway := err == nil
+
 	fmt.Println("----")
 	fmt.Println("Sequencer RPC", networkConnector.SequencerRPCAddress())
 	for i := 0; i < networkConnector.NumValidators(); i++ {
 		fmt.Println("Validator  ", i, networkConnector.ValidatorRPCAddress(i))
 	}
+	if hasGateway {
+		fmt.Println("Gateway      ", gatewayURL)
+	}
 	fmt.Println("----")
+
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 	fmt.Println("Network running until test is stopped...")

--- a/integration/networktest/userwallet/authclient.go
+++ b/integration/networktest/userwallet/authclient.go
@@ -46,6 +46,7 @@ func (s *AuthClientUser) SendFunds(ctx context.Context, addr gethcommon.Address,
 	}
 
 	txData := &types.LegacyTx{
+		Nonce: s.wal.GetNonce(),
 		Value: value,
 		To:    &addr,
 	}

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -207,7 +207,7 @@ func (s *InMemDevNetwork) startTenGateway() {
 	}
 	tenGWContainer := container.NewWalletExtensionContainerFromConfig(cfg, s.logger)
 	go func() {
-		fmt.Println("Starting Ten Gateway")
+		fmt.Println("Starting Ten Gateway, HTTP Port:", _gwHTTPPort, "WS Port:", _gwWSPort)
 		err := tenGWContainer.Start()
 		if err != nil {
 			s.logger.Error("failed to start ten gateway", "err", err)


### PR DESCRIPTION
### Why this change is needed

We want to be able to quickly debug at every layer with a local network.

### What changes were made as part of this PR

- add gateway to long running local network
- add function to fund accs with faucet on any network (useful for local network)
- fix some stuff

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


