### PR TITLE
Networktests: run local gateway against testnets

### DIFF
--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -1,60 +1,138 @@
 package env
 
 import (
+	"fmt"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/go/enclave/genesis"
+	"github.com/ten-protocol/go-ten/integration"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/networktest"
+	gatewaycfg "github.com/ten-protocol/go-ten/tools/walletextension/config"
+	"github.com/ten-protocol/go-ten/tools/walletextension/container"
 )
 
-func SepoliaTestnet() networktest.Environment {
-	connector := NewTestnetConnector(
+const (
+	// these ports were picked arbitrarily, if we want plan to use these tests on CI we need to use ports in the constants.go file
+	_gwHTTPPort = 11180
+	_gwWSPort   = 11181
+)
+
+func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
+	connector := newTestnetConnector(
 		"http://erpc.sepolia-testnet.ten.xyz:80", // this is actually a validator...
 		[]string{"http://erpc.sepolia-testnet.ten.xyz:80"},
 		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"https://rpc.sepolia.org/",
 		"https://testnet.ten.xyz", // :81 for websocket
 	)
-	return &testnetEnv{connector}
+	return newTestnetEnv(connector, opts...)
 }
 
-func UATTestnet() networktest.Environment {
-	connector := NewTestnetConnector(
+func UATTestnet(opts ...TestnetEnvOption) networktest.Environment {
+	connector := newTestnetConnector(
 		"http://erpc.uat-testnet.ten.xyz:80", // this is actually a validator...
 		[]string{"http://erpc.uat-testnet.ten.xyz:80"},
 		"http://uat-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://uat-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 		"https://uat-testnet.ten.xyz",
 	)
-	return &testnetEnv{connector}
+	return newTestnetEnv(connector, opts...)
 }
 
-func DevTestnet() networktest.Environment {
-	connector := NewTestnetConnector(
+func DevTestnet(opts ...TestnetEnvOption) networktest.Environment {
+	connector := newTestnetConnector(
 		"http://erpc.dev-testnet.ten.xyz:80", // this is actually a validator...
 		[]string{"http://erpc.dev-testnet.ten.xyz:80"},
 		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 		"https://dev-testnet.ten.xyz",
 	)
-	return &testnetEnv{connector}
+	return newTestnetEnv(connector, opts...)
 }
 
 // LongRunningLocalNetwork is a local network, the l1WSURL is optional (can be empty string), only required if testing L1 interactions
 func LongRunningLocalNetwork(l1WSURL string) networktest.Environment {
-	connector := NewTestnetConnectorWithFaucetAccount(
+	connector := newTestnetConnectorWithFaucetAccount(
 		"ws://127.0.0.1:26900",
 		[]string{"ws://127.0.0.1:26901"},
 		genesis.TestnetPrefundedPK,
 		l1WSURL,
 		"",
 	)
-	return &testnetEnv{connector}
+	return newTestnetEnv(connector)
 }
 
+type TestnetEnvOption func(env *testnetEnv)
+
 type testnetEnv struct {
-	testnetConnector networktest.NetworkConnector
+	testnetConnector    *testnetConnector
+	localTenGateway     bool
+	tenGatewayContainer *container.WalletExtensionContainer
+	logger              gethlog.Logger
 }
 
 func (t *testnetEnv) Prepare() (networktest.NetworkConnector, func(), error) {
+	if t.logger == nil {
+		t.logger = testlog.Logger()
+	}
+	if t.localTenGateway {
+		t.startTenGateway()
+	}
+	cleanup := func() {
+		if t.tenGatewayContainer != nil {
+			go func() {
+				err := t.tenGatewayContainer.Stop()
+				if err != nil {
+					fmt.Println("failed to stop ten gateway", err.Error())
+				}
+			}()
+		}
+	}
 	// no cleanup or setup required for the testnet connector (unlike dev network which has teardown and startup to handle)
-	return t.testnetConnector, func() {}, nil
+	return t.testnetConnector, cleanup, nil
+}
+
+func (t *testnetEnv) startTenGateway() {
+	validator := t.testnetConnector.ValidatorRPCAddress(0)
+	// remove http:// prefix for the gateway config
+	validatorHTTP := validator[len("http://"):]
+	// replace the last character with a 1 (expect it to be zero), this is good enough for these tests
+	validatorWS := validatorHTTP[:len(validatorHTTP)-1] + "1"
+	cfg := gatewaycfg.Config{
+		WalletExtensionHost:     "127.0.0.1",
+		WalletExtensionPortHTTP: _gwHTTPPort,
+		WalletExtensionPortWS:   _gwWSPort,
+		NodeRPCHTTPAddress:      validatorHTTP,
+		NodeRPCWebsocketAddress: validatorWS,
+		LogPath:                 "sys_out",
+		VerboseFlag:             false,
+		DBType:                  "sqlite",
+		TenChainID:              integration.TenChainID,
+	}
+	tenGWContainer := container.NewWalletExtensionContainerFromConfig(cfg, t.logger)
+	go func() {
+		fmt.Println("Starting Ten Gateway, HTTP Port:", _gwHTTPPort, "WS Port:", _gwWSPort)
+		err := tenGWContainer.Start()
+		if err != nil {
+			t.logger.Error("failed to start ten gateway", "err", err)
+			panic(err)
+		}
+		t.tenGatewayContainer = tenGWContainer
+	}()
+	t.testnetConnector.tenGatewayURL = fmt.Sprintf("http://localhost:%d", _gwHTTPPort)
+}
+
+func newTestnetEnv(testnetConnector *testnetConnector, opts ...TestnetEnvOption) networktest.Environment {
+	env := &testnetEnv{testnetConnector: testnetConnector}
+	for _, opt := range opts {
+		opt(env)
+	}
+	return env
+}
+
+func WithLocalTenGateway() TestnetEnvOption {
+	return func(env *testnetEnv) {
+		env.localTenGateway = true
+	}
 }

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -36,7 +36,7 @@ type testnetConnector struct {
 	faucetWallet          userwallet.User
 }
 
-func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string, l1WSURL string, tenGatewayURL string) networktest.NetworkConnector {
+func newTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string, l1WSURL string, tenGatewayURL string) *testnetConnector {
 	return &testnetConnector{
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
@@ -46,7 +46,7 @@ func NewTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, fau
 	}
 }
 
-func NewTestnetConnectorWithFaucetAccount(seqRPCAddr string, validatorRPCAddressses []string, faucetPK string, l1RPCAddress string, tenGatewayURL string) networktest.NetworkConnector {
+func newTestnetConnectorWithFaucetAccount(seqRPCAddr string, validatorRPCAddressses []string, faucetPK string, l1RPCAddress string, tenGatewayURL string) *testnetConnector {
 	ecdsaKey, err := crypto.HexToECDSA(faucetPK)
 	if err != nil {
 		panic(err)

--- a/integration/networktest/runner.go
+++ b/integration/networktest/runner.go
@@ -39,7 +39,7 @@ func Run(testName string, t *testing.T, env Environment, action Action) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(20 * time.Second) // allow time for latest test transactions to propagate todo (@matt) make network speeds readable from env to configure this
+	time.Sleep(2 * time.Second) // allow time for latest test transactions to propagate todo (@matt) make network speeds readable from env to configure this
 	fmt.Println("Verifying test:", testName)
 	err = action.Verify(ctx, network)
 	if err != nil {

--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -23,7 +23,7 @@ func TestGatewayHappyPath(t *testing.T) {
 	networktest.Run(
 		"gateway-happy-path",
 		t,
-		env.LocalDevNetwork(env.WithTenGateway()),
+		env.SepoliaTestnet(env.WithLocalTenGateway()),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0, UseGateway: true},
 			&actions.CreateTestUser{UserID: 1, UseGateway: true},

--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -23,7 +23,7 @@ func TestGatewayHappyPath(t *testing.T) {
 	networktest.Run(
 		"gateway-happy-path",
 		t,
-		env.SepoliaTestnet(env.WithLocalTenGateway()),
+		env.LocalDevNetwork(env.WithTenGateway()),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0, UseGateway: true},
 			&actions.CreateTestUser{UserID: 1, UseGateway: true},

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -53,7 +53,6 @@ func TestRunLocalGatewayAgainstRemoteTestnet(t *testing.T) {
 	defer cleanUp()
 
 	keepRunning(networkConnector)
-
 }
 
 func TestRunLocalNetworkAgainstSepolia(t *testing.T) {

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ten-protocol/go-ten/go/ethadapter"
 	"github.com/ten-protocol/go-ten/go/wallet"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
-
 	"github.com/ten-protocol/go-ten/integration/networktest"
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
 )
@@ -39,6 +38,22 @@ func TestRunLocalNetwork(t *testing.T) {
 	defer cleanUp()
 
 	keepRunning(networkConnector)
+}
+
+func TestRunLocalGatewayAgainstRemoteTestnet(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.EnsureTestLogsSetUp("local-faucet-remote-testnet")
+
+	// set the testnet the gateway will connect to here
+	netw := env.SepoliaTestnet(env.WithLocalTenGateway())
+	networkConnector, cleanUp, err := netw.Prepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanUp()
+
+	keepRunning(networkConnector)
+
 }
 
 func TestRunLocalNetworkAgainstSepolia(t *testing.T) {


### PR DESCRIPTION
### Why this change is needed

It's useful to be able to test against a local gateway running against a remote testnet, lets you debug the interactions and run with code changes.

### What changes were made as part of this PR

Add `WithLocalTenGateway()` option to the Sepolia/UAT/DevTestnet environments in network tests.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


