### PR TITLE
Host: ignore empty L1 head status from enclave

### DIFF
--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -120,7 +120,10 @@ func (s *StateTracker) OnEnclaveStatus(es common.Status) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.enclaveStatusCode = es.StatusCode
-	s.enclaveL1Head = es.L1Head
+	// only update L1 head if non-empty head reported
+	if es.L1Head != gethutil.EmptyHash {
+		s.enclaveL1Head = es.L1Head
+	}
 	s.enclaveL2Head = es.L2Head
 
 	s.setStatus(s.calculateStatus())


### PR DESCRIPTION
### Why this change is needed

If enclave had issues with db it sometimes failed to report an L1 head, then the guardian in the host started replaying blocks from L2 genesis.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


