### PR TITLE
use same script for creating the node as newer versions

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -76,11 +76,11 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ github.event.inputs.testnet_type }}-OG-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscurogateway-${{ github.event.inputs.testnet_type }}" \
+            --public-ip-address "${{ github.event.inputs.testnet_type }}-OG-static" \
             --tags deploygroup=ObscuroGateway-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_GATEWAY }}=true \
             --vnet-name ObscuroGateway-${{ github.event.inputs.testnet_type }}-01VNET --subnet ObscuroGateway-${{ github.event.inputs.testnet_type }}-01Subnet \
             --size 	Standard_D4_v5 --image Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest \
-            --public-ip-sku Basic --authentication-type password
+            --authentication-type password
 
       - name: 'Open Obscuro node-${{ matrix.host_id }} ports on Azure'
         uses: azure/CLI@v1


### PR DESCRIPTION
### Why this change is needed

Currently we cannot deploy version 0.23 after 0.24 version was deployed, due to changes in a way public address is defined.
Bringing those changes to this release version is necessary for if we want to deploy previous versions.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


