### PR TITLE
tweak performance

### DIFF
--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -92,7 +92,8 @@ create table if not exists obsdb.batch
     primary key (sequence),
     INDEX USING HASH (hash(8)),
     INDEX USING HASH (l1_proof_hash(8)),
-    INDEX (body, l1_proof),
+    INDEX (body),
+    INDEX (l1_proof),
     INDEX (height)
 );
 GRANT ALL ON obsdb.batch TO obscuro;

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -80,7 +80,8 @@ create table if not exists batch
 );
 create index IDX_BATCH_HASH on batch (hash);
 create index IDX_BATCH_BLOCK on batch (l1_proof_hash);
-create index IDX_BATCH_BODY on batch (body, l1_proof);
+create index IDX_BATCH_BODY on batch (body);
+create index IDX_BATCH_L1 on batch (l1_proof);
 create index IDX_BATCH_HEIGHT on batch (height);
 
 create table if not exists tx


### PR DESCRIPTION
### Why this change is needed

There is a performance degradation when inserting l1 blocks. 
Most likely because the canonical update query does not properly use the indexes.

### What changes were made as part of this PR

Optimize the block insertion.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


