### PR TITLE
Properly create the event interface for deployment script in order to fix testnet startup.

### DIFF
--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -54,7 +54,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const topic = hre.ethers.id(eventSignature)
 
     // Get the interface for the event in order to convert it to cross chain message.
-    let eventIface = new hre.ethers.Interface([ `event ${eventSignature}`]);
+    let eventIface = new hre.ethers.Interface([ `event LogMessagePublished(address indexed,uint64,uint32,uint32,bytes,uint8)`]);
 
     // This function converts the logs from transaction receipts into cross chain messages
     function getXChainMessages(result: Receipt) {


### PR DESCRIPTION
### Why this change is needed

Previous merge broke the testnet startup due to a mismatch in the actual event and the one put in the interface to process it in the javascript deployment scripts.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


