### PR TITLE
truncate events

### DIFF
--- a/go/enclave/main/enclave-test.json
+++ b/go/enclave/main/enclave-test.json
@@ -2,7 +2,7 @@
   "exe": "main",
   "key": "testnet.pem",
   "debug": true,
-  "heapSize": 4096,
+  "heapSize": 8192,
   "executableHeap": true,
   "productID": 1,
   "securityVersion": 1,

--- a/go/enclave/main/enclave.json
+++ b/go/enclave/main/enclave.json
@@ -2,7 +2,7 @@
   "exe": "main",
   "key": "testnet.pem",
   "debug": true,
-  "heapSize": 4096,
+  "heapSize": 8192,
   "executableHeap": true,
   "productID": 1,
   "securityVersion": 1,

--- a/go/enclave/storage/init/migration/db_migration.go
+++ b/go/enclave/storage/init/migration/db_migration.go
@@ -20,6 +20,13 @@ import (
 const currentMigrationVersionKey = "CURRENT_MIGRATION_VERSION"
 
 func DBMigration(db *sql.DB, sqlFiles embed.FS, logger gethlog.Logger) error {
+
+	// this is a temporary performance fix
+	_, err := db.Exec("truncate table events")
+	if err != nil {
+		return fmt.Errorf("failed to trunctate events. Cause: %w", err)
+	}
+
 	migrationFiles, err := readMigrationFiles(sqlFiles)
 	if err != nil {
 		return err


### PR DESCRIPTION
DO NOT MERGE
### Why this change is needed

to relieve performance until a proper fix.

### What changes were made as part of this PR

truncate the events table

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


