### PR TITLE
Network tests: util func for L1 transfers

### DIFF
--- a/integration/networktest/tests/helpful/accs_and_contracts_test.go
+++ b/integration/networktest/tests/helpful/accs_and_contracts_test.go
@@ -1,23 +1,113 @@
 package helpful
 
 import (
+	"context"
+	"fmt"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ten-protocol/go-ten/go/common/retry"
+	"github.com/ten-protocol/go-ten/go/wallet"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/networktest"
 	"github.com/ten-protocol/go-ten/integration/networktest/actions"
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
 )
 
-var _accountToFund = common.HexToAddress("0xD19f62b5A721747A04b969C90062CBb85D4aAaA8")
+/*
+ * This file contains helpful tests for funding accounts, transferring funds, interacting with contracts, etc.
+ */
 
-// Run this test to fund an account with native funds
+// Run this test to fund an account with native L2 funds
 func TestSendFaucetFunds(t *testing.T) {
+	// Set the account to fund here
+	accountToFund := common.HexToAddress("<account address to fund>")
+
 	networktest.TestOnlyRunsInIDE(t)
 	networktest.Run(
 		"send-faucet-funds",
 		t,
 		env.LongRunningLocalNetwork(""),
-		&actions.AllocateFaucetFunds{Account: &_accountToFund},
+		&actions.AllocateFaucetFunds{Account: &accountToFund},
+	)
+}
+
+// Run this test to send native L1 ETH from one account to another
+func TestTransferL1Funds(t *testing.T) {
+	// Set the accounts addresses and amount to send here
+	fromPK := "<pk string with no 0x prefix>"
+	to := common.HexToAddress("<account address to send to>")
+	// amount to send in wei
+	amt := big.NewInt(0).Mul(big.NewInt(1), big.NewInt(int64(params.Ether)))
+
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"send-native-funds",
+		t,
+		env.SepoliaTestnet(),
+		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+			l1Wallet := wallet.NewInMemoryWalletFromConfig(fromPK, _sepoliaChainID, testlog.Logger())
+			cli, err := network.GetL1Client()
+			if err != nil {
+				panic(err)
+			}
+			// in sepolia if you have issues, you may need a more reliable RPC endpoint, e.g. infura with an api-key:
+			// cli, err := ethadapter.NewEthClientFromURL("https://sepolia.infura.io/v3/<api-key>", 10*time.Second, common.HexToAddress("0x0"), testlog.Logger())
+			nonce, err := cli.Nonce(l1Wallet.Address())
+			if err != nil {
+				panic(err)
+			}
+			l1Wallet.SetNonce(nonce)
+
+			gasPrice, err := cli.EthClient().SuggestGasPrice(context.Background())
+			if err != nil {
+				panic(err)
+			}
+			// apply multiplier to the gas price here if you want to guarantee it goes through quickly
+			// gasPrice = big.NewInt(0).Mul(gasPrice, big.NewInt(2))
+
+			// create transaction from l1Wallet to toAddress
+			tx := &types.LegacyTx{
+				Nonce:    l1Wallet.GetNonce(),
+				Value:    amt,
+				Gas:      uint64(25_000),
+				GasPrice: gasPrice,
+				To:       &to,
+			}
+			signedTx, err := l1Wallet.SignTransaction(tx)
+			if err != nil {
+				panic(err)
+			}
+
+			err = cli.SendTransaction(signedTx)
+			if err != nil {
+				panic(err)
+			}
+
+			// await receipt
+			err = retry.Do(func() error {
+				receipt, err := cli.TransactionReceipt(signedTx.Hash())
+				if err != nil {
+					return err
+				}
+				if receipt == nil {
+					return fmt.Errorf("no receipt yet")
+				}
+				if receipt.Status != types.ReceiptStatusSuccessful {
+					return retry.FailFast(fmt.Errorf("receipt had status failed for transaction %s", signedTx.Hash().Hex()))
+				}
+				return nil
+			}, retry.NewTimeoutStrategy(70*time.Second, 20*time.Second))
+
+			if err != nil {
+				panic(err)
+			}
+
+			return ctx, nil
+		}),
 	)
 }

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -1,9 +1,19 @@
 package helpful
 
 import (
+	"context"
+	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ten-protocol/go-ten/go/common/retry"
+	"github.com/ten-protocol/go-ten/go/ethadapter"
+	"github.com/ten-protocol/go-ten/go/wallet"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/networktest"
 	"github.com/ten-protocol/go-ten/integration/networktest/actions"
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
@@ -32,5 +42,80 @@ func TestExecuteNativeFundsTransfer(t *testing.T) {
 			&actions.VerifyBalanceAfterTest{UserID: 1, ExpectedBalance: _transferAmount},
 			&actions.VerifyBalanceDiffAfterTest{UserID: 0, Snapshot: actions.SnapAfterAllocation, ExpectedDiff: big.NewInt(0).Neg(_transferAmount)},
 		),
+	)
+}
+
+// util test that transfers funds from a sepolia account with a known PK to another account
+func TestExecuteSepoliaFundsTransfer(t *testing.T) {
+	networktest.TestOnlyRunsInIDE(t)
+	networktest.Run(
+		"sepolia-funds-smoketest",
+		t,
+		env.SepoliaTestnet(),
+		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
+			// create wallet for DEPLOYER_PK
+			DEPLOYER_PK := ""
+			l1Wallet := wallet.NewInMemoryWalletFromConfig(DEPLOYER_PK, _sepoliaChainID, testlog.Logger())
+			cli, err := ethadapter.NewEthClientFromURL("https://sepolia.infura.io/v3/187f3057b39849d091727cc3dcfae011", 10*time.Second, gethcommon.HexToAddress("0x0"), testlog.Logger())
+			if err != nil {
+				panic(err)
+			}
+			nonce, err := cli.Nonce(l1Wallet.Address())
+			if err != nil {
+				panic(err)
+			}
+
+			l1Wallet.SetNonce(nonce)
+
+			amt := big.NewInt(0).Mul(big.NewInt(0), big.NewInt(int64(params.GWei)))
+
+			destAddr := gethcommon.HexToAddress("0x563EAc5dfDFebA3C53c2160Bf1Bd62941E3D0005")
+
+			gasPrice, err := cli.EthClient().SuggestGasPrice(context.Background())
+			if err != nil {
+				panic(err)
+			}
+			// multiply gas price by 2
+			gasPrice = big.NewInt(0).Mul(gasPrice, big.NewInt(3))
+
+			// create transaction from l1Wallet to toAddress
+			tx := &types.LegacyTx{
+				Nonce:    l1Wallet.GetNonce(),
+				Value:    amt,
+				Gas:      uint64(25_000),
+				GasPrice: gasPrice,
+				To:       &destAddr,
+			}
+			signedTx, err := l1Wallet.SignTransaction(tx)
+			if err != nil {
+				panic(err)
+			}
+
+			err = cli.SendTransaction(signedTx)
+			if err != nil {
+				panic(err)
+			}
+
+			// await receipt
+			err = retry.Do(func() error {
+				receipt, err := cli.TransactionReceipt(signedTx.Hash())
+				if err != nil {
+					return err
+				}
+				if receipt == nil {
+					return fmt.Errorf("no receipt yet")
+				}
+				if receipt.Status != types.ReceiptStatusSuccessful {
+					return retry.FailFast(fmt.Errorf("receipt had status failed for transaction %s", signedTx.Hash().Hex()))
+				}
+				return nil
+			}, retry.NewTimeoutStrategy(70*time.Second, 20*time.Second))
+
+			if err != nil {
+				panic(err)
+			}
+
+			return ctx, nil
+		}),
 	)
 }

