### PR TITLE
increase max message size grpc config

### DIFF
--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -35,8 +35,10 @@ type RPCServer struct {
 // NewEnclaveRPCServer prepares an enclave RPCServer (doesn't start listening until `StartServer` is called
 func NewEnclaveRPCServer(listenAddress string, enclave common.Enclave, logger gethlog.Logger) *RPCServer {
 	return &RPCServer{
-		enclave:       enclave,
-		grpcServer:    grpc.NewServer(),
+		enclave: enclave,
+		grpcServer: grpc.NewServer(
+			grpc.MaxRecvMsgSize(1024 * 1024 * 50),
+		),
 		logger:        logger,
 		listenAddress: listenAddress,
 	}

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -516,7 +516,7 @@ func (c *Client) StreamL2Updates() (chan common.StreamL2UpdatesResponse, func())
 	batchChan := make(chan common.StreamL2UpdatesResponse, 10)
 	cancelCtx, cancel := context.WithCancel(context.Background())
 
-	stream, err := c.protoClient.StreamL2Updates(cancelCtx, &generated.StreamL2UpdatesRequest{})
+	stream, err := c.protoClient.StreamL2Updates(cancelCtx, &generated.StreamL2UpdatesRequest{}, grpc.MaxCallRecvMsgSize(1024*1024*50))
 	if err != nil {
 		c.logger.Error("Error opening batch stream.", log.ErrKey, err)
 		cancel()


### PR DESCRIPTION
### Why this change is needed

To avoid errors like: `grpc: received message larger than max`

### What changes were made as part of this PR

Increase some grpc default settings

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


