### PR TITLE
Network tests: start gateway synchronously to fix race

### DIFF
--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -114,15 +114,14 @@ func (t *testnetEnv) startTenGateway() {
 		TenChainID:              integration.TenChainID,
 	}
 	tenGWContainer := walletextension.NewContainerFromConfig(cfg, t.logger)
-	go func() {
-		fmt.Println("Starting Ten Gateway, HTTP Port:", _gwHTTPPort, "WS Port:", _gwWSPort)
-		err := tenGWContainer.Start()
-		if err != nil {
-			t.logger.Error("failed to start ten gateway", "err", err)
-			panic(err)
-		}
-		t.tenGatewayContainer = tenGWContainer
-	}()
+
+	fmt.Println("Starting Ten Gateway, HTTP Port:", _gwHTTPPort, "WS Port:", _gwWSPort)
+	err := tenGWContainer.Start()
+	if err != nil {
+		t.logger.Error("failed to start ten gateway", "err", err)
+		panic(err)
+	}
+	t.tenGatewayContainer = tenGWContainer
 	t.testnetConnector.tenGatewayURL = fmt.Sprintf("http://localhost:%d", _gwHTTPPort)
 }
 


### PR DESCRIPTION
### Why this change is needed

Running test against testnets but with local gateway was failing because it started async and wasn't up in time for the test interactions.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


