### PR TITLE
Host: avoid spamming stuck L1 transactions

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -246,12 +246,16 @@ func (e *gethRPCClient) FetchLastBatchSeqNo(address gethcommon.Address) (*big.In
 
 // PrepareTransactionToSend takes a txData type and overrides the From, Gas and Gas Price field with current values
 func (e *gethRPCClient) PrepareTransactionToSend(ctx context.Context, txData types.TxData, from gethcommon.Address) (types.TxData, error) {
-	return e.PrepareTransactionToRetry(ctx, txData, from, 0)
+	nonce, err := e.EthClient().PendingNonceAt(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("could not get nonce - %w", err)
+	}
+	return e.PrepareTransactionToRetry(ctx, txData, from, nonce, 0)
 }
 
 // PrepareTransactionToRetry takes a txData type and overrides the From, Gas and Gas Price field with current values
 // it bumps the price by a multiplier for retries. retryNumber is zero on first attempt (no multiplier on price)
-func (e *gethRPCClient) PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, retryNumber int) (types.TxData, error) {
+func (e *gethRPCClient) PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, nonce uint64, retryNumber int) (types.TxData, error) {
 	unEstimatedTx := types.NewTx(txData)
 	gasPrice, err := e.EthClient().SuggestGasPrice(ctx)
 	if err != nil {
@@ -277,12 +281,6 @@ func (e *gethRPCClient) PrepareTransactionToRetry(ctx context.Context, txData ty
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not estimate gas - %w", err)
-	}
-
-	// we fetch the current nonce on every retry to avoid any risk of nonce reuse/conflicts
-	nonce, err := e.EthClient().PendingNonceAt(ctx, from)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch nonce - %w", err)
 	}
 
 	return &types.LegacyTx{

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -35,7 +35,7 @@ type EthClient interface {
 
 	// PrepareTransactionToSend updates the tx with from address, current nonce and current estimates for the gas and the gas price
 	PrepareTransactionToSend(ctx context.Context, txData types.TxData, from gethcommon.Address) (types.TxData, error)
-	PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, retries int) (types.TxData, error)
+	PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, nonce uint64, retries int) (types.TxData, error)
 
 	FetchLastBatchSeqNo(address gethcommon.Address) (*big.Int, error)
 

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -393,7 +393,7 @@ func (p *Publisher) publishTransaction(tx types.TxData) error {
 
 	// we keep trying to send the transaction with this nonce until it is included in a block
 	// note: this is only safe because of the sendingLock guaranteeing only one transaction in-flight at a time
-	nonce, err := p.ethClient.EthClient().PendingNonceAt(p.sendingContext, p.hostWallet.Address())
+	nonce, err := p.ethClient.Nonce(p.hostWallet.Address())
 	if err != nil {
 		return fmt.Errorf("could not get nonce for L1 tx: %w", err)
 	}

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -99,7 +99,7 @@ func (m *Node) PrepareTransactionToSend(_ context.Context, txData types.TxData, 
 	}, nil
 }
 
-func (m *Node) PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, _ int) (types.TxData, error) {
+func (m *Node) PrepareTransactionToRetry(ctx context.Context, txData types.TxData, from gethcommon.Address, _ uint64, _ int) (types.TxData, error) {
 	return m.PrepareTransactionToSend(ctx, txData, from)
 }
 


### PR DESCRIPTION
### Why this change is needed

While retrying a stuck transaction we were incrementing the nonce. These pending transactions eventually all went through together costing the sequencer a fortune in unnecessary gas. Also, I think they were blocking each other which is why the stuck transactions carried on so long.

### What changes were made as part of this PR

The nonce is acquired only once when the sending lock is acquired so price updates overwrite the transaction in the mempool.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


