### PR TITLE
improve log subscription unsubscribe

### DIFF
--- a/go/common/subscription/utils.go
+++ b/go/common/subscription/utils.go
@@ -17,7 +17,7 @@ import (
 func ForwardFromChannels[R any](inputChannels []chan R, onMessage func(R) error, onBackendDisconnect func(), backendDisconnected *atomic.Bool, stopped *atomic.Bool, timeoutInterval time.Duration, logger gethlog.Logger) {
 	inputCases := make([]reflect.SelectCase, len(inputChannels)+1)
 
-	cleanupTicker := time.NewTicker(2 * time.Second)
+	cleanupTicker := time.NewTicker(1 * time.Second)
 	defer cleanupTicker.Stop()
 	// create a ticker to handle cleanup, check the "stopped" flag and exit the goroutine
 	inputCases[0] = reflect.SelectCase{
@@ -36,7 +36,7 @@ loop:
 		// this mechanism removes closed input channels. When there is none left, the subscription is considered "disconnected".
 		_, value, ok := reflect.Select(inputCases)
 		if !ok {
-			logger.Error("Failed to read from the channel")
+			logger.Debug("Failed to read from the channel")
 			break loop
 		}
 

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -347,7 +347,11 @@ func (e *enclaveImpl) StopClient() common.SystemError {
 }
 
 func (e *enclaveImpl) sendBatch(batch *core.Batch, outChannel chan common.StreamL2UpdatesResponse) {
-	e.logger.Info("Streaming batch to host", log.BatchHashKey, batch.Hash(), log.BatchSeqNoKey, batch.SeqNo())
+	if batch.SeqNo().Uint64()%10 == 0 {
+		e.logger.Info("Streaming batch to host", log.BatchHashKey, batch.Hash(), log.BatchSeqNoKey, batch.SeqNo())
+	} else {
+		e.logger.Debug("Streaming batch to host", log.BatchHashKey, batch.Hash(), log.BatchSeqNoKey, batch.SeqNo())
+	}
 	extBatch, err := batch.ToExtBatch(e.dataEncryptionService, e.dataCompressionService)
 	if err != nil {
 		// this error is unrecoverable

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -104,7 +104,7 @@ func (oc *obscuroChain) GetBalanceAtBlock(ctx context.Context, accountAddr gethc
 func (oc *obscuroChain) ObsCall(ctx context.Context, apiArgs *gethapi.TransactionArgs, blockNumber *gethrpc.BlockNumber) (*gethcore.ExecutionResult, error) {
 	result, err := oc.ObsCallAtBlock(ctx, apiArgs, blockNumber)
 	if err != nil {
-		oc.logger.Info(fmt.Sprintf("Obs_Call: failed to execute contract %s.", apiArgs.To), log.CtrErrKey, err.Error())
+		oc.logger.Debug(fmt.Sprintf("Obs_Call: failed to execute contract %s.", apiArgs.To), log.CtrErrKey, err.Error())
 		return nil, err
 	}
 

--- a/go/host/rpc/clientapi/client_api_filter.go
+++ b/go/host/rpc/clientapi/client_api_filter.go
@@ -77,8 +77,11 @@ func (api *FilterAPI) Logs(ctx context.Context, encryptedParams common.Encrypted
 		api.logger,
 	)
 	go subscriptioncommon.HandleUnsubscribe(subscription, func() {
-		api.host.UnsubscribeLogs(subscription.ID)
+		// first exit the forwarding go-routine
 		unsubscribed.Store(true)
+		time.Sleep(100 * time.Millisecond)
+		// and then close the channel
+		api.host.UnsubscribeLogs(subscription.ID)
 	})
 	return subscription, nil
 }


### PR DESCRIPTION
### Why this change is needed

the log subscription unsubscribe process is not working properly

### What changes were made as part of this PR

- change the order of actions
- reduce lock contention
- make some logs less noisy

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


