### PR TITLE
EDB Connect: placeholder commit for new GH action workflow

### DIFF
--- a/.github/workflows/manual-publish-edb-connect.yml
+++ b/.github/workflows/manual-publish-edb-connect.yml
@@ -1,0 +1,33 @@
+# Publishes the latest version of edb-connect to the Azure Container Registry
+# Users will then have access to this latest version when they run the edb-connect.sh script on the node VMs.
+
+name: "[M] Publish EDB Connect"
+run-name: "[M] Publish EDB Connect"
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Set up Docker"
+        uses: docker/setup-buildx-action@v1
+
+      - name: "Login to Azure docker registry"
+        uses: azure/docker-login@v1
+        with:
+          login-server: testnetobscuronet.azurecr.io
+          username: testnetobscuronet
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: "Login via Azure CLI"
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Build and Push Docker EDB Connect Image
+        run: |
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_EDB_CONNECT }} -f ./tools/edbconnect/Dockerfile . 
+          docker push ${{ vars.DOCKER_BUILD_TAG_EDB_CONNECT }}


### PR DESCRIPTION
### Why this change is needed

Want to test the EDB Connect changes end to end but can't without the GH action workflow file existing on main.

This will not be actively used until https://github.com/ten-protocol/go-ten/pull/1963 is tested and merged.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


