### PR TITLE
Network tests: basic sim to run in CI builds

### DIFF
--- a/integration/constants.go
+++ b/integration/constants.go
@@ -9,6 +9,7 @@ const (
 	StartPortSimulationGethInMem     = 18000
 	StartPortSimulationInMem         = 22000
 	StartPortSimulationFullNetwork   = 26000
+	StartPortNetworkTests            = 28000
 	StartPortSmartContractTests      = 30000
 	StartPortContractDeployerTest1   = 34000
 	StartPortContractDeployerTest2   = 35000

--- a/integration/networktest/README.md
+++ b/integration/networktest/README.md
@@ -29,8 +29,8 @@ These tests require a network that provides access to its nodes through the `Nod
 
 They can be used to test scenarios such as rejoining the network after a restart, sequencer failover, nodes losing connectivity.
 
-### `/ci` (coming soon)
-These are the only ones that will run during the CI builds by default, they should be quick and not fragile.
+### `/ci`
+These are the only tests that will run during the CI builds by default, they should be quick and not fragile.
 
 ## UserWallet
 In `/userwallet` is a high-level client that bundles a simulated user's private key, an RPC client and manages the nonce and viewing key.

--- a/integration/networktest/tests/ci/simulation_test.go
+++ b/integration/networktest/tests/ci/simulation_test.go
@@ -1,0 +1,26 @@
+package ci
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ten-protocol/go-ten/integration/networktest"
+	"github.com/ten-protocol/go-ten/integration/networktest/actions"
+	"github.com/ten-protocol/go-ten/integration/networktest/env"
+)
+
+// TestSimulation spins up a local network and runs some activity on it, verifying the results.
+// This is useful for testing the network in a more realistic scenario, we will extend this to include more complex tests.
+func TestSimulation(t *testing.T) {
+	networktest.Run(
+		"ci-simulation-test",
+		t,
+		env.LocalDevNetwork(),
+		actions.Series(
+			actions.CreateAndFundTestUsers(25),
+			actions.GenerateUsersRandomisedTransferActionsInParallel(5, 10*time.Second),
+
+			actions.VerifyUserBalancesSanity(),
+		),
+	)
+}

--- a/integration/simulation/devnetwork/config.go
+++ b/integration/simulation/devnetwork/config.go
@@ -40,7 +40,7 @@ func DefaultDevNetwork(tenGateway bool) *InMemDevNetwork {
 	numNodes := 4 // Default sim currently uses 4 L1 nodes. Obscuro nodes: 1 seq, 3 validators
 	networkWallets := params.NewSimWallets(0, numNodes, integration.EthereumChainID, integration.TenChainID)
 	l1Config := &L1Config{
-		PortStart:        integration.StartPortSimulationFullNetwork,
+		PortStart:        integration.StartPortNetworkTests,
 		NumNodes:         4,
 		AvgBlockDuration: 1 * time.Second,
 	}
@@ -50,7 +50,7 @@ func DefaultDevNetwork(tenGateway bool) *InMemDevNetwork {
 		networkWallets: networkWallets,
 		l1Network:      l1Network,
 		obscuroConfig: ObscuroConfig{
-			PortStart:         integration.StartPortSimulationFullNetwork,
+			PortStart:         integration.StartPortNetworkTests,
 			InitNumValidators: 3,
 			BatchInterval:     1 * time.Second,
 			RollupInterval:    10 * time.Second,
@@ -92,7 +92,7 @@ func LiveL1DevNetwork(seqWallet wallet.Wallet, validatorWallets []wallet.Wallet,
 		networkWallets: networkWallets,
 		l1Network:      l1Network,
 		obscuroConfig: ObscuroConfig{
-			PortStart:         integration.StartPortSimulationFullNetwork,
+			PortStart:         integration.StartPortNetworkTests,
 			InitNumValidators: len(validatorWallets),
 			BatchInterval:     5 * time.Second,
 			RollupInterval:    3 * time.Minute,


### PR DESCRIPTION
### Why this change is needed

Network tests might run things slightly differently to existing sims so get extra coverage with another sim. Longer term if it works out easy to work and we extend it sufficiently then it might replace the existing sim.

### What changes were made as part of this PR

Add a basic network test which will not be skipped on CI. It spins up network, runs light load of transactions and verifies the state.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


