### PR TITLE
fix newHeads unsubscribe

### DIFF
--- a/go/common/subscription/utils.go
+++ b/go/common/subscription/utils.go
@@ -62,8 +62,5 @@ func ForwardFromChannels[R any](inputChannels []chan R, unsubscribed *atomic.Boo
 // Must be called as a go routine!
 func HandleUnsubscribe(connectionSub *rpc.Subscription, unsubscribed *atomic.Bool, onUnsub func()) {
 	<-connectionSub.Err()
-	if unsubscribed != nil {
-		unsubscribed.Store(true)
-	}
 	onUnsub()
 }

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -62,6 +62,7 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 	})
 	go subscriptioncommon.HandleUnsubscribe(subscription, &unsubscribed, func() {
 		api.host.UnsubscribeLogs(subscription.ID)
+		unsubscribed.Store(true)
 	})
 	return subscription, nil
 }

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -9,9 +9,7 @@ import (
 	"github.com/ten-protocol/go-ten/go/common/docker"
 )
 
-var (
-	_enclaveDataDir = "/enclavedata" // this is how the directory is references within the enclave container
-)
+var _enclaveDataDir = "/enclavedata" // this is how the directory is references within the enclave container
 
 type DockerNode struct {
 	cfg *Config

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -114,6 +114,7 @@ func (api *FilterAPI) Logs(ctx context.Context, crit common.FilterCriteria) (*rp
 		for _, connection := range backendWSConnections {
 			_ = returnConn(api.we.rpcWSConnPool, connection.BackingClient())
 		}
+		unsubscribed.Store(true)
 	})
 
 	return subscription, err


### PR DESCRIPTION
### Why this change is needed

The `NewHeads` subscription is not working properly.

It appears as though the first "unsubscribe" was killing all connections.

### What changes were made as part of this PR

- no longer kill all connections on the first unsubscribe

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


