### PR TITLE
add vk check

### DIFF
--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -66,6 +66,25 @@ type RPCSignedViewingKey struct {
 	SignatureWithAccountKey []byte
 }
 
+const (
+	pubKeyLen = 33
+	sigLen    = 65
+)
+
+func (vk RPCSignedViewingKey) Validate() error {
+	// todo - remove this when merging to main
+	if vk.Account == nil {
+		return fmt.Errorf("invalid account in viewing key")
+	}
+	if len(vk.PublicKey) != pubKeyLen {
+		return fmt.Errorf("invalid viewing key")
+	}
+	if len(vk.SignatureWithAccountKey) != sigLen {
+		return fmt.Errorf("invalid viewing key signature")
+	}
+	return nil
+}
+
 // GenerateViewingKeyForWallet takes an account wallet, generates a viewing key and signs the key with the acc's private key
 // uses the same method of signature handling as Metamask/geth
 func GenerateViewingKeyForWallet(wal wallet.Wallet) (*ViewingKey, error) {

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -26,6 +26,11 @@ type AuthenticatedViewingKey struct {
 }
 
 func VerifyViewingKey(rpcVK *viewingkey.RPCSignedViewingKey, chainID int64) (*AuthenticatedViewingKey, error) {
+	err := rpcVK.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	vkPubKey, err := crypto.DecompressPubkey(rpcVK.PublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("could not decompress viewing key bytes - %w", err)


### PR DESCRIPTION
### Why this change is needed

avoid crashing enclave when the vk is invalid

### What changes were made as part of this PR

validate the vk before processing

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


