### PR TITLE
Ziga/add gateway reverse proxy

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -137,5 +137,5 @@ jobs:
             && docker run -d -p 80:80 -p 81:81 --name ${{ github.event.inputs.testnet_type }}-OG-${{ GITHUB.RUN_NUMBER }} \
               -e OBSCURO_GATEWAY_VERSION="${{ GITHUB.RUN_NUMBER }}-${{ GITHUB.SHA }}" \
                ${{ vars.DOCKER_BUILD_TAG_GATEWAY }} \
-               ./wallet_extension_linux -host=0.0.0.0 -port=80 -portWS=81 -nodeHost=${{ vars.L2_RPC_URL_VALIDATOR }} \
+               -host=0.0.0.0 -port=8080 -portWS=81 -nodeHost=${{ vars.L2_RPC_URL_VALIDATOR }} \
                -logPath=sys_out -dbType=mariaDB -dbConnectionURL="obscurouser:${{ secrets.OBSCURO_GATEWAY_MARIADB_USER_PWD }}@tcp(obscurogateway-mariadb-${{  github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:3306)/ogdb"'

--- a/tools/walletextension/Dockerfile
+++ b/tools/walletextension/Dockerfile
@@ -55,10 +55,22 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Lightweight final build stage. Includes bare minimum to start wallet extension
 FROM alpine:3.18
 
+# Install NGINX
+RUN apk update && apk add nginx
+
 # copy over the gateway executable
 COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/bin /home/obscuro/go-obscuro/tools/walletextension/bin
 
 # copy over the .sql migration files
 COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/storage/database /home/obscuro/go-obscuro/tools/walletextension/storage/database
 
-WORKDIR /home/obscuro/go-obscuro/tools/walletextension/bin
+# copy over the NGINX configuration file
+COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/nginx.conf /etc/nginx/nginx.conf
+
+
+# copy over the entrypoint script
+COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/tools/walletextension/entrypoint.sh
+++ b/tools/walletextension/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Start NGINX in the background
+nginx &
+
+# Start wallet_extension_linux with parameters passed to the script
+/home/obscuro/go-obscuro/tools/walletextension/bin/wallet_extension_linux "$@"
+
+# Wait for any process to exit
+wait -n
+
+# Exit with the status of the process that exited first
+exit $?

--- a/tools/walletextension/nginx.conf
+++ b/tools/walletextension/nginx.conf
@@ -1,0 +1,27 @@
+events {
+        worker_connections  4096;
+}
+
+http {
+    server {
+        listen 80;
+
+        location = / {
+            proxy_pass http://localhost:8080/static/; # Redirects only the root URL
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        location / {
+            proxy_pass http://localhost:8080; # Pass all other requests to the app
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
+}

--- a/tools/walletextension/storage/database/mariadb/003_add_signature_type.sql
+++ b/tools/walletextension/storage/database/mariadb/003_add_signature_type.sql
@@ -1,2 +1,1 @@
-ALTER TABLE ogdb.accounts
-ADD COLUMN signature_type INT DEFAULT 0;
+ALTER TABLE ogdb.accounts ADD COLUMN IF NOT EXISTS signature_type INT DEFAULT 0;


### PR DESCRIPTION
### Why this change is needed

After RPC changes website and static files are served from `/static`. We want to keep serving website from root `/` as this is much more user friendly and keep API endpoints untouched at `/v1`.

### What changes were made as part of this PR

- nginx is used as a reverse proxy (there are some additional changes needed in Dockefile, githib actions, etc. to make it work in Docker while allowing us to have same deployment process with Github actions).
- small bug with migrations was discovered and is also fixed with this bug (`ADD COLUMN IF NOT EXISTS`)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


