### PR TITLE
Host: notify separately for new heads and new validated heads

### DIFF
--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -118,14 +118,20 @@ type L1Publisher interface {
 
 // L2BatchRepository provides an interface for the host to request L2 batch data (live-streaming and historical)
 type L2BatchRepository interface {
-	// Subscribe will register a batch handler to receive new batches as they arrive
-	Subscribe(handler L2BatchHandler) func()
+	// SubscribeNewBatches will register a handler to receive new batches from the publisher as they arrive at the host
+	SubscribeNewBatches(handler L2BatchHandler) func()
+
+	// SubscribeValidatedBatches will register a handler to receive batches that have been validated by the enclave
+	SubscribeValidatedBatches(handler L2BatchHandler) func()
 
 	FetchBatchBySeqNo(background context.Context, seqNo *big.Int) (*common.ExtBatch, error)
 
 	// AddBatch is used to notify the repository of a new batch, e.g. from the enclave when seq produces one or a rollup is consumed
 	// Note: it is fine to add batches that the repo already has, it will just ignore them
 	AddBatch(batch *common.ExtBatch) error
+
+	// NotifyNewValidatedHead - called after an enclave validates a batch, to update the repo's validated head and notify subscribers
+	NotifyNewValidatedHead(batch *common.ExtBatch)
 }
 
 // L2BatchHandler is an interface for receiving new batches from the publisher as they arrive

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -97,7 +97,7 @@ func NewHost(config *config.HostConfig, hostServices *ServicesRegistry, p2p host
 	l2Repo := l2.NewBatchRepository(config, hostServices, hostStorage, logger)
 	subsService := events.NewLogEventManager(hostServices, logger)
 
-	l2Repo.Subscribe(batchListener{newHeads: host.newHeads})
+	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1BlockRepositoryName, l1Repo)
 	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying


### PR DESCRIPTION
### Why this change is needed

We have bugs that are likely caused by the host newHeads subscriptions getting notified of new batches before the enclave has processed them.

### What changes were made as part of this PR

Separate out the L2 repo's subscribers between those that want to know about a new head added to the DB and a new head batch that has been validated by that node's own enclave. Use the latter for the new heads RPC subscriptions.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


