### PR TITLE
Ziga/fix gateway frontend issues after geth rpc

### DIFF
--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -29,6 +29,7 @@ const (
 	EncryptedTokenQueryParameter        = "token"
 	AddressQueryParameter               = "a"
 	MessageUserIDLen                    = 40
+	MessageUserIDLenWithPrefix          = 42
 	EthereumAddressLen                  = 42
 	GetStorageAtUserIDRequestMethodName = "0x0000000000000000000000000000000000000000"
 	SuccessMsg                          = "success"

--- a/tools/walletextension/frontend/src/api/ethRequests.ts
+++ b/tools/walletextension/frontend/src/api/ethRequests.ts
@@ -151,7 +151,7 @@ export async function authenticateAccountWithTenGatewayEIP712(
       ...typedData,
       message: {
         ...typedData.message,
-        "Encryption Token": "0x" + token,
+        "Encryption Token":  token,
       },
     };
     const signature = await getSignature(account, data);

--- a/tools/walletextension/frontend/src/lib/constants.ts
+++ b/tools/walletextension/frontend/src/lib/constants.ts
@@ -35,7 +35,7 @@ export const testnetUrls = {
 };
 
 export const SWITCHED_CODE = 4902;
-export const tokenHexLength = 40;
+export const tokenHexLength = 42;
 
 export const tenGatewayVersion = "v1";
 export const tenChainIDDecimal = 443;

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -283,11 +283,28 @@ func networkHealthRequestHandler(walletExt *rpcapi.Services, userConn UserConn) 
 		return
 	}
 
+	// call `obscuro-health` rpc method to get the health status of the node
 	healthStatus, err := walletExt.GetTenNodeHealthStatus()
 
+	// create the response in the required format
+	type HealthStatus struct {
+		Errors        []string `json:"Errors"`
+		OverallHealth bool     `json:"OverallHealth"`
+	}
+
+	errorStrings := make([]string, 0)
+	if err != nil {
+		errorStrings = append(errorStrings, err.Error())
+	}
+	healthStatusResponse := HealthStatus{
+		Errors:        errorStrings,
+		OverallHealth: healthStatus,
+	}
+
 	data, err := json.Marshal(map[string]interface{}{
-		"result": healthStatus,
-		"error":  err,
+		"id":      "1",
+		"jsonrpc": "2.0",
+		"result":  healthStatusResponse,
 	})
 	if err != nil {
 		walletExt.Logger().Error("error marshaling response", log.ErrKey, err)

--- a/tools/walletextension/httpapi/utils.go
+++ b/tools/walletextension/httpapi/utils.go
@@ -25,10 +25,10 @@ func getUserID(conn UserConn) ([]byte, error) {
 	// try getting userID (`token`) from query parameters and return it if successful
 	userID, err := getQueryParameter(conn.ReadRequestParams(), common.EncryptedTokenQueryParameter)
 	if err == nil {
-		if len(userID) != common.MessageUserIDLen {
+		if len(userID) != common.MessageUserIDLenWithPrefix {
 			return nil, fmt.Errorf(fmt.Sprintf("wrong length of userID from URL. Got: %d, Expected: %d", len(userID), common.MessageUserIDLen))
 		}
-		return hexutils.HexToBytes(userID), err
+		return hexutils.HexToBytes(userID[2:]), err
 	}
 
 	return nil, fmt.Errorf("missing token field")

--- a/tools/walletextension/httpapi/utils.go
+++ b/tools/walletextension/httpapi/utils.go
@@ -26,7 +26,7 @@ func getUserID(conn UserConn) ([]byte, error) {
 	userID, err := getQueryParameter(conn.ReadRequestParams(), common.EncryptedTokenQueryParameter)
 	if err == nil {
 		if len(userID) != common.MessageUserIDLenWithPrefix {
-			return nil, fmt.Errorf(fmt.Sprintf("wrong length of userID from URL. Got: %d, Expected: %d", len(userID), common.MessageUserIDLen))
+			return nil, fmt.Errorf(fmt.Sprintf("wrong length of userID from URL. Got: %d, Expected: %d", len(userID), common.MessageUserIDLenWithPrefix))
 		}
 		return hexutils.HexToBytes(userID[2:]), err
 	}

--- a/tools/walletextension/lib/client_lib.go
+++ b/tools/walletextension/lib/client_lib.go
@@ -74,7 +74,7 @@ func (o *TGLib) RegisterAccount(pk *ecdsa.PrivateKey, addr gethcommon.Address) e
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
-		o.httpURL+"/v1/authenticate/?token="+hexutils.BytesToHex(o.userID),
+		o.httpURL+"/v1/authenticate/?token=0x"+hexutils.BytesToHex(o.userID),
 		strings.NewReader(payload),
 	)
 	if err != nil {
@@ -124,7 +124,7 @@ func (o *TGLib) RegisterAccountPersonalSign(pk *ecdsa.PrivateKey, addr gethcommo
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
-		o.httpURL+"/v1/authenticate/?token="+hexutils.BytesToHex(o.userID),
+		o.httpURL+"/v1/authenticate/?token=0x"+hexutils.BytesToHex(o.userID),
 		strings.NewReader(payload),
 	)
 	if err != nil {

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	walletExtensionAddr := fmt.Sprintf("%s:%d", common.Localhost, config.WalletExtensionPortHTTP)
 	fmt.Printf("💡 Wallet extension started \n") // Some tests rely on seeing this message. Removed in next PR.
-	fmt.Printf("💡 Obscuro Gateway started - visit http://%s to use it.\n", walletExtensionAddr)
+	fmt.Printf("💡 Obscuro Gateway started - visit http://%s/static to use it.\n", walletExtensionAddr)
 
 	select {}
 }


### PR DESCRIPTION
### Why this change is needed

After merging PR with Geth RPC there were some frontend issues. But we decided to fix them in this PR.

### What changes were made as part of this PR

- fixed the response of the `/network-health` endpoint (before this endpoint was not used and request was forwarded to ethereumRPC handler which forwarded the response to the node. After implementing geth RPC we don't have that endpoint and this endpoint was actually called. I decided to return the response in the same format as before).

- fixed some differences regarding encryptionToken and `0x` prefix that emerged in that PR.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


