### PR TITLE
Host: notify batch subscribers of new batches from any src

### DIFF
--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -97,12 +97,6 @@ func (s *StateTracker) OnReceivedBlock(l1Head gethcommon.Hash) {
 func (s *StateTracker) OnProcessedBatch(enclL2HeadSeqNo *big.Int) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	if s.hostL2Head == nil || s.hostL2Head.Cmp(enclL2HeadSeqNo) < 0 {
-		// we've successfully processed this batch, so the host's head should be at least as high as the enclave's (this shouldn't happen, we want it to be visible if it happens)
-		s.logger.Trace("host head behind enclave head - updating to match", "hostHead", s.hostL2Head, "enclaveHead", enclL2HeadSeqNo)
-		s.hostL2Head = enclL2HeadSeqNo
-	}
-
 	s.enclaveL2Head = enclL2HeadSeqNo
 	s.setStatus(s.calculateStatus())
 }


### PR DESCRIPTION
### Why this change is needed

The L2 batch repo only notifies subscribers of new batches from p2p source. This was convenient but confusing.

It is more re-usable if it notifies on every batch that is new to the host, so it will work for sequencers.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


