### PR TITLE
Gateway: add net_version support and test

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -379,7 +379,7 @@ func (executor *batchExecutor) populateOutboundCrossChainData(ctx context.Contex
 
 		encodedTree, err := json.Marshal(xchainTree)
 		if err != nil {
-			panic(err) //todo: figure out what to do
+			panic(err) // todo: figure out what to do
 		}
 
 		batch.Header.CrossChainTree = encodedTree

--- a/go/enclave/crosschain/common.go
+++ b/go/enclave/crosschain/common.go
@@ -234,7 +234,7 @@ func (ms MessageStructs) HashPacked(index int) gethcommon.Hash {
 		},
 	}
 
-	//todo @siliev: err
+	// todo @siliev: err
 	packed, _ := args.Pack(messageStruct.Sender, messageStruct.Sequence, messageStruct.Nonce, messageStruct.Topic, messageStruct.Payload, messageStruct.ConsistencyLevel)
 	hash := crypto.Keccak256Hash(packed)
 	return hash

--- a/go/enclave/genesis/testnet_genesis.go
+++ b/go/enclave/genesis/testnet_genesis.go
@@ -9,8 +9,10 @@ import (
 )
 
 const TestnetPrefundedPK = "8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b" // The genesis main account private key.
-var GasBridgingKeys, _ = crypto.GenerateKey()                                                 // todo - make static
-var GasWithdrawalKeys, _ = crypto.GenerateKey()                                               // todo - make static
+var (
+	GasBridgingKeys, _   = crypto.GenerateKey() // todo - make static
+	GasWithdrawalKeys, _ = crypto.GenerateKey() // todo - make static
+)
 
 var TestnetGenesis = Genesis{
 	Accounts: []Account{

--- a/go/enclave/nodetype/common.go
+++ b/go/enclave/nodetype/common.go
@@ -40,6 +40,6 @@ func ExportCrossChainData(ctx context.Context, storage storage.Storage, fromSeqN
 		L1BlockHash:          block.Hash(),
 		L1BlockNum:           big.NewInt(0).Set(block.Header().Number),
 		CrossChainRootHashes: crossChainHashes,
-	} //todo: check fromSeqNo
+	} // todo: check fromSeqNo
 	return bundle, nil
 }

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -468,6 +468,7 @@ func (s *sequencer) signCrossChainBundle(bundle *common.ExtCrossChainBundle) err
 	}
 	return nil
 }
+
 func (s *sequencer) OnL1Block(ctx context.Context, block *types.Block, result *components.BlockIngestionType) error {
 	// nothing to do
 	return nil

--- a/integration/networktest/userwallet/gateway.go
+++ b/integration/networktest/userwallet/gateway.go
@@ -114,6 +114,10 @@ func (g *GatewayUser) Wallet() wallet.Wallet {
 	return g.wal
 }
 
+func (g *GatewayUser) Client() *ethclient.Client {
+	return g.client
+}
+
 func (g *GatewayUser) WSClient() (*ethclient.Client, error) {
 	if g.wsClient == nil {
 		var err error

--- a/tools/walletextension/rpcapi/net_api.go
+++ b/tools/walletextension/rpcapi/net_api.go
@@ -1,0 +1,17 @@
+package rpcapi
+
+import (
+	"context"
+)
+
+type NetAPI struct {
+	we *Services
+}
+
+func NewNetAPI(we *Services) *NetAPI {
+	return &NetAPI{we}
+}
+
+func (api *NetAPI) Version(ctx context.Context) (*string, error) {
+	return UnauthenticatedTenRPCCall[string](ctx, api.we, &CacheCfg{CacheType: LongLiving}, "net_version")
+}

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -83,6 +83,9 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 		}, {
 			Namespace: "eth",
 			Service:   rpcapi.NewFilterAPI(walletExt),
+		}, {
+			Namespace: "net",
+			Service:   rpcapi.NewNetAPI(walletExt),
 		},
 	})
 


### PR DESCRIPTION
### Why this change is needed

net_version requests weren't supported by gateway and some tools rely on it.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


