### PR TITLE
Ziga/gateway verbose logging and bugfix

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -137,5 +137,5 @@ jobs:
             && docker run -d -p 80:80 -p 81:81 --name ${{ github.event.inputs.testnet_type }}-OG-${{ GITHUB.RUN_NUMBER }} \
               -e OBSCURO_GATEWAY_VERSION="${{ GITHUB.RUN_NUMBER }}-${{ GITHUB.SHA }}" \
                ${{ vars.DOCKER_BUILD_TAG_GATEWAY }} \
-               -host=0.0.0.0 -port=8080 -portWS=81 -nodeHost=${{ vars.L2_RPC_URL_VALIDATOR }} \
+               -host=0.0.0.0 -port=8080 -portWS=81 -nodeHost=${{ vars.L2_RPC_URL_VALIDATOR }} -verbose=true \
                -logPath=sys_out -dbType=mariaDB -dbConnectionURL="obscurouser:${{ secrets.OBSCURO_GATEWAY_MARIADB_USER_PWD }}@tcp(obscurogateway-mariadb-${{  github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:3306)/ogdb"'

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -332,7 +332,7 @@ func versionRequestHandler(walletExt *rpcapi.Services, userConn UserConn) {
 	}
 }
 
-// getMessageRequestHandler handles request to /get-message endpoint.
+// getMessageRequestHandler handles request to /getmessage endpoint.
 func getMessageRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 	// read the request
 	body, err := conn.ReadRequest()
@@ -351,8 +351,15 @@ func getMessageRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 
 	// get address from the request
 	encryptionToken, ok := reqJSONMap[common.JSONKeyEncryptionToken]
-	if !ok || len(encryptionToken.(string)) != common.MessageUserIDLen {
-		handleError(conn, walletExt.Logger(), fmt.Errorf("unable to read encryptionToken field from the request or it is not of correct length"))
+	if !ok {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("encryptionToken field not found in the request"))
+		return
+	}
+	if tokenStr, ok := encryptionToken.(string); !ok {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("encryptionToken field is not a string"))
+		return
+	} else if len(tokenStr) != common.MessageUserIDLen {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("encryptionToken field is not of correct length"))
 		return
 	}
 


### PR DESCRIPTION
### Why this change is needed

- Currently there is a bug in the Gateway causing following errors: 
```
2024/04/25 20:49:35 http: panic serving 127.0.0.1:59676: interface conversion: interface {} is map[string]interface {}, not string
```
- To improve further error checking we want to turn on verbose error checking for all deployed testnets

### What changes were made as part of this PR

- additional type check
- verbose flag set to true in the deployment script

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


