### PR TITLE
Gateway: hardcode response to clientVersion request

### DIFF
--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -66,6 +66,17 @@ func TestGatewayHappyPath(t *testing.T) {
 					return fmt.Errorf("expected net_version to be %s but got %s", expectedResult, result)
 				}
 
+				// check web3_clientVersion response
+				var cvResult string
+				err = rpcClient.CallContext(ctx, &cvResult, "web3_clientVersion")
+				if err != nil {
+					return fmt.Errorf("failed to get web3_clientVersion: %w", err)
+				}
+				fmt.Println("web3_clientVersion response:", cvResult)
+				if cvResult == "" {
+					return fmt.Errorf("expected web3_clientVersion to be non-empty")
+				}
+
 				return nil
 			}),
 		),

--- a/tools/walletextension/rpcapi/web3_api.go
+++ b/tools/walletextension/rpcapi/web3_api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-var _hardcodedClientVersion = "Geth/v10.0.0/drpc"
+var _hardcodedClientVersion = "Geth/v10.0.0/ten"
 
 type Web3API struct {
 	we *Services

--- a/tools/walletextension/rpcapi/web3_api.go
+++ b/tools/walletextension/rpcapi/web3_api.go
@@ -1,0 +1,20 @@
+package rpcapi
+
+import (
+	"context"
+)
+
+var _hardcodedClientVersion = "Geth/v10.0.0/drpc"
+
+type Web3API struct {
+	we *Services
+}
+
+func NewWeb3API(we *Services) *Web3API {
+	return &Web3API{we}
+}
+
+func (api *Web3API) ClientVersion(_ context.Context) (*string, error) {
+	// todo: have this return the Ten version from the node
+	return &_hardcodedClientVersion, nil
+}

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -86,6 +86,9 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 		}, {
 			Namespace: "net",
 			Service:   rpcapi.NewNetAPI(walletExt),
+		}, {
+			Namespace: "web3",
+			Service:   rpcapi.NewWeb3API(walletExt),
 		},
 	})
 


### PR DESCRIPTION
### Why this change is needed

Some tools expect a response from web3_clientVersion. Hardcode one in the gateway for now.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


