### PR TITLE
Create separate deployment for Ten Gateway Frontend

### DIFF
--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -1,0 +1,79 @@
+# Deploys Ten Gateway Frontend on Azure for Testnet
+# Builds the Ten Gateway image, pushes the image to dockerhub and starts the Ten Gateway on Azure VM
+
+name: '[M] Deploy Ten Gateway Frontend'
+run-name: '[M] Deploy Ten Gateway Frontend ( ${{ github.event.inputs.testnet_type }} )'
+on:
+  workflow_dispatch:
+    inputs:
+      testnet_type:
+        description: 'Testnet Type'
+        required: true
+        default: 'dev-testnet'
+        type: choice
+        options:
+          - 'dev-testnet'
+          - 'uat-testnet'
+          - 'sepolia-testnet'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.testnet_type }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - testnet_type: 'dev-testnet'
+            GATEWAY_API_URL: 'https://dev-testnet.ten.xyz'
+          - testnet_type: 'uat-testnet'
+            GATEWAY_API_URL: 'https://uat-testnet.ten.xyz'
+          - testnet_type: 'sepolia-testnet'
+            GATEWAY_API_URL: 'https://testnet.ten.xyz'
+    steps:
+      - name: 'Print GitHub variables'
+        run: |
+          echo "Selected Testnet Type: ${{ matrix.testnet_type }}"
+          echo "Gateway API URL: ${{ matrix.GATEWAY_API_URL }}"
+
+      - uses: actions/checkout@v3
+
+      - name: 'Extract branch name'
+        shell: bash
+        run: |
+          echo "Branch Name: ${GITHUB_REF_NAME}"
+          echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: 'Set up Docker'
+        uses: docker/setup-buildx-action@v1
+
+      - name: 'Login to Azure docker registry'
+        uses: azure/docker-login@v1
+        with:
+          login-server: testnetobscuronet.azurecr.io
+          username: testnetobscuronet
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Build and Push Docker Image
+        run: |
+          DOCKER_BUILDKIT=1 docker build --build-arg GATEWAY_API_URL=${{ matrix.GATEWAY_API_URL }} -t ${{ vars.DOCKER_BUILD_TAG_GATEWAY_FE }} -f ./tools/walletextension/frontend/Dockerfile .
+          docker push ${{ vars.DOCKER_BUILD_TAG_GATEWAY_FE }}
+
+      - name: "Deploy Gateway FE to Azure Container Instances"
+        uses: "azure/aci-deploy@v1"
+        with:
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          dns-name-label: ${{ github.event.inputs.testnet_type }}-ten-gateway
+          image: ${{ vars.DOCKER_BUILD_TAG_GATEWAY_FE }}
+          name: ${{ github.event.inputs.testnet_type }}-fe-ten-gateway
+          location: "uksouth"
+          restart-policy: "Never"
+          ports: "80"
+          cpu: 2
+          memory: 2

--- a/tools/walletextension/frontend/Dockerfile
+++ b/tools/walletextension/frontend/Dockerfile
@@ -8,6 +8,7 @@ ARG GATEWAY_API_URL
 
 # ENV for URL to be used in the app
 ENV NEXT_PUBLIC_API_GATEWAY_URL=${GATEWAY_API_URL}
+ENV PORT=80
 
 # Copy package.json and package-lock.json (or yarn.lock) into the container
 COPY package*.json ./
@@ -15,4 +16,5 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build
+EXPOSE 80
 CMD ["npm", "start"]

--- a/tools/walletextension/frontend/Dockerfile
+++ b/tools/walletextension/frontend/Dockerfile
@@ -1,0 +1,18 @@
+# Use an official Node.js 22 as a parent image
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+
+# ARG for build-time variable (GATEWAY_API_URL)
+ARG GATEWAY_API_URL
+
+# ENV for URL to be used in the app
+ENV NEXT_PUBLIC_API_GATEWAY_URL=${GATEWAY_API_URL}
+
+# Copy package.json and package-lock.json (or yarn.lock) into the container
+COPY package*.json ./
+
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["npm", "start"]

--- a/tools/walletextension/frontend/next.config.js
+++ b/tools/walletextension/frontend/next.config.js
@@ -1,9 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: "export",
+  // distDir should be "../api/static" in production but .next in development
+  distDir: process.env.NODE_ENV === "development" ? ".next" : "../api/static",
   images: {
     unoptimized: true,
   },
+  // base path for static files should be "" in development but "/static" in production
+  basePath: process.env.NODE_ENV === "development" ? "" : "/static",
 };
 
 module.exports = nextConfig;

--- a/tools/walletextension/frontend/next.config.js
+++ b/tools/walletextension/frontend/next.config.js
@@ -1,14 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: "export",
-  // distDir should be "../api/static" in production but .next in development
-  distDir: process.env.NODE_ENV === "development" ? ".next" : "../api/static",
   images: {
     unoptimized: true,
   },
-  // base path for static files should be "" in development but "/static" in production
-  basePath: process.env.NODE_ENV === "development" ? "" : "/static",
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
### Why this change is needed

Deploying Ten Gateway frontend separately will simplify Ten gateway and it won't need to serve frontend/static files anymore. Additionally it will give us an option to remove nginx and make it run as a SGX application.

### What changes were made as part of this PR

- Dockerfile
- Github actions file
- minor other changes

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


