### PR TITLE
update ports

### DIFF
--- a/integration/constants.go
+++ b/integration/constants.go
@@ -1,21 +1,22 @@
 package integration
 
 // Tracks the start ports handed out to different tests, in a bid to minimise conflicts.
+// Note: the max should not exceed 30000 because the OS can use those ports and we'll get conflicts
 const (
 	StartPortEth2NetworkTests        = 10000
-	StartPortTenscanUnitTest         = 12000
-	StartPortNodeRunnerTest          = 14000
-	StartPortTenGatewayUnitTest      = 16000
-	StartPortSimulationGethInMem     = 18000
-	StartPortSimulationInMem         = 22000
-	StartPortSimulationFullNetwork   = 26000
-	StartPortNetworkTests            = 28000
-	StartPortSmartContractTests      = 30000
-	StartPortContractDeployerTest1   = 34000
-	StartPortContractDeployerTest2   = 35000
-	StartPortWalletExtensionUnitTest = 38000
-	StartPortFaucetUnitTest          = 42000
-	StartPortFaucetHTTPUnitTest      = 48000
+	StartPortTenscanUnitTest         = 11000
+	StartPortNodeRunnerTest          = 12000
+	StartPortTenGatewayUnitTest      = 13000
+	StartPortSimulationGethInMem     = 14000
+	StartPortSimulationInMem         = 15000
+	StartPortSimulationFullNetwork   = 16000
+	StartPortNetworkTests            = 17000
+	StartPortSmartContractTests      = 18000
+	StartPortContractDeployerTest1   = 19000
+	StartPortContractDeployerTest2   = 20000
+	StartPortWalletExtensionUnitTest = 21000
+	StartPortFaucetUnitTest          = 22000
+	StartPortFaucetHTTPUnitTest      = 23000
 
 	DefaultGethWSPortOffset         = 100
 	DefaultGethAUTHPortOffset       = 200

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -6,7 +6,6 @@ const (
 	StartPortEth2NetworkTests        = 10000
 	StartPortTenscanUnitTest         = 11000
 	StartPortNodeRunnerTest          = 12000
-	StartPortTenGatewayUnitTest      = 13000
 	StartPortSimulationGethInMem     = 14000
 	StartPortSimulationInMem         = 15000
 	StartPortSimulationFullNetwork   = 16000
@@ -17,6 +16,7 @@ const (
 	StartPortWalletExtensionUnitTest = 21000
 	StartPortFaucetUnitTest          = 22000
 	StartPortFaucetHTTPUnitTest      = 23000
+	StartPortTenGatewayUnitTest      = 24000
 
 	DefaultGethWSPortOffset         = 100
 	DefaultGethAUTHPortOffset       = 200

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -56,7 +56,7 @@ func (s *Simulation) Start() {
 
 	// Arbitrary sleep to wait for RPC clients to get up and running
 	// and for all l2 nodes to receive the genesis l2 batch
-	time.Sleep(5 * time.Second)
+	time.Sleep(6 * time.Second)
 
 	s.bridgeFundingToObscuro()
 	s.trackLogs()              // Create log subscriptions, to validate that they're working correctly later.


### PR DESCRIPTION
### Why this change is needed

to minimise port clashes, we stay under 32000 because the OSs use those (https://en.wikipedia.org/wiki/Ephemeral_port)