--- a/integration/networktest/tests/helpful/smoke_test.go
+++ b/integration/networktest/tests/helpful/smoke_test.go
@@ -1,19 +1,9 @@
 package helpful
 
 import (
-	"context"
-	"fmt"
 	"math/big"
 	"testing"
-	"time"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ten-protocol/go-ten/go/common/retry"
-	"github.com/ten-protocol/go-ten/go/ethadapter"
-	"github.com/ten-protocol/go-ten/go/wallet"
-	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/networktest"
 	"github.com/ten-protocol/go-ten/integration/networktest/actions"
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
@@ -42,80 +32,5 @@ func TestExecuteNativeFundsTransfer(t *testing.T) {
 			&actions.VerifyBalanceAfterTest{UserID: 1, ExpectedBalance: _transferAmount},
 			&actions.VerifyBalanceDiffAfterTest{UserID: 0, Snapshot: actions.SnapAfterAllocation, ExpectedDiff: big.NewInt(0).Neg(_transferAmount)},
 		),
-	)
-}
-
-// util test that transfers funds from a sepolia account with a known PK to another account
-func TestExecuteSepoliaFundsTransfer(t *testing.T) {
-	networktest.TestOnlyRunsInIDE(t)
-	networktest.Run(
-		"sepolia-funds-smoketest",
-		t,
-		env.SepoliaTestnet(),
-		actions.RunOnlyAction(func(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
-			// create wallet for DEPLOYER_PK
-			DEPLOYER_PK := ""
-			l1Wallet := wallet.NewInMemoryWalletFromConfig(DEPLOYER_PK, _sepoliaChainID, testlog.Logger())
-			cli, err := ethadapter.NewEthClientFromURL("https://sepolia.infura.io/v3/187f3057b39849d091727cc3dcfae011", 10*time.Second, gethcommon.HexToAddress("0x0"), testlog.Logger())
-			if err != nil {
-				panic(err)
-			}
-			nonce, err := cli.Nonce(l1Wallet.Address())
-			if err != nil {
-				panic(err)
-			}
-
-			l1Wallet.SetNonce(nonce)
-
-			amt := big.NewInt(0).Mul(big.NewInt(0), big.NewInt(int64(params.GWei)))
-
-			destAddr := gethcommon.HexToAddress("0x563EAc5dfDFebA3C53c2160Bf1Bd62941E3D0005")
-
-			gasPrice, err := cli.EthClient().SuggestGasPrice(context.Background())
-			if err != nil {
-				panic(err)
-			}
-			// multiply gas price by 2
-			gasPrice = big.NewInt(0).Mul(gasPrice, big.NewInt(3))
-
-			// create transaction from l1Wallet to toAddress
-			tx := &types.LegacyTx{
-				Nonce:    l1Wallet.GetNonce(),
-				Value:    amt,
-				Gas:      uint64(25_000),
-				GasPrice: gasPrice,
-				To:       &destAddr,
-			}
-			signedTx, err := l1Wallet.SignTransaction(tx)
-			if err != nil {
-				panic(err)
-			}
-
-			err = cli.SendTransaction(signedTx)
-			if err != nil {
-				panic(err)
-			}
-
-			// await receipt
-			err = retry.Do(func() error {
-				receipt, err := cli.TransactionReceipt(signedTx.Hash())
-				if err != nil {
-					return err
-				}
-				if receipt == nil {
-					return fmt.Errorf("no receipt yet")
-				}
-				if receipt.Status != types.ReceiptStatusSuccessful {
-					return retry.FailFast(fmt.Errorf("receipt had status failed for transaction %s", signedTx.Hash().Hex()))
-				}
-				return nil
-			}, retry.NewTimeoutStrategy(70*time.Second, 20*time.Second))
-
-			if err != nil {
-				panic(err)
-			}
-
-			return ctx, nil
-		}),
 	)
 }


### PR DESCRIPTION
### Why this change is needed

Utility test in the network tests that lets you transfer L1 funds from one acc to another (providing PK string, dest address, amount).

Useful for moving/recovering funds on sepolia.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


