### PR TITLE
Node config: wire through seq addr flag

### DIFF
--- a/go/node/cmd/main.go
+++ b/go/node/cmd/main.go
@@ -37,6 +37,7 @@ func main() {
 		node.WithRollupInterval(cliConfig.rollupInterval),
 		node.WithL1ChainID(cliConfig.l1ChainID),
 		node.WithPostgresDBHost(cliConfig.postgresDBHost),
+		node.WithSequencerP2PAddr(cliConfig.sequencerP2PAddr),
 	)
 
 	dockerNode := node.NewDockerNode(nodeCfg)


### PR DESCRIPTION
Missed one of the many hops where the flag has to be wired through.

Have checked that this fixed the deploy (https://github.com/ten-protocol/go-ten/actions/runs/8881374641).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


