### PR TITLE
small mempool fixes

### DIFF
--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -5,15 +5,17 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	_ "unsafe"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 
 	// unsafe package imported in order to link to a private function in go-ethereum.
 	// This allows us to validate transactions against the tx pool rules.
-	_ "unsafe"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/go/common/log"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtxpool "github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -67,9 +69,11 @@ func (t *TxPool) Start() error {
 
 // PendingTransactions returns all pending transactions grouped per address and ordered per nonce
 func (t *TxPool) PendingTransactions() map[gethcommon.Address][]*gethtxpool.LazyTransaction {
-	// todo
+	// todo - for now using the base fee from the block
+	baseFee := t.Chain.CurrentBlock().BaseFee
 	return t.pool.Pending(gethtxpool.PendingFilter{
-		// BaseFee:
+		BaseFee:      uint256.NewInt(baseFee.Uint64()),
+		OnlyPlainTxs: true,
 	})
 }
 
@@ -121,5 +125,5 @@ func (t *TxPool) Close() error {
 			t.logger.Error("Could not close legacy pool", log.ErrKey, err)
 		}
 	}()
-	return t.legacyPool.Close()
+	return t.pool.Close()
 }


### PR DESCRIPTION
### Why this change is needed

The mempool integration needs a bit more work. 
The main issue that prevents that work is how we execute transactions to build a batch.
We need to rework them such that we execute them one by one.

Until then, it's useful to make the logs a little less verbose.

### What changes were made as part of this PR

- close the mempool properly
- filter out transactions with invalid base fee
- change logging level of tx execution failure

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


