### PR TITLE
Wire edgeless in simulation mode for local testnet

### DIFF
--- a/go/enclave/storage/db_init.go
+++ b/go/enclave/storage/db_init.go
@@ -43,21 +43,18 @@ func CreateDBFromConfig(cfg *config.EnclaveConfig, logger gethlog.Logger) (encla
 
 // validateDBConf high-level checks that you have a valid configuration for DB creation
 func validateDBConf(cfg *config.EnclaveConfig) error {
-	//if cfg.UseInMemoryDB && cfg.EdgelessDBHost != "" {
-	//	return fmt.Errorf("invalid db config, useInMemoryDB=true so EdgelessDB host not expected, but EdgelessDBHost=%s", cfg.EdgelessDBHost)
-	//}
-	//if !cfg.WillAttest && cfg.EdgelessDBHost != "" {
-	//	return fmt.Errorf("invalid db config, willAttest=false so EdgelessDB host not supported, but EdgelessDBHost=%s", cfg.EdgelessDBHost)
-	//}
-	//if !cfg.UseInMemoryDB && cfg.WillAttest && cfg.EdgelessDBHost == "" {
-	//	return fmt.Errorf("useInMemoryDB=false, willAttest=true so expected an EdgelessDB host but none was provided")
-	//}
-	//if cfg.SqliteDBPath != "" && cfg.UseInMemoryDB {
-	//	return fmt.Errorf("useInMemoryDB=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
-	//}
-	//if cfg.SqliteDBPath != "" && cfg.WillAttest {
-	//	return fmt.Errorf("willAttest=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
-	//}
+	if cfg.UseInMemoryDB && cfg.EdgelessDBHost != "" {
+		return fmt.Errorf("invalid db config, useInMemoryDB=true so EdgelessDB host not expected, but EdgelessDBHost=%s", cfg.EdgelessDBHost)
+	}
+	if cfg.UseInMemoryDB && cfg.WillAttest {
+		return fmt.Errorf("useInMemoryDB=true, willAttest=true : cannot support attestation for inmemory mode")
+	}
+	if cfg.SqliteDBPath != "" && cfg.UseInMemoryDB {
+		return fmt.Errorf("useInMemoryDB=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
+	}
+	if cfg.SqliteDBPath != "" && cfg.WillAttest {
+		return fmt.Errorf("willAttest=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
+	}
 	return nil
 }
 

--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -81,7 +81,7 @@ const (
 	edbManifestEndpoint  = "/manifest"
 	edbSignatureEndpoint = "/signature"
 
-	dataDir         = "data"
+	dataDir         = "/data"
 	certIssuer      = "obscuroCA"
 	certSubject     = "obscuroUser"
 	enclaveHostName = "enclave"

--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -81,7 +81,7 @@ const (
 	edbManifestEndpoint  = "/manifest"
 	edbSignatureEndpoint = "/signature"
 
-	dataDir         = "/data"
+	dataDir         = "data"
 	certIssuer      = "obscuroCA"
 	certSubject     = "obscuroUser"
 	enclaveHostName = "enclave"
@@ -138,7 +138,7 @@ func Connector(edbCfg *Config, config config.EnclaveConfig, logger gethlog.Logge
 	}
 
 	// load credentials from encrypted persistence if available, otherwise perform handshake and initialization to prepare them
-	edbCredentials, err := getHandshakeCredentials(edbCfg, logger)
+	edbCredentials, err := getHandshakeCredentials(config, edbCfg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func waitForEdgelessDBToStart(edbHost string, logger gethlog.Logger) error {
 		edgelessDBStartTimeout, edgelessHTTPAddr, err)
 }
 
-func getHandshakeCredentials(edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
+func getHandshakeCredentials(enclaveConfig config.EnclaveConfig, edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
 	// if we have previously performed the handshake we can retrieve the creds from disk and proceed
 	edbCreds, found, err := loadCredentialsFromFile()
 	if err != nil {
@@ -189,7 +189,7 @@ func getHandshakeCredentials(edbCfg *Config, logger gethlog.Logger) (*Credential
 	}
 	if !found {
 		// they don't exist on disk so we have to perform the handshake and set them up
-		edbCreds, err = performHandshake(edbCfg, logger)
+		edbCreds, err = performHandshake(enclaveConfig, edbCfg, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +216,7 @@ func loadCredentialsFromFile() (*Credentials, bool, error) {
 	return edbCreds, true, nil
 }
 
-func performHandshake(edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
+func performHandshake(enclaveConfig config.EnclaveConfig, edbCfg *Config, logger gethlog.Logger) (*Credentials, error) {
 	// we need to make sure this dir exists before we start read/writing files in there
 	err := os.MkdirAll(dataDir, 0o644)
 	if err != nil {
@@ -229,7 +229,7 @@ func performHandshake(edbCfg *Config, logger gethlog.Logger) (*Credentials, erro
 	// The trust path is as follows:
 	// 1. The Obscuro Enclave performs RA on the database enclave, and the RA object contains a certificate which only the database enclave controls.
 	// 2. Connecting to the database via mutually authenticated TLS using the above certificate, will give the Obscuro enclave confidence that it is only giving data away to some code and hardware it trusts.
-	edbPEM, err := performEDBRemoteAttestation(edbCfg.Host, defaultEDBConstraints, logger)
+	edbPEM, err := performEDBRemoteAttestation(enclaveConfig, edbCfg.Host, defaultEDBConstraints, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -193,9 +193,11 @@ func (d *DockerNode) startEnclave() error {
 		cmd = append(cmd, "-willAttest=false")
 	}
 
-	enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
+	// we'll only need the volume when we'll have upgrade scenarios
+	//enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
+	//_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume)
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, nil)
 	return err
 }
 

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -177,6 +177,7 @@ func (d *DockerNode) startEnclave() error {
 		"-maxRollupSize=65536",
 		fmt.Sprintf("-logLevel=%d", d.cfg.logLevel),
 		"-obscuroGenesis", "{}",
+		"-edgelessDBHost", d.cfg.nodeName+"-edgelessdb",
 	)
 
 	if d.cfg.sgxEnabled {
@@ -187,14 +188,9 @@ func (d *DockerNode) startEnclave() error {
 
 		// prepend the entry.sh execution
 		cmd = append([]string{"/home/obscuro/go-obscuro/go/enclave/main/entry.sh"}, cmd...)
-		cmd = append(cmd,
-			"-edgelessDBHost", d.cfg.nodeName+"-edgelessdb",
-			"-willAttest=true",
-		)
+		cmd = append(cmd, "-willAttest=true")
 	} else {
-		cmd = append(cmd,
-			"-sqliteDBPath", "/data/sqlite.db",
-		)
+		cmd = append(cmd, "-willAttest=false")
 	}
 
 	enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
@@ -204,26 +200,25 @@ func (d *DockerNode) startEnclave() error {
 }
 
 func (d *DockerNode) startEdgelessDB() error {
-	if !d.cfg.sgxEnabled {
-		// Non-SGX hardware use sqlite database so EdgelessDB is not required.
-		return nil
-	}
-
 	envs := map[string]string{
 		"EDG_EDB_CERT_DNS": d.cfg.nodeName + "-edgelessdb",
 	}
+	devices := map[string]string{}
 
-	devices := map[string]string{
-		"/dev/sgx_enclave":   "/dev/sgx_enclave",
-		"/dev/sgx_provision": "/dev/sgx_provision",
+	if d.cfg.sgxEnabled {
+		devices["/dev/sgx_enclave"] = "/dev/sgx_enclave"
+		devices["/dev/sgx_provision"] = "/dev/sgx_provision"
+	} else {
+		envs["OE_SIMULATION"] = "1"
 	}
 
 	// only set the pccsAddr env var if it's defined
 	if d.cfg.pccsAddr != "" {
 		envs["PCCS_ADDR"] = d.cfg.pccsAddr
 	}
+	dbVolume := map[string]string{d.cfg.nodeName + "-db-volume": "/data"}
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, dbVolume)
 
 	return err
 }

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -193,11 +193,10 @@ func (d *DockerNode) startEnclave() error {
 		cmd = append(cmd, "-willAttest=false")
 	}
 
-	// we'll only need the volume when we'll have upgrade scenarios
-	//enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
-	//_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume)
+	// we need the enclave volume to store the db credentials
+	enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume)
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, nil)
 	return err
 }
 

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -216,9 +216,12 @@ func (d *DockerNode) startEdgelessDB() error {
 	if d.cfg.pccsAddr != "" {
 		envs["PCCS_ADDR"] = d.cfg.pccsAddr
 	}
-	dbVolume := map[string]string{d.cfg.nodeName + "-db-volume": "/data"}
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, dbVolume)
+	// todo - do we need this volume?
+	//dbVolume := map[string]string{d.cfg.nodeName + "-db-volume": "/data"}
+	//_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, dbVolume)
+
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil)
 
 	return err
 }

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -55,7 +55,7 @@ func (s *Simulation) Start() {
 
 	// Arbitrary sleep to wait for RPC clients to get up and running
 	// and for all l2 nodes to receive the genesis l2 batch
-	time.Sleep(6 * time.Second)
+	time.Sleep(7 * time.Second)
 
 	s.bridgeFundingToObscuro()
 	s.trackLogs()              // Create log subscriptions, to validate that they're working correctly later.

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -65,6 +65,9 @@ func (t *Testnet) Start() error {
 		node.WithLogLevel(t.cfg.logLevel),
 		node.WithEdgelessDBImage("ghcr.io/edgelesssys/edgelessdb-sgx-4gb:v0.3.2"), // default edgeless db value
 	)
+	if !t.cfg.isSGXEnabled {
+		sequencerNodeConfig.UpdateNodeConfig(node.WithEdgelessDBImage("ghcr.io/edgelesssys/edgelessdb-sgx-1gb:v0.3.2"))
+	}
 
 	sequencerNode := node.NewDockerNode(sequencerNodeConfig)
 
@@ -105,6 +108,10 @@ func (t *Testnet) Start() error {
 		node.WithLogLevel(t.cfg.logLevel),
 		node.WithEdgelessDBImage("ghcr.io/edgelesssys/edgelessdb-sgx-4gb:v0.3.2"), // default edgeless db value
 	)
+
+	if !t.cfg.isSGXEnabled {
+		validatorNodeConfig.UpdateNodeConfig(node.WithEdgelessDBImage("ghcr.io/edgelesssys/edgelessdb-sgx-1gb:v0.3.2"))
+	}
 
 	validatorNode := node.NewDockerNode(validatorNodeConfig)
 


### PR DESCRIPTION
### Why this change is needed

Sqlite doesn't work properly under load. The e2e tests running against a "local testnet" deployment fail with "database locked"

### What changes were made as part of this PR

replace sqlite with edgeless for the "local testnet"

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


