### PR TITLE
add index on tx.sender, and clean up

### DIFF
--- a/go/enclave/rpc/GetCustomQuery.go
+++ b/go/enclave/rpc/GetCustomQuery.go
@@ -31,14 +31,14 @@ func GetCustomQueryExecute(builder *CallBuilder[common.PrivateCustomQueryListTra
 		return nil //nolint:nilerr
 	}
 
-	encryptReceipts, err := rpc.storage.GetReceiptsPerAddress(builder.ctx, &builder.Param.Address, &builder.Param.Pagination)
+	encryptReceipts, err := rpc.storage.GetTransactionsPerAddress(builder.ctx, &builder.Param.Address, &builder.Param.Pagination)
 	if err != nil {
-		return fmt.Errorf("GetReceiptsPerAddress - %w", err)
+		return fmt.Errorf("GetTransactionsPerAddress - %w", err)
 	}
 
-	receiptsCount, err := rpc.storage.GetReceiptsPerAddressCount(builder.ctx, &builder.Param.Address)
+	receiptsCount, err := rpc.storage.CountTransactionsPerAddress(builder.ctx, &builder.Param.Address)
 	if err != nil {
-		return fmt.Errorf("GetReceiptsPerAddressCount - %w", err)
+		return fmt.Errorf("CountTransactionsPerAddress - %w", err)
 	}
 
 	builder.ReturnValue = &common.PrivateQueryResponse{

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -439,71 +439,12 @@ func BatchWasExecuted(ctx context.Context, db *sql.DB, hash common.L2BatchHash) 
 	return result, nil
 }
 
-func GetReceiptsPerAddress(ctx context.Context, db *sql.DB, config *params.ChainConfig, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error) {
-	// todo - not indexed
+func GetTransactionsPerAddress(ctx context.Context, db *sql.DB, config *params.ChainConfig, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error) {
 	return selectReceipts(ctx, db, config, "where tx.sender_address = ? ORDER BY height DESC LIMIT ? OFFSET ? ", address.Bytes(), pagination.Size, pagination.Offset)
 }
 
-func GetReceiptsPerAddressCount(ctx context.Context, db *sql.DB, address *gethcommon.Address) (uint64, error) {
-	// todo - this is not indexed and will do a full table scan!
+func CountTransactionsPerAddress(ctx context.Context, db *sql.DB, address *gethcommon.Address) (uint64, error) {
 	row := db.QueryRowContext(ctx, "select count(1) from exec_tx join tx on tx.id=exec_tx.tx join batch on batch.sequence=exec_tx.batch "+" where tx.sender_address = ?", address.Bytes())
-
-	var count uint64
-	err := row.Scan(&count)
-	if err != nil {
-		return 0, err
-	}
-
-	return count, nil
-}
-
-func GetPublicTransactionData(ctx context.Context, db *sql.DB, pagination *common.QueryPagination) ([]common.PublicTransaction, error) {
-	return selectPublicTxsBySender(ctx, db, " ORDER BY height DESC LIMIT ? OFFSET ? ", pagination.Size, pagination.Offset)
-}
-
-func selectPublicTxsBySender(ctx context.Context, db *sql.DB, query string, args ...any) ([]common.PublicTransaction, error) {
-	var publicTxs []common.PublicTransaction
-
-	q := "select tx.hash, batch.height, batch.header from exec_tx join batch on batch.sequence=exec_tx.batch join tx on tx.id=exec_tx.tx where batch.is_canonical=true " + query
-	rows, err := db.QueryContext(ctx, q, args...)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// make sure the error is converted to obscuro-wide not found error
-			return nil, errutil.ErrNotFound
-		}
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var txHash []byte
-		var batchHeight uint64
-		var batchHeader string
-		err := rows.Scan(&txHash, &batchHeight, &batchHeader)
-		if err != nil {
-			return nil, err
-		}
-
-		h := new(common.BatchHeader)
-		if err := rlp.DecodeBytes([]byte(batchHeader), h); err != nil {
-			return nil, fmt.Errorf("could not decode batch header. Cause: %w", err)
-		}
-
-		publicTxs = append(publicTxs, common.PublicTransaction{
-			TransactionHash: gethcommon.BytesToHash(txHash),
-			BatchHeight:     big.NewInt(0).SetUint64(batchHeight),
-			BatchTimestamp:  h.Time,
-			Finality:        common.BatchFinal,
-		})
-	}
-	if rows.Err() != nil {
-		return nil, rows.Err()
-	}
-
-	return publicTxs, nil
-}
-
-func GetPublicTransactionCount(ctx context.Context, db *sql.DB) (uint64, error) {
-	row := db.QueryRowContext(ctx, "select count(1) from exec_tx join batch on batch.sequence=exec_tx.batch where batch.is_canonical=true")
 
 	var count uint64
 	err := row.Scan(&count)

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -108,6 +108,7 @@ create table if not exists obsdb.tx
     idx            int        NOT NULL,
     body           int        NOT NULL,
     INDEX USING HASH (hash(8)),
+    INDEX USING HASH (sender_address),
     primary key (id)
 );
 GRANT ALL ON obsdb.tx TO obscuro;

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -95,6 +95,7 @@ create table if not exists tx
     body           int        NOT NULL REFERENCES batch_body
 );
 create index IDX_TX_HASH on tx (hash);
