### PR TITLE
Fix failed rollup insertion on Host

### DIFF
--- a/go/host/storage/hostdb/hostdb.go
+++ b/go/host/storage/hostdb/hostdb.go
@@ -59,3 +59,10 @@ func (b *dbTransaction) Write() error {
 	}
 	return nil
 }
+
+func (b *dbTransaction) Rollback() error {
+	if err := b.tx.Rollback(); err != nil {
+		return fmt.Errorf("failed to rollback host transaction. Cause: %w", err)
+	}
+	return nil
+}

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -34,6 +34,9 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 	}
 
 	if err := hostdb.AddBatch(dbtx, s.db.GetSQLStatement(), batch); err != nil {
+		if err := dbtx.Rollback(); err != nil {
+			return err
+		}
 		return fmt.Errorf("could not add batch to host. Cause: %w", err)
 	}
 
@@ -56,6 +59,9 @@ func (s *storageImpl) AddRollup(rollup *common.ExtRollup, metadata *common.Publi
 	}
 
 	if err := hostdb.AddRollup(dbtx, s.db.GetSQLStatement(), rollup, metadata, block); err != nil {
+		if err := dbtx.Rollback(); err != nil {
+			return err
+		}
 		return fmt.Errorf("could not add rollup to host. Cause: %w", err)
 	}
 
@@ -72,6 +78,9 @@ func (s *storageImpl) AddBlock(b *types.Header, rollupHash common.L2RollupHash) 
 	}
 
 	if err := hostdb.AddBlock(dbtx, s.db.GetSQLStatement(), b, rollupHash); err != nil {
+		if err := dbtx.Rollback(); err != nil {
+			return err
+		}
 		return fmt.Errorf("could not add block to host. Cause: %w", err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3246

The connections to postgres keep running out and theres a lot of failed rollup insertions that result in idle connections.


```
| idle in transaction (aborted) | -8488598446982951149 | INSERT INTO rollup_host (hash, start_seq, end_seq, time_stamp, ext_rollup, compression_block) values ($1, $2, $3, $4, $5, $6) | client backend |
```

If this doesn't fix it we can try connection pooling via Azure but theres a cost associated. 

### What changes were made as part of this PR

* Add rollback to storage interface

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


