### PR TITLE
improve rpc conn pool

### DIFF
--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -116,7 +116,10 @@ func (api *FilterAPI) Logs(ctx context.Context, crit common.FilterCriteria) (*rp
 			}
 			return nil
 		},
-		nil, // todo - we can implement reconnect logic here
+		func() {
+			// release resources
+			api.closeConnections(backendSubscriptions, backendWSConnections)
+		}, // todo - we can implement reconnect logic here
 		&unsubscribedByBackend,
 		&unsubscribedByClient,
 		12*time.Hour,
@@ -126,7 +129,6 @@ func (api *FilterAPI) Logs(ctx context.Context, crit common.FilterCriteria) (*rp
 	// handles any of the backend connections being closed
 	go subscriptioncommon.HandleUnsubscribeErrChan(errorChannels, func() {
 		unsubscribedByBackend.Store(true)
-		api.closeConnections(backendSubscriptions, backendWSConnections)
 	})
 
 	// handles "unsubscribe" from the user

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -78,7 +78,7 @@ func (api *FilterAPI) Logs(ctx context.Context, crit common.FilterCriteria) (*rp
 	errorChannels := make([]<-chan error, 0)
 	backendSubscriptions := make([]*rpc.ClientSubscription, 0)
 	for _, address := range candidateAddresses {
-		rpcWSClient, err := connectWS(user.accounts[*address], api.we.Logger())
+		rpcWSClient, err := connectWS(ctx, user.accounts[*address], api.we.Logger())
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +143,7 @@ func (api *FilterAPI) closeConnections(backendSubscriptions []*rpc.ClientSubscri
 		backendSub.Unsubscribe()
 	}
 	for _, connection := range backendWSConnections {
-		_ = returnConn(api.we.rpcWSConnPool, connection.BackingClient())
+		_ = returnConn(api.we.rpcWSConnPool, connection.BackingClient(), api.logger)
 	}
 }
 

--- a/tools/walletextension/rpcapi/wallet_extension.go
+++ b/tools/walletextension/rpcapi/wallet_extension.go
@@ -90,7 +90,7 @@ func NewServices(hostAddrHTTP string, hostAddrWS string, storage storage.Storage
 		}, nil, nil, nil)
 
 	cfg := pool.NewDefaultPoolConfig()
-	cfg.MaxTotal = 100 // todo - what is the right number
+	cfg.MaxTotal = 200 // todo - what is the right number
 
 	services := Services{
 		HostAddrHTTP:    hostAddrHTTP,
@@ -138,6 +138,7 @@ func subscribeToNewHeadsWithRetry(ch chan *tencommon.BatchHeader, services Servi
 			sub, err = rpcClient.Subscribe(context.Background(), rpc.SubscribeNamespace, ch, rpc.SubscriptionTypeNewHeads)
 			if err != nil {
 				logger.Info("could not subscribe for new head blocks", log.ErrKey, err)
+				_ = returnConn(services.rpcWSConnPool, rpcClient, logger)
 			}
 			return err
 		},
@@ -270,7 +271,7 @@ func (w *Services) Version() string {
 }
 
 func (w *Services) GetTenNodeHealthStatus() (bool, error) {
-	res, err := withPlainRPCConnection[bool](w, func(client *gethrpc.Client) (*bool, error) {
+	res, err := withPlainRPCConnection[bool](context.Background(), w, func(client *gethrpc.Client) (*bool, error) {
 		res, err := obsclient.NewObsClient(client).Health()
 		return &res, err
 	})


### PR DESCRIPTION
### Why this change is needed

We seem to have a resource leak on the TG RPC conn pool

### What changes were made as part of this PR

- return connection in some error cases
- add context to the borrowing method
- improve logging

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


