### PR TITLE
Set max Postgres DB Connections

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -120,7 +120,7 @@ jobs:
             databases=$(az postgres flexible-server db list --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --query "[?starts_with(name, 'host_')].[name]" -o tsv)
 
             for db in $databases; do
-              az postgres db delete --name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }}.postgres.database.azure.com --yes
+              az postgres flexible-server db delete --name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --yes
             done
 
       - name: 'Upload L1 deployer container logs'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -120,7 +120,7 @@ jobs:
             databases=$(az postgres flexible-server db list --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --query "[?starts_with(name, 'host_')].[name]" -o tsv)
 
             for db in $databases; do
-              az postgres flexible-server db delete --name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --yes
+              az postgres flexible-server db delete --database-name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --yes
             done
 
       - name: 'Upload L1 deployer container logs'

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -117,7 +117,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            databases=$(az postgres server list --resource-group Testnet --query "[?starts_with(name, 'host_')].[name]" -o tsv)
+            databases=$(az postgres flexible-server db list --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }} --query "[?starts_with(name, 'host_')].[name]" -o tsv)
 
             for db in $databases; do
               az postgres db delete --name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }}.postgres.database.azure.com --yes

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -112,6 +112,17 @@ jobs:
           inlineScript: |
             $(az resource list --tag ${{ vars.AZURE_DEPLOY_GROUP_L2 }}=true --query '[]."id"' -o tsv | xargs -n1 az resource delete --verbose -g Testnet --ids) || true
 
+      # Delete old database tables from previous deployment
+      - name: 'Delete host databases'
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            databases=$(az postgres server list --resource-group Testnet --query "[?starts_with(name, 'host_')].[name]" -o tsv)
+
+            for db in $databases; do
+              az postgres db delete --name "$db" --resource-group Testnet --server-name postgres-ten-${{ github.event.inputs.testnet_type }}.postgres.database.azure.com --yes
+            done
+
       - name: 'Upload L1 deployer container logs'
         uses: actions/upload-artifact@v3
         with:

--- a/go/host/storage/init/postgres/postgres.go
+++ b/go/host/storage/init/postgres/postgres.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	defaultDatabase = "postgres"
+	maxDBPoolSize   = 100
 )
 
 func CreatePostgresDBConnection(baseURL string, dbName string) (*sql.DB, error) {
@@ -46,6 +47,7 @@ func CreatePostgresDBConnection(baseURL string, dbName string) (*sql.DB, error) 
 	dbURL = fmt.Sprintf("%s%s", baseURL, dbName)
 
 	db, err = sql.Open("postgres", dbURL)
+	db.SetMaxOpenConns(maxDBPoolSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to PostgreSQL database %s: %v", dbName, err)
 	}

--- a/integration/simulation/p2p/in_mem_obscuro_client.go
+++ b/integration/simulation/p2p/in_mem_obscuro_client.go
@@ -109,6 +109,9 @@ func (c *inMemObscuroClient) Call(result interface{}, method string, args ...int
 	case rpc.GetRollupListing:
 		return c.getRollupListing(result, args)
 
+	case rpc.GetPublicTransactionData:
+		return c.getPublicTransactionData(result, args)
+
 	default:
 		return fmt.Errorf("RPC method %s is unknown", method)
 	}
@@ -366,6 +369,28 @@ func (c *inMemObscuroClient) getRollupListing(result interface{}, args []interfa
 		return fmt.Errorf("result is of type %T, expected *common.BatchListingResponseDeprecated", result)
 	}
 	*res = *rollups
+	return nil
+}
+
+func (c *inMemObscuroClient) getPublicTransactionData(result interface{}, args []interface{}) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 arg to %s, got %d", rpc.GetPublicTransactionData, len(args))
+	}
+	pagination, ok := args[0].(*common.QueryPagination)
+	if !ok {
+		return fmt.Errorf("first arg to %s is of type %T, expected type int", rpc.GetPublicTransactionData, args[0])
+	}
+
+	txs, err := c.tenScanAPI.GetPublicTransactionData(pagination)
+	if err != nil {
+		return fmt.Errorf("`%s` call failed. Cause: %w", rpc.GetPublicTransactionData, err)
+	}
+
+	res, ok := result.(*common.TransactionListingResponse)
+	if !ok {
+		return fmt.Errorf("result is of type %T, expected *common.BatchListingResponseDeprecated", result)
+	}
+	*res = *txs
 	return nil
 }
 


### PR DESCRIPTION
### Why this change is needed

The dev host node errored late last night:

```
CRIT [04-11|21:36:08.096] failed to add batch to L2 repo           node_id=0xd6bCf7694fc4Ed7c7C61B3fC5757919E237D0bf5 component=host enclave_id=0x281330F7a477e1e525687b092089480cC1041BF7 batch=0x8ee70adf010b2dee3cee5378d96464a964f6fea10fac715d248d3f4eaf498651 err="could not add batch: failed to begin host db transaction. Cause: pq: remaining connection slots are reserved for roles with privileges of the \"pg_use_reserved_connections\" role"
```

### What changes were made as part of this PR

* Set max connections to 100 same as edgelessDB
* (unrelated) Add check to in-mem test for batchByTx to catch any flakeyness 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


