### PR TITLE
Tudor/reconnect new heads

### DIFF
--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/ten-protocol/go-ten/go/common/rpc"
 	"github.com/ten-protocol/go-ten/go/common/subscription"
@@ -273,7 +274,10 @@ func (c *EncRPCClient) logSubscription(ctx context.Context, namespace string, ch
 			outboundChannel <- *decryptedLog
 		}
 		return nil
-	})
+	},
+		nil,
+		12*time.Hour,
+	)
 
 	return backendSub, nil
 }


### PR DESCRIPTION
### Why this change is needed

The `newHeads` subscription is used to invalidate the Ten Gateway cache. It needs to be resilient.

### What changes were made as part of this PR

- introduce reconnecting logic in the "NewHeadService"
- introduce timeout checking in the "NewHeadService" - to handle the case when the backend dies silently
- separate the newHead subscribe logic to pass it as a lambda

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


