### PR TITLE
wire edgeless in simulation mode for local testnet

### DIFF
--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -81,7 +81,7 @@ const (
 	edbManifestEndpoint  = "/manifest"
 	edbSignatureEndpoint = "/signature"
 
-	dataDir         = "/data"
+	dataDir         = "data"
 	certIssuer      = "obscuroCA"
 	certSubject     = "obscuroUser"
 	enclaveHostName = "enclave"
@@ -138,7 +138,7 @@ func Connector(edbCfg *Config, config config.EnclaveConfig, logger gethlog.Logge
 	}
 
 	// load credentials from encrypted persistence if available, otherwise perform handshake and initialization to prepare them
-	edbCredentials, err := getHandshakeCredentials(edbCfg, logger)
+	edbCredentials, err := getHandshakeCredentials(config, edbCfg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func waitForEdgelessDBToStart(edbHost string, logger gethlog.Logger) error {
 		edgelessDBStartTimeout, edgelessHTTPAddr, err)
 }
 
-func getHandshakeCredentials(edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
+func getHandshakeCredentials(enclaveConfig config.EnclaveConfig, edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
 	// if we have previously performed the handshake we can retrieve the creds from disk and proceed
 	edbCreds, found, err := loadCredentialsFromFile()
 	if err != nil {
@@ -189,7 +189,7 @@ func getHandshakeCredentials(edbCfg *Config, logger gethlog.Logger) (*Credential
 	}
 	if !found {
 		// they don't exist on disk so we have to perform the handshake and set them up
-		edbCreds, err = performHandshake(edbCfg, logger)
+		edbCreds, err = performHandshake(enclaveConfig, edbCfg, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +216,7 @@ func loadCredentialsFromFile() (*Credentials, bool, error) {
 	return edbCreds, true, nil
 }
 
-func performHandshake(edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
+func performHandshake(enclaveConfig config.EnclaveConfig, edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
 	// we need to make sure this dir exists before we start read/writing files in there
 	err := os.MkdirAll(dataDir, 0o644)
 	if err != nil {
@@ -229,7 +229,7 @@ func performHandshake(edbCfg *Config, logger gethlog.Logger) (*Credentials, erro
 	// The trust path is as follows:
 	// 1. The Obscuro Enclave performs RA on the database enclave, and the RA object contains a certificate which only the database enclave controls.
 	// 2. Connecting to the database via mutually authenticated TLS using the above certificate, will give the Obscuro enclave confidence that it is only giving data away to some code and hardware it trusts.
-	edbPEM, err := performEDBRemoteAttestation(edbCfg.Host, defaultEDBConstraints, logger)
+	edbPEM, err := performEDBRemoteAttestation(enclaveConfig, edbCfg.Host, defaultEDBConstraints, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -177,6 +177,7 @@ func (d *DockerNode) startEnclave() error {
 		"-maxRollupSize=65536",
 		fmt.Sprintf("-logLevel=%d", d.cfg.logLevel),
 		"-obscuroGenesis", "{}",
+		"-edgelessDBHost", d.cfg.nodeName+"-edgelessdb",
 	)
 
 	if d.cfg.sgxEnabled {
@@ -187,14 +188,9 @@ func (d *DockerNode) startEnclave() error {
 
 		// prepend the entry.sh execution
 		cmd = append([]string{"/home/obscuro/go-obscuro/go/enclave/main/entry.sh"}, cmd...)
-		cmd = append(cmd,
-			"-edgelessDBHost", d.cfg.nodeName+"-edgelessdb",
-			"-willAttest=true",
-		)
+		cmd = append(cmd, "-willAttest=true")
 	} else {
-		cmd = append(cmd,
-			"-sqliteDBPath", "/data/sqlite.db",
-		)
+		cmd = append(cmd, "-willAttest=false")
 	}
 
 	enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
@@ -204,26 +200,25 @@ func (d *DockerNode) startEnclave() error {
 }
 
 func (d *DockerNode) startEdgelessDB() error {
-	if !d.cfg.sgxEnabled {
-		// Non-SGX hardware use sqlite database so EdgelessDB is not required.
-		return nil
-	}
-
 	envs := map[string]string{
 		"EDG_EDB_CERT_DNS": d.cfg.nodeName + "-edgelessdb",
 	}
+	devices := map[string]string{}
 
-	devices := map[string]string{
-		"/dev/sgx_enclave":   "/dev/sgx_enclave",
-		"/dev/sgx_provision": "/dev/sgx_provision",
+	if d.cfg.sgxEnabled {
+		devices["/dev/sgx_enclave"] = "/dev/sgx_enclave"
+		devices["/dev/sgx_provision"] = "/dev/sgx_provision"
+	} else {
+		envs["OE_SIMULATION"] = "1"
 	}
 
 	// only set the pccsAddr env var if it's defined
 	if d.cfg.pccsAddr != "" {
 		envs["PCCS_ADDR"] = d.cfg.pccsAddr
 	}
+	dbVolume := map[string]string{d.cfg.nodeName + "-db-volume": "/data"}
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, dbVolume)
 
 	return err
 }


### PR DESCRIPTION
### Why this change is needed

Sqlite doesn't work properly under load. The e2e tests running against a "local testnet" deployment fail with "database locked"

### What changes were made as part of this PR

replace sqlite with edgeless for the "local testnet"

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


