### PR TITLE
Add security headers

### DIFF
--- a/tools/walletextension/frontend/src/components/head-seo.tsx
+++ b/tools/walletextension/frontend/src/components/head-seo.tsx
@@ -28,7 +28,6 @@ const HeadSeo = ({
       <meta http-equiv="X-Frame-Options" content="deny"></meta>
       {/* to indicate the browser shouldn't interpret the response as something other than the specified content type */}
       <meta http-equiv="X-Content-Type-Options" content="nosniff"></meta>
-      {/* The Content-Security-Policy header is used to prevent a wide range of attacks, including Cross-Site Scripting (XSS) and other cross-site injections. */}
       {/* twitter metadata */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content={siteMetadata.twitterHandle} />

--- a/tools/walletextension/frontend/src/components/head-seo.tsx
+++ b/tools/walletextension/frontend/src/components/head-seo.tsx
@@ -24,6 +24,11 @@ const HeadSeo = ({
         // @ts-ignore
         signature="_vd3udx2g2hfn9zclob5cat43b94q7fyk"
       ></meta>
+      {/* SECURITY: to prevent the page from being loaded in an iFrame */}
+      <meta http-equiv="X-Frame-Options" content="deny"></meta>
+      {/* to indicate the browser shouldn't interpret the response as something other than the specified content type */}
+      <meta http-equiv="X-Content-Type-Options" content="nosniff"></meta>
+      {/* The Content-Security-Policy header is used to prevent a wide range of attacks, including Cross-Site Scripting (XSS) and other cross-site injections. */}
       {/* twitter metadata */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content={siteMetadata.twitterHandle} />


### PR DESCRIPTION
### Why this change is needed

Please provide a description and a link to the underlying ticket

https://github.com/ten-protocol/ten-internal/issues/3140
Add security headers as proposed by Beagle Security mitigation techniques

### What changes were made as part of this PR

Please provide a high level list of the changes made

- set `X-Frame-Options` to `deny` to prevent the page from being loaded in an iFrame
-  set `X-Content-Type-Options` to `nosniff` to indicate the browser shouldn't interpret the response as something other than the specified content type

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


