### PR TITLE
Simplify EncryptedRPC Client

### DIFF
--- a/go/common/subscription/utils.go
+++ b/go/common/subscription/utils.go
@@ -35,14 +35,14 @@ func ForwardFromChannels[R any](inputChannels []chan R, unsubscribed *atomic.Boo
 			continue
 		}
 
-		if unsubscribed.Load() {
+		if unsubscribed != nil && unsubscribed.Load() {
 			return
 		}
 
 		switch v := value.Interface().(type) {
 		case time.Time:
 			// exit the loop to avoid a goroutine leak
-			if unsubscribed.Load() {
+			if unsubscribed != nil && unsubscribed.Load() {
 				return
 			}
 		case R:

--- a/go/enclave/events/subscription_manager.go
+++ b/go/enclave/events/subscription_manager.go
@@ -60,7 +60,7 @@ func NewSubscriptionManager(storage storage.Storage, chainID int64, logger gethl
 func (s *SubscriptionManager) AddSubscription(id gethrpc.ID, encodedSubscription []byte) error {
 	subscription := &common.LogSubscription{}
 	if err := json.Unmarshal(encodedSubscription, subscription); err != nil {
-		return fmt.Errorf("could not decocde log subscription from RLP. Cause: %w", err)
+		return fmt.Errorf("could not decode log subscription. Cause: %w", err)
 	}
 
 	// verify the viewing key

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -102,11 +102,7 @@ func EstimateGasExecute(builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64
 		}
 
 		// return EVM error
-		evmErr, err := serializeEVMError(err)
-		if err == nil {
-			err = fmt.Errorf(string(evmErr))
-		}
-		builder.Err = err
+		builder.Err = convertError(err)
 		return nil
 	}
 

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -56,24 +56,9 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 		return nil, fmt.Errorf("could not subscribe for logs. Cause: %w", err)
 	}
 
-	// We send the ID of the newly-created subscription, before sending any log events. This is because the wallet
-	// extension needs to return the subscription ID to the end client, but this information is not exposed to it
-	// (since the subscription ID is automatically converted to a subscription object).
-	err = notifier.Notify(subscription.ID, common.IDAndEncLog{
-		SubID: subscription.ID,
-	})
-	if err != nil {
-		api.host.UnsubscribeLogs(subscription.ID)
-		return nil, fmt.Errorf("could not send subscription ID to client on subscription %s", subscription.ID)
-	}
-
 	var unsubscribed atomic.Bool
 	go subscriptioncommon.ForwardFromChannels([]chan []byte{logsFromSubscription}, &unsubscribed, func(elem []byte) error {
-		msg := &common.IDAndEncLog{
-			SubID:  subscription.ID,
-			EncLog: elem,
-		}
-		return notifier.Notify(subscription.ID, msg)
+		return notifier.Notify(subscription.ID, elem)
 	})
 	go subscriptioncommon.HandleUnsubscribe(subscription, &unsubscribed, func() {
 		api.host.UnsubscribeLogs(subscription.ID)

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -191,7 +191,7 @@ func (ac *AuthObsClient) BalanceAt(ctx context.Context, blockNumber *big.Int) (*
 	return (*big.Int)(&result), err
 }
 
-func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria common.FilterCriteria, ch chan common.IDAndLog) (ethereum.Subscription, error) {
+func (ac *AuthObsClient) SubscribeFilterLogs(ctx context.Context, filterCriteria common.FilterCriteria, ch chan types.Log) (ethereum.Subscription, error) {
 	return ac.rpcClient.Subscribe(ctx, rpc.SubscribeNamespace, ch, rpc.SubscriptionTypeLogs, filterCriteria)
 }
 

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -5,17 +5,15 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/ten-protocol/go-ten/go/common/subscription"
 	"reflect"
-	"sync/atomic"
 
 	"github.com/ten-protocol/go-ten/go/common/rpc"
+	"github.com/ten-protocol/go-ten/go/common/subscription"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ten-protocol/go-ten/go/common"
-	"github.com/ten-protocol/go-ten/go/common/errutil"
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"github.com/ten-protocol/go-ten/go/responses"
@@ -51,7 +49,7 @@ type EncRPCClient struct {
 	logger           gethlog.Logger
 }
 
-// NewEncRPCClient sets up a client with a viewing key for encrypted communication
+// NewEncRPCClient wrapper over rpc clients with a viewing key for encrypted communication
 func NewEncRPCClient(client Client, viewingKey *viewingkey.ViewingKey, logger gethlog.Logger) (*EncRPCClient, error) {
 	// todo: this is a convenience for testnet but needs to replaced by a parameter and/or retrieved from the target host
 	enclPubECDSA, err := crypto.DecompressPubkey(gethcommon.Hex2Bytes(enclavePublicKeyHex))
@@ -102,8 +100,7 @@ func (c *EncRPCClient) Subscribe(ctx context.Context, namespace string, ch inter
 		return nil, fmt.Errorf("missing subscription type")
 	}
 
-	subscriptionType := args[0]
-	switch subscriptionType {
+	switch args[0] {
 	case SubscriptionTypeLogs:
 		return c.logSubscription(ctx, namespace, ch, args...)
 	case SubscriptionTypeNewHeads:
@@ -155,19 +152,6 @@ func (c *EncRPCClient) executeSensitiveCall(ctx context.Context, result interfac
 
 	// If there is a user error that was decrypted we return it
 	if decodedError != nil {
-		// EstimateGas and Call methods return EVM Errors that are json objects
-		// and contain multiple keys that normally do not get serialized
-		if method == EstimateGas || method == Call {
-			var evmErr errutil.EVMSerialisableError
-			err = json.Unmarshal([]byte(decodedError.Error()), &evmErr)
-			if err != nil {
-				return decodedError
-			}
-			// Return the evm user error.
-			return evmErr
-		}
-
-		// Return the user error.
 		return decodedError
 	}
 
@@ -240,8 +224,14 @@ func (c *EncRPCClient) decryptResponse(encryptedBytes []byte) ([]byte, error) {
 	return decryptedResult, nil
 }
 
+// creates a subscription to the Ten node, but decrypts the messages from that channel and forwards them to the `ch`
 func (c *EncRPCClient) logSubscription(ctx context.Context, namespace string, ch interface{}, args ...any) (*gethrpc.ClientSubscription, error) {
-	logSubscription, err := c.createAuthenticatedLogSubscription(args)
+	outboundChannel, ok := ch.(chan types.Log)
+	if !ok {
+		return nil, fmt.Errorf("expected a channel of type `chan types.Log`, got %T", ch)
+	}
+
+	logSubscription, err := common.CreateAuthenticatedLogSubscriptionPayload(args, c.viewingKey)
 	if err != nil {
 		return nil, err
 	}
@@ -256,19 +246,17 @@ func (c *EncRPCClient) logSubscription(ctx context.Context, namespace string, ch
 		return nil, fmt.Errorf("failed to encrypt args for subscription in namespace %s - %w", namespace, err)
 	}
 
-	outputChannel, ok := ch.(chan common.IDAndLog)
-	if !ok {
-		return nil, fmt.Errorf("expected a channel of type `chan types.Log`, got %T", ch)
-	}
-	inputChannel := make(chan common.IDAndEncLog)
-	backendSub, err := c.obscuroClient.Subscribe(ctx, namespace, inputChannel, SubscriptionTypeLogs, encryptedParams)
+	// the node sends encrypted logs
+	inboundChannel := make(chan []byte)
+	backendSub, err := c.obscuroClient.Subscribe(ctx, namespace, inboundChannel, SubscriptionTypeLogs, encryptedParams)
 	if err != nil {
 		return nil, err
 	}
 
-	unsubscribed := atomic.Bool{}
-	go subscription.ForwardFromChannels([]chan common.IDAndEncLog{inputChannel}, &unsubscribed, func(idAndEncLog common.IDAndEncLog) error {
-		jsonLogs, err := c.decryptResponse(idAndEncLog.EncLog)
+	// todo - do we need to handle unsubscribe in a special way?
+	// probably not, because when the inbound channel is closed, this goroutine will exit as well.
+	go subscription.ForwardFromChannels([]chan []byte{inboundChannel}, nil, func(encLog []byte) error {
+		jsonLogs, err := c.decryptResponse(encLog)
 		if err != nil {
 			c.logger.Error("could not decrypt logs received from subscription.", log.ErrKey, err)
 			return err
@@ -282,41 +270,12 @@ func (c *EncRPCClient) logSubscription(ctx context.Context, namespace string, ch
 		}
 
 		for _, decryptedLog := range logs {
-			idAndLog := common.IDAndLog{
-				SubID: idAndEncLog.SubID,
-				Log:   decryptedLog,
-			}
-			outputChannel <- idAndLog
+			outboundChannel <- *decryptedLog
 		}
 		return nil
 	})
-	subscription.HandleUnsubscribe()
 
 	return backendSub, nil
-}
-
-func (c *EncRPCClient) createAuthenticatedLogSubscription(args []interface{}) (*common.LogSubscription, error) {
-	logSubscription := &common.LogSubscription{
-		ViewingKey: &viewingkey.RPCSignedViewingKey{
-			PublicKey:               c.viewingKey.PublicKey,
-			SignatureWithAccountKey: c.viewingKey.SignatureWithAccountKey,
-			SignatureType:           c.viewingKey.SignatureType,
-		},
-	}
-
-	// If there are less than two arguments, it means no filter criteria was passed.
-	if len(args) < 2 {
-		logSubscription.Filter = &common.FilterCriteriaJSON{}
-		return logSubscription, nil
-	}
-
-	filterCriteria, ok := args[1].(common.FilterCriteria)
-	if !ok {
-		return nil, fmt.Errorf("invalid subscription")
-	}
-	fc := common.FromCriteria(filterCriteria)
-	logSubscription.Filter = &fc
-	return logSubscription, nil
 }
 
 func (c *EncRPCClient) newHeadSubscription(ctx context.Context, namespace string, ch interface{}, args ...any) (*gethrpc.ClientSubscription, error) {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -41,8 +41,8 @@ type Simulation struct {
 	SimulationTime   time.Duration
 	Stats            *stats.Stats
 	Params           *params.SimParams
-	LogChannels      map[string][]chan common.IDAndLog // Maps an owner to the channels on which they receive logs for each client.
-	Subscriptions    []ethereum.Subscription           // A slice of all created event subscriptions.
+	LogChannels      map[string][]chan types.Log // Maps an owner to the channels on which they receive logs for each client.
+	Subscriptions    []ethereum.Subscription     // A slice of all created event subscriptions.
 	ctx              context.Context
 }
 
@@ -185,10 +185,10 @@ func (s *Simulation) trackLogs() {
 
 	for owner, clients := range s.RPCHandles.AuthObsClients {
 		// There is a subscription, and corresponding log channel, per owner per client.
-		s.LogChannels[owner] = []chan common.IDAndLog{}
+		s.LogChannels[owner] = []chan types.Log{}
 
 		for _, client := range clients {
-			channel := make(chan common.IDAndLog, 1000)
+			channel := make(chan types.Log, 1000)
 
 			// To exercise the filtering mechanism, we subscribe for HOC events only, ignoring POC events.
 			hocFilter := common.FilterCriteria{

--- a/integration/simulation/simulation_tester.go
+++ b/integration/simulation/simulation_tester.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ten-protocol/go-ten/integration/common/testlog"
+	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/ten-protocol/go-ten/go/common"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ten-protocol/go-ten/integration/simulation/network"
@@ -61,7 +61,7 @@ func testSimulation(t *testing.T, netw network.Network, params *params.SimParams
 		SimulationTime:   params.SimulationTime,
 		Stats:            stats,
 		Params:           params,
-		LogChannels:      make(map[string][]chan common.IDAndLog),
+		LogChannels:      make(map[string][]chan types.Log),
 		Subscriptions:    []ethereum.Subscription{},
 	}
 

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -610,15 +610,15 @@ func checkReceivedLogs(t *testing.T, s *Simulation) {
 }
 
 // Checks that a subscription has received the expected logs.
-func checkSubscribedLogs(t *testing.T, owner string, channel chan common.IDAndLog) int {
+func checkSubscribedLogs(t *testing.T, owner string, channel chan types.Log) int {
 	var logs []*types.Log
 
 	for {
 		if len(channel) == 0 {
 			break
 		}
-		idAndLog := <-channel
-		logs = append(logs, idAndLog.Log)
+		log := <-channel
+		logs = append(logs, &log)
 	}
 
 	assertLogsValid(t, owner, logs)

--- a/lib/gethfork/rpc/client.go
+++ b/lib/gethfork/rpc/client.go
@@ -511,7 +511,6 @@ func (c *Client) ShhSubscribe(ctx context.Context, channel interface{}, args ...
 // before considering the subscriber dead. The subscription Err channel will receive
 // ErrSubscriptionQueueOverflow. Use a sufficiently large buffer on the channel or ensure
 // that the channel usually has at least one reader to prevent this issue.
-// Subscribe creates a subscription to the Obscuro host.
 func (c *Client) Subscribe(ctx context.Context, namespace string, channel interface{}, args ...interface{}) (*ClientSubscription, error) {
 	// Check type of channel first.
 	chanVal := reflect.ValueOf(channel)


### PR DESCRIPTION
### Why this change is needed

To remove unnecessary operations and clarify responsabilities

### What changes were made as part of this PR

- remove unnecessary IDAndLog and IDAndEncLog types
- use the standard message forwarder for the encrypted log subscription
- remove unnecessary marshalling and unmarshalling of the the evm errors and the extra custom logic in the encrypted rpc client

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


