### PR TITLE
Tudor/validate vk

### DIFF
--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -37,10 +37,6 @@ const (
 )
 
 func (vk RPCSignedViewingKey) Validate() error {
-	// todo - remove this when merging to main
-	if vk.Account == nil {
-		return fmt.Errorf("invalid account in viewing key")
-	}
 	if len(vk.PublicKey) != pubKeyLen {
 		return fmt.Errorf("invalid viewing key")
 	}

--- a/go/common/viewingkey/viewing_key.go
+++ b/go/common/viewingkey/viewing_key.go
@@ -31,6 +31,25 @@ type RPCSignedViewingKey struct {
 	SignatureType           SignatureType
 }
 
+const (
+	pubKeyLen = 33
+	sigLen    = 65
+)
+
+func (vk RPCSignedViewingKey) Validate() error {
+	// todo - remove this when merging to main
+	if vk.Account == nil {
+		return fmt.Errorf("invalid account in viewing key")
+	}
+	if len(vk.PublicKey) != pubKeyLen {
+		return fmt.Errorf("invalid viewing key")
+	}
+	if len(vk.SignatureWithAccountKey) != sigLen {
+		return fmt.Errorf("invalid viewing key signature")
+	}
+	return nil
+}
+
 // GenerateViewingKeyForWallet takes an account wallet, generates a viewing key and signs the key with the acc's private key
 func GenerateViewingKeyForWallet(wal wallet.Wallet) (*ViewingKey, error) {
 	chainID := wal.ChainID().Int64()

--- a/go/enclave/vkhandler/vk_handler.go
+++ b/go/enclave/vkhandler/vk_handler.go
@@ -25,6 +25,11 @@ type AuthenticatedViewingKey struct {
 }
 
 func VerifyViewingKey(rpcVK *viewingkey.RPCSignedViewingKey, chainID int64) (*AuthenticatedViewingKey, error) {
+	err := rpcVK.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	vkPubKey, err := crypto.DecompressPubkey(rpcVK.PublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("could not decompress viewing key bytes - %w", err)


### PR DESCRIPTION
### Why this change is needed

to avoid unexpected behaviour on invalid vk formats

### What changes were made as part of this PR

validate the vk 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


