### PR TITLE
fix the EIP712 getmessage response

### DIFF
--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -415,7 +415,6 @@ func getMessageRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 			return
 		}
 	} else if messageFormat == viewingkey.EIP712Signature {
-
 		var messageMap map[string]interface{}
 		err = json.Unmarshal([]byte(message), &messageMap)
 		if err != nil {


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3232 

EIP712 message format was not user friendly to use and users needed to perform manipulations on it to make it work.
This needs to be done in the gateway so that users can use it out of the box.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


