### PR TITLE
Batch transactions query accepts full or short hash

### DIFF
--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -311,8 +311,8 @@ func GetBatchByHeight(db HostDB, height *big.Int) (*common.PublicBatch, error) {
 
 // GetBatchTransactions returns the TransactionListingResponse for a given batch hash
 func GetBatchTransactions(db HostDB, batchHash gethcommon.Hash) (*common.TransactionListingResponse, error) {
-	whereQuery := " WHERE b.full_hash=" + db.GetSQLStatement().Placeholder
-	return fetchBatchTxs(db.GetSQLDB(), whereQuery, batchHash)
+	whereQuery := " WHERE b.hash=" + db.GetSQLStatement().Placeholder
+	return fetchBatchTxs(db.GetSQLDB(), whereQuery, truncTo16(batchHash))
 }
 
 func fetchBatchHeader(db *sql.DB, whereQuery string, args ...any) (*common.BatchHeader, error) {
@@ -490,7 +490,7 @@ func fetchTx(db HostDB, seqNo uint64) ([]common.TxHash, error) {
 	return transactions, nil
 }
 
-func fetchBatchTxs(db *sql.DB, whereQuery string, batchHash gethcommon.Hash) (*common.TransactionListingResponse, error) {
+func fetchBatchTxs(db *sql.DB, whereQuery string, batchHash []byte) (*common.TransactionListingResponse, error) {
 	query := selectBatchTxs + whereQuery
 	rows, err := db.Query(query, batchHash)
 	if err != nil {

--- a/integration/tenscan/tenscan_test.go
+++ b/integration/tenscan/tenscan_test.go
@@ -264,15 +264,6 @@ func TestTenscan(t *testing.T) {
 		Item common.ObscuroNetworkInfo `json:"item"`
 	}
 
-	//Timer for running local tests
-	countdownDuration := 20 * time.Minute
-	tickDuration := 30 * time.Second
-
-	for remaining := countdownDuration; remaining > 0; remaining -= tickDuration {
-		fmt.Printf("Shutting down in %s...\n", remaining)
-		time.Sleep(tickDuration)
-	}
-
 	configFetchObj := configFetch{}
 	err = json.Unmarshal(body, &configFetchObj)
 	assert.NoError(t, err)

--- a/integration/tenscan/tenscan_test.go
+++ b/integration/tenscan/tenscan_test.go
@@ -264,6 +264,15 @@ func TestTenscan(t *testing.T) {
 		Item common.ObscuroNetworkInfo `json:"item"`
 	}
 
+	//Timer for running local tests
+	countdownDuration := 20 * time.Minute
+	tickDuration := 30 * time.Second
+
+	for remaining := countdownDuration; remaining > 0; remaining -= tickDuration {
+		fmt.Printf("Shutting down in %s...\n", remaining)
+		time.Sleep(tickDuration)
+	}
+
 	configFetchObj := configFetch{}
 	err = json.Unmarshal(body, &configFetchObj)
 	assert.NoError(t, err)


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3314

### What changes were made as part of this PR

* Trunc the hash and query by the shortened version

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


