### PR TITLE
3116 - Adds a log configuration to docker containers to roll

### DIFF
--- a/.github/workflows/runner-scripts/create-vm.txt
+++ b/.github/workflows/runner-scripts/create-vm.txt
@@ -5,6 +5,7 @@ az vm create \
   --resource-group Testnet \
   --name MakeImageVM \
   --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202206220 \
+  --security-type 'Standard' \
   --admin-username obscurouser --admin-password 'PWD'
 
 ssh obscurouser@IPADDRESS
@@ -18,9 +19,10 @@ exit
 
 az vm deallocate --resource-group Testnet --name MakeImageVM
 az vm generalize --resource-group Testnet --name MakeImageVM
+az image delete --resource-group Testnet --name ObscuroConfUbuntu
 az image create --resource-group Testnet --name ObscuroConfUbuntu --source MakeImageVM --hyper-v-generation V2
 
 az vm delete --resource-group Testnet --name MakeImageVM --yes
-az disk delete --resource-group Testnet --name MakeImageVM_OSDisk --yes
-az network nic delete --resource-group Testnet --name MakeImageVM_NIC
+az disk delete --resource-group Testnet --name MakeImageVM_OsDisk-<get uuid from azure> --yes --no-wait
+az network nic delete --resource-group Testnet --name MakeImageVMVMNIC --no-wait
 

--- a/.github/workflows/runner-scripts/create-vm.txt
+++ b/.github/workflows/runner-scripts/create-vm.txt
@@ -11,7 +11,7 @@ ssh obscurouser@IPADDRESS
 
 sudo apt-get update \
  && sudo apt-get install -y gcc \
- && sudo snap refresh && sudo snap install --channel=1.20 go --classic \
+ && sudo snap refresh && sudo snap install go --channel=1.21/stable --classic \
  && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh
 
 exit

--- a/go/common/docker/docker.go
+++ b/go/common/docker/docker.go
@@ -89,6 +89,12 @@ func StartNewContainer(containerName, image string, cmds []string, ports []int, 
 		exposedPorts[nat.Port(fmt.Sprintf("%d/tcp", port))] = struct{}{}
 	}
 
+	// set log rotations
+	logOptions := map[string]string{
+		"max-size": "10m",
+		"max-file": "3",
+	}
+
 	// create the container
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image:        image,
@@ -101,6 +107,7 @@ func StartNewContainer(containerName, image string, cmds []string, ports []int, 
 			PortBindings: portBindings,
 			Mounts:       mountVolumes,
 			Resources:    container.Resources{Devices: deviceMapping},
+			LogConfig:    container.LogConfig{Type: "json-file", Config: logOptions},
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{


### PR DESCRIPTION
### Why this change is needed

Containers (nodes) were crashing due to overflow of container logs (default is persisting internally to `json-file`) which had no rotation scheme.

### What changes were made as part of this PR

Added some log options to the standard rolling behavior of 10m per log file -> creation of new file when exceeding -> maximum historic files of 3 -> delete oldest on next rotation.

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] Run and inspected against Dev Testnet


