### PR TITLE
store incoming transactions in a database

### DIFF
--- a/integration/obscurogateway/tengateway_test.go
+++ b/integration/obscurogateway/tengateway_test.go
@@ -67,6 +67,7 @@ func TestTenGateway(t *testing.T) {
 		VerboseFlag:             false,
 		DBType:                  "sqlite",
 		TenChainID:              443,
+		StoreIncomingTxs:        true,
 	}
 
 	tenGwContainer := container.NewWalletExtensionContainerFromConfig(tenGatewayConf, testlog.Logger())

--- a/tools/walletextension/api/routes.go
+++ b/tools/walletextension/api/routes.go
@@ -171,6 +171,11 @@ func ethRequestHandler(walletExt *walletextension.WalletExtension, conn userconn
 		hexUserID = hex.EncodeToString([]byte(common.DefaultUser)) // todo (@ziga) - this can be removed once old WE endpoints are removed
 	}
 
+	if len(hexUserID) < 3 {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("encryption token length is incorrect"))
+		return
+	}
+
 	// todo (@pedro) remove this conn dependency
 	response, err := walletExt.ProxyEthRequest(request, conn, hexUserID)
 	if err != nil {

--- a/tools/walletextension/config/config.go
+++ b/tools/walletextension/config/config.go
@@ -13,4 +13,5 @@ type Config struct {
 	DBType                  string
 	DBConnectionURL         string
 	TenChainID              int
+	StoreIncomingTxs        bool
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -55,6 +55,10 @@ const (
 	tenChainIDName      = "tenChainID"
 	tenChainIDDefault   = 443
 	tenChainIDFlagUsage = "ChainID of Ten network that the gateway is communicating with"
+
+	storeIncomingTxs        = "storeIncomingTxs"
+	storeIncomingTxsDefault = true
+	storeIncomingTxsUsage   = "Flag to enable storing incoming transactions in the database for debugging purposes. Default: true"
 )
 
 func parseCLIArgs() config.Config {
@@ -70,6 +74,7 @@ func parseCLIArgs() config.Config {
 	dbType := flag.String(dbTypeFlagName, dbTypeFlagDefault, dbTypeFlagUsage)
 	dbConnectionURL := flag.String(dbConnectionURLFlagName, dbConnectionURLFlagDefault, dbConnectionURLFlagUsage)
 	tenChainID := flag.Int(tenChainIDName, tenChainIDDefault, tenChainIDFlagUsage)
+	storeIncomingTransactions := flag.Bool(storeIncomingTxs, storeIncomingTxsDefault, storeIncomingTxsUsage)
 	flag.Parse()
 
 	return config.Config{
@@ -84,5 +89,6 @@ func parseCLIArgs() config.Config {
 		DBType:                  *dbType,
 		DBConnectionURL:         *dbConnectionURL,
 		TenChainID:              *tenChainID,
+		StoreIncomingTxs:        *storeIncomingTransactions,
 	}
 }

--- a/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
+++ b/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
@@ -1,0 +1,10 @@
+/*
+    This is a migration file for MariaDB that creates transactions table for storing incoming transactions
+*/
+
+CREATE TABLE IF NOT EXISTS ogdb.transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id varbinary(20),
+    tx TEXT
+    tx_time DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
+++ b/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
@@ -5,6 +5,7 @@
 CREATE TABLE IF NOT EXISTS ogdb.transactions (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id varbinary(20),
+    tx_hash TEXT,
     tx TEXT,
     tx_time DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
+++ b/tools/walletextension/storage/database/mariadb/002_store_incoming_txs.sql
@@ -5,6 +5,6 @@
 CREATE TABLE IF NOT EXISTS ogdb.transactions (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id varbinary(20),
-    tx TEXT
+    tx TEXT,
     tx_time DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"path/filepath"
 	"runtime"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	_ "github.com/go-sql-driver/mysql" // Importing MariaDB driver
 	"github.com/ten-protocol/go-ten/go/common/errutil"
@@ -153,9 +154,13 @@ func (m *MariaDB) StoreTransaction(rawTx string, userID []byte) error {
 	defer stmt.Close()
 
 	// Calculate tx hash
+	if len(rawTx) < 3 {
+		fmt.Println("Invalid rawTx: ", rawTx)
+		return nil
+	}
 	rawTxBytes, err := hex.DecodeString(rawTx[2:])
 	if err != nil {
-		panic(err)
+		fmt.Println("Error decoding rawTx: ", rawTx)
 	}
 	txHash := crypto.Keccak256Hash(rawTxBytes)
 

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -142,3 +142,18 @@ func (m *MariaDB) GetAllUsers() ([]common.UserDB, error) {
 
 	return users, nil
 }
+
+func (m *MariaDB) StoreTransaction(rawTx string, userID []byte) error {
+	stmt, err := m.db.Prepare("INSERT INTO transactions(user_id, tx) VALUES (?, ?)")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(userID, rawTx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/walletextension/storage/database/mariadb/mariadb.go
+++ b/tools/walletextension/storage/database/mariadb/mariadb.go
@@ -153,16 +153,20 @@ func (m *MariaDB) StoreTransaction(rawTx string, userID []byte) error {
 	}
 	defer stmt.Close()
 
-	// Calculate tx hash
+	// Validate rawTx length and get the txHash
+	txHash := ""
 	if len(rawTx) < 3 {
 		fmt.Println("Invalid rawTx: ", rawTx)
-		return nil
+	} else {
+		// Decode the hex string to bytes, excluding the '0x' prefix
+		rawTxBytes, err := hex.DecodeString(rawTx[2:])
+		if err != nil {
+			fmt.Println("Error decoding rawTx: ", err)
+		} else {
+			// Compute Keccak-256 hash
+			txHash = crypto.Keccak256Hash(rawTxBytes).Hex()
+		}
 	}
-	rawTxBytes, err := hex.DecodeString(rawTx[2:])
-	if err != nil {
-		fmt.Println("Error decoding rawTx: ", rawTx)
-	}
-	txHash := crypto.Keccak256Hash(rawTxBytes)
 
 	_, err = stmt.Exec(userID, txHash, rawTx)
 	if err != nil {

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"os"
 	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	_ "github.com/mattn/go-sqlite3" // sqlite driver for sql.Open()
 	obscurocommon "github.com/ten-protocol/go-ten/go/common"
@@ -211,9 +212,13 @@ func (s *Database) StoreTransaction(rawTx string, userID []byte) error {
 	defer stmt.Close()
 
 	// Calculate tx hash
+	if len(rawTx) < 3 {
+		fmt.Println("Invalid rawTx: ", rawTx)
+		return nil
+	}
 	rawTxBytes, err := hex.DecodeString(rawTx[2:])
 	if err != nil {
-		panic(err)
+		fmt.Println("Error decoding rawTx: ", rawTx)
 	}
 	txHash := crypto.Keccak256Hash(rawTxBytes)
 

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -59,7 +59,7 @@ func NewSqliteDatabase(dbPath string) (*Database, error) {
 	}
 
 	// create transactions table
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS ogdb.transactions (
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS transactions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id binary(20),
     tx TEXT,

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -211,16 +211,19 @@ func (s *Database) StoreTransaction(rawTx string, userID []byte) error {
 	}
 	defer stmt.Close()
 
-	// Calculate tx hash
+	txHash := ""
 	if len(rawTx) < 3 {
 		fmt.Println("Invalid rawTx: ", rawTx)
-		return nil
+	} else {
+		// Decode the hex string to bytes, excluding the '0x' prefix
+		rawTxBytes, err := hex.DecodeString(rawTx[2:])
+		if err != nil {
+			fmt.Println("Error decoding rawTx: ", err)
+		} else {
+			// Compute Keccak-256 hash
+			txHash = crypto.Keccak256Hash(rawTxBytes).Hex()
+		}
 	}
-	rawTxBytes, err := hex.DecodeString(rawTx[2:])
-	if err != nil {
-		fmt.Println("Error decoding rawTx: ", rawTx)
-	}
-	txHash := crypto.Keccak256Hash(rawTxBytes)
 
 	_, err = stmt.Exec(userID, txHash, rawTx)
 	if err != nil {

--- a/tools/walletextension/storage/storage.go
+++ b/tools/walletextension/storage/storage.go
@@ -16,6 +16,7 @@ type Storage interface {
 	AddAccount(userID []byte, accountAddress []byte, signature []byte) error
 	GetAccounts(userID []byte) ([]common.AccountDB, error)
 	GetAllUsers() ([]common.UserDB, error)
+	StoreTransaction(rawTx string, userID []byte) error
 }
 
 func New(dbType string, dbConnectionURL, dbPath string) (Storage, error) {

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -14,6 +14,7 @@ var tests = map[string]func(storage Storage, t *testing.T){
 	"testAddAndGetAccounts": testAddAndGetAccounts,
 	"testDeleteUser":        testDeleteUser,
 	"testGetAllUsers":       testGetAllUsers,
+	"testStoringNewTx":      testStoringNewTx,
 }
 
 func TestSQLiteGatewayDB(t *testing.T) {
@@ -142,5 +143,15 @@ func testGetAllUsers(storage Storage, t *testing.T) {
 
 	if len(afterInsertUsers) != len(initialUsers)+1 {
 		t.Errorf("Expected user count to increase by 1. Got %d initially and %d after insert", len(initialUsers), len(afterInsertUsers))
+	}
+}
+
+func testStoringNewTx(storage Storage, t *testing.T) {
+	userID := []byte("userID")
+	rawTransaction := "0x0123456789"
+
+	err := storage.StoreTransaction(rawTransaction, userID)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Why this change is needed

For debugging purposes we would like to store unencrypted transactions in the gateway to be able to reproduce some errors if they occur.

### What changes were made as part of this PR

Additional database table, storing transactions

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [X] PR checks reviewed and performed 

https://github.com/ten-protocol/ten-test/actions/runs/8143119529


