### PR TITLE
Fix for interval. (#1926)

### DIFF
--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -286,10 +286,6 @@ func (p *Publisher) PublishCrossChainBundle(bundle *common.ExtCrossChainBundle) 
 		return nil
 	}
 
-	if len(bundle.CrossChainRootHashes) == 0 {
-		return fmt.Errorf("nothing to publish in cross chain bundle")
-	}
-
 	managementCtr, err := ManagementContract.NewManagementContract(*p.mgmtContractLib.GetContractAddr(), p.ethClient.EthClient())
 	if err != nil {
 		p.logger.Error("Unable to instantiate management contract client")

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -151,6 +151,7 @@ func (n *InMemNodeOperator) createHostContainer() *hostcontainer.HostContainer {
 		BatchInterval:         n.config.BatchInterval,
 		RollupInterval:        n.config.RollupInterval,
 		L1BlockTime:           n.config.L1BlockTime,
+		CrossChainInterval:    n.config.CrossChainInterval,
 		MaxRollupSize:         1024 * 64,
 	}
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -73,6 +73,7 @@ func createInMemObscuroNode(
 		ManagementContractAddress: *mgtContractAddress,
 		MessageBusAddress:         l1BusAddress,
 		BatchInterval:             batchInterval,
+		CrossChainInterval:        config.DefaultHostParsedConfig().CrossChainInterval,
 		IsInboundP2PDisabled:      incomingP2PDisabled,
 		L1BlockTime:               l1BlockTime,
 		UseInMemoryDB:             true,


### PR DESCRIPTION
* Fix for interval.

* Removed defaulting from guardian as there should already be a default value.

* Made the fromSeqNo to be local.

* Modify how the local cached seq no is set.

* Add missing cfg option.

* Another missing default value.

---------

### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


