### PR TITLE
remove legacy signature type

### DIFF
--- a/go/common/viewingkey/viewing_key_messages.go
+++ b/go/common/viewingkey/viewing_key_messages.go
@@ -15,7 +15,6 @@ import (
 const (
 	EIP712Signature SignatureType = 0
 	PersonalSign    SignatureType = 1
-	Legacy          SignatureType = 2
 )
 
 // SignatureType is used to differentiate between different signature types (string is used, because int is not RLP-serializable)
@@ -32,7 +31,6 @@ const (
 	EIP712DomainVersionValue  = "1.0"
 	UserIDHexLength           = 40
 	PersonalSignMessageFormat = "Token: %s on chain: %d version: %d"
-	SignedMsgPrefix           = "vk" // prefix for legacy signed messages (remove when legacy signature type is removed)
 	PersonalSignVersion       = 1
 )
 
@@ -125,13 +123,6 @@ func GetMessageHash(message []byte, signatureType SignatureType) ([]byte, error)
 		return nil, fmt.Errorf("unsupported signature type")
 	}
 	return hashFunction.getMessageHash(message), nil
-}
-
-// GenerateSignMessage creates the message to be signed
-// vkPubKey is expected to be a []byte("0x....") to create the signing message
-// todo (@ziga) Remove this method once old WE endpoints are removed
-func GenerateSignMessage(vkPubKey []byte) string {
-	return SignedMsgPrefix + hex.EncodeToString(vkPubKey)
 }
 
 // getBytesFromTypedData creates EIP-712 compliant hash from typedData.

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -51,12 +51,6 @@ func checkViewingKeyAndRecoverAddress(vk *AuthenticatedViewingKey, chainID int64
 	userID := viewingkey.CalculateUserIDHex(vk.rpcVK.PublicKey)
 	vk.UserID = userID
 
-	// todo - remove this when the legacy format is no longer supported
-	// this is a temporary fix to support the legacy format which will be removed soon
-	if vk.rpcVK.SignatureType == viewingkey.Legacy {
-		userID = string(vk.rpcVK.PublicKey) // for legacy format, the userID is the public key
-	}
-
 	// check the signature and recover the address assuming the message was signed with EIP712
 	recoveredSignerAddress, err := viewingkey.CheckSignature(userID, vk.rpcVK.SignatureWithAccountKey, chainID, vk.rpcVK.SignatureType)
 	if err != nil {

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -30,8 +30,6 @@ const (
 	PathRoot                            = "/"
 	PathReady                           = "/ready/"
 	PathViewingKeys                     = "/viewingkeys/"
-	PathGenerateViewingKey              = "/generateviewingkey/"
-	PathSubmitViewingKey                = "/submitviewingkey/"
 	PathJoin                            = "/join/"
 	PathGetMessage                      = "/getmessage/"
 	PathAuthenticate                    = "/authenticate/"


### PR DESCRIPTION
### Why this change is needed

I already removed old wallet extension endpoints from the gateway. Now we only use and produce new signatures (EIP712 and PersonalSign). There is no need to support old legacy format anymore and it just adds additional complexity to our codebase. 

### What changes were made as part of this PR

Removed old legacy format for signed viewing keys.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


