### PR TITLE
Use conn pool for plaintext rpc

### DIFF
--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -68,8 +68,14 @@ func NewEncRPCClient(client Client, viewingKey *viewingkey.ViewingKey, logger ge
 	return encClient, nil
 }
 
-func (c *EncRPCClient) Client() Client {
-	return c.obscuroClient
+func (c *EncRPCClient) Client() *gethrpc.Client {
+	switch backingClient := c.obscuroClient.(type) {
+	case *NetworkClient:
+		return backingClient.RpcClient
+	default:
+		// not supported
+		return nil
+	}
 }
 
 // Call handles JSON rpc requests without a context - see CallContext for details

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -190,7 +190,7 @@ func handleUnsubscribe(connectionSub *rpc.Subscription, backendSubscriptions []*
 		backendSub.Unsubscribe()
 	}
 	for _, connection := range connections {
-		_ = returnConn(p, connection)
+		_ = returnConn(p, connection.Client())
 	}
 }
 

--- a/tools/walletextension/rpcapi/wallet_extension.go
+++ b/tools/walletextension/rpcapi/wallet_extension.go
@@ -226,10 +226,6 @@ func (w *Services) GetTenNodeHealthStatus() (bool, error) {
 	return w.tenClient.Health()
 }
 
-func (w *Services) UnauthenticatedClient() (rpc.Client, error) {
-	return rpc.NewNetworkClient(w.HostAddrHTTP)
-}
-
 func (w *Services) GenerateUserMessageToSign(encryptionToken []byte, formatsSlice []string) (string, error) {
 	// Check if the formats are valid
 	for _, format := range formatsSlice {


### PR DESCRIPTION
### Why this change is needed

Improve resource consumption

### What changes were made as part of this PR

use the existing pool for UnauthRPC

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