+create index IDX_TX_SENDER_ADDRESS on tx (sender_address);
 
 create table if not exists exec_tx
 (

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -150,9 +150,7 @@ type Storage interface {
 
 type ScanStorage interface {
 	GetContractCount(ctx context.Context) (*big.Int, error)
-	GetReceiptsPerAddress(ctx context.Context, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error)
-	GetPublicTransactionData(ctx context.Context, pagination *common.QueryPagination) ([]common.PublicTransaction, error)
-	GetPublicTransactionCount(ctx context.Context) (uint64, error)
+	GetTransactionsPerAddress(ctx context.Context, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error)
 
-	GetReceiptsPerAddressCount(ctx context.Context, addr *gethcommon.Address) (uint64, error)
+	CountTransactionsPerAddress(ctx context.Context, addr *gethcommon.Address) (uint64, error)
 }

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -668,24 +668,14 @@ func (s *storageImpl) BatchWasExecuted(ctx context.Context, hash common.L2BatchH
 	return enclavedb.BatchWasExecuted(ctx, s.db.GetSQLDB(), hash)
 }
 
-func (s *storageImpl) GetReceiptsPerAddress(ctx context.Context, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error) {
-	defer s.logDuration("GetReceiptsPerAddress", measure.NewStopwatch())
-	return enclavedb.GetReceiptsPerAddress(ctx, s.db.GetSQLDB(), s.chainConfig, address, pagination)
+func (s *storageImpl) GetTransactionsPerAddress(ctx context.Context, address *gethcommon.Address, pagination *common.QueryPagination) (types.Receipts, error) {
+	defer s.logDuration("GetTransactionsPerAddress", measure.NewStopwatch())
+	return enclavedb.GetTransactionsPerAddress(ctx, s.db.GetSQLDB(), s.chainConfig, address, pagination)
 }
 
-func (s *storageImpl) GetReceiptsPerAddressCount(ctx context.Context, address *gethcommon.Address) (uint64, error) {
-	defer s.logDuration("GetReceiptsPerAddressCount", measure.NewStopwatch())
-	return enclavedb.GetReceiptsPerAddressCount(ctx, s.db.GetSQLDB(), address)
-}
-
-func (s *storageImpl) GetPublicTransactionData(ctx context.Context, pagination *common.QueryPagination) ([]common.PublicTransaction, error) {
-	defer s.logDuration("GetPublicTransactionData", measure.NewStopwatch())
-	return enclavedb.GetPublicTransactionData(ctx, s.db.GetSQLDB(), pagination)
-}
-
-func (s *storageImpl) GetPublicTransactionCount(ctx context.Context) (uint64, error) {
-	defer s.logDuration("GetPublicTransactionCount", measure.NewStopwatch())
-	return enclavedb.GetPublicTransactionCount(ctx, s.db.GetSQLDB())
+func (s *storageImpl) CountTransactionsPerAddress(ctx context.Context, address *gethcommon.Address) (uint64, error) {
+	defer s.logDuration("CountTransactionsPerAddress", measure.NewStopwatch())
+	return enclavedb.CountTransactionsPerAddress(ctx, s.db.GetSQLDB(), address)
 }
 
 func (s *storageImpl) logDuration(method string, stopWatch *measure.Stopwatch) {


### PR DESCRIPTION
### Why this change is needed

- "The personal transactions" displayed on tenscan are very slow because there is no index on the `tx. sender`
- the host db took over some responsibilities that were in the enclave before

### What changes were made as part of this PR

- add index
- remove dead code
- clarify some method naming

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


