### PR TITLE
Host config: renamed flag fix

### DIFF
--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -95,7 +95,7 @@ func (d *DockerNode) startHost() error {
 	cmd := []string{
 		"/home/obscuro/go-obscuro/go/host/main/main",
 		"-l1WSURL", d.cfg.l1WSURL,
-		"-enclaveRPCAddress", fmt.Sprintf("%s:%d", d.cfg.nodeName+"-enclave", d.cfg.enclaveWSPort),
+		"-enclaveRPCAddresses", fmt.Sprintf("%s:%d", d.cfg.nodeName+"-enclave", d.cfg.enclaveWSPort),
 		"-managementContractAddress", d.cfg.managementContractAddr,
 		"-messageBusContractAddress", d.cfg.messageBusContractAddress,
 		"-l1Start", d.cfg.l1Start,

--- a/testnet/docker-compose.debug.yml
+++ b/testnet/docker-compose.debug.yml
@@ -26,7 +26,7 @@ services:
       "/home/obscuro/go-obscuro/go/host/main/main",
       "--l1NodeHost=$L1HOST",
       "--l1NodePort=$L1PORT",
-      "--enclaveRPCAddress=enclave:11000",
+      "--enclaveRPCAddresses=enclave:11000",
       "--managementContractAddress=$MGMTCONTRACTADDR",
       "--messageBusContractAddress=$MSGBUSCONTRACTADDR",
       "--privateKey=$PKSTRING",

--- a/testnet/docker-compose.non-sgx.yml
+++ b/testnet/docker-compose.non-sgx.yml
@@ -27,7 +27,7 @@ services:
       "/home/obscuro/go-obscuro/go/host/main/main",
       "--l1NodeHost=$L1HOST",
       "--l1NodePort=$L1PORT",
-      "--enclaveRPCAddress=enclave:11000",
+      "--enclaveRPCAddresses=enclave:11000",
       "--managementContractAddress=$MGMTCONTRACTADDR",
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",

--- a/testnet/docker-compose.yml
+++ b/testnet/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       "/home/obscuro/go-obscuro/go/host/main/main",
       "--l1NodeHost=$L1HOST",
       "--l1NodePort=$L1PORT",
-      "--enclaveRPCAddress=enclave:11000",
+      "--enclaveRPCAddresses=enclave:11000",
       "--managementContractAddress=$MGMTCONTRACTADDR",
       "--privateKey=$PKSTRING",
       "--clientRPCHost=0.0.0.0",


### PR DESCRIPTION
### Why this change is needed

Missed some flag usages when I changed the flag name on this recent PR https://github.com/ten-protocol/go-ten/pull/1852

### What changes were made as part of this PR

`enclaveRPCAddress` -> `enclaveRPCAddresses` in host flags.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


