### PR TITLE
Fix parsing both tokens with 0x prefix and without it

### DIFF
--- a/tools/walletextension/httpapi/utils.go
+++ b/tools/walletextension/httpapi/utils.go
@@ -25,10 +25,13 @@ func getUserID(conn UserConn) ([]byte, error) {
 	// try getting userID (`token`) from query parameters and return it if successful
 	userID, err := getQueryParameter(conn.ReadRequestParams(), common.EncryptedTokenQueryParameter)
 	if err == nil {
-		if len(userID) != common.MessageUserIDLenWithPrefix {
-			return nil, fmt.Errorf(fmt.Sprintf("wrong length of userID from URL. Got: %d, Expected: %d", len(userID), common.MessageUserIDLenWithPrefix))
+		if len(userID) == common.MessageUserIDLenWithPrefix {
+			return hexutils.HexToBytes(userID[2:]), nil
+		} else if len(userID) == common.MessageUserIDLen {
+			return hexutils.HexToBytes(userID), nil
 		}
-		return hexutils.HexToBytes(userID[2:]), err
+
+		return nil, fmt.Errorf(fmt.Sprintf("wrong length of userID from URL. Got: %d, Expected: %d od %d", len(userID), common.MessageUserIDLenWithPrefix, common.MessageUserIDLen))
 	}
 
 	return nil, fmt.Errorf("missing token field")


### PR DESCRIPTION
### Why this change is needed

This is a temporary fix that enables local testnet again.
In a separate PR I will provide full solution with consistent usage of `0x` prefix and fixed gateway issues.

Local testnet was successfully started with this branch: https://github.com/ten-protocol/ten-test/actions/runs/8543430314/job/23407243846

### What changes were made as part of this PR

 accept both tokens with `0x` prefix and without it.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


