### PR TITLE
db tweaks + getLogs Fix

### DIFF
--- a/go/common/log_events.go
+++ b/go/common/log_events.go
@@ -43,7 +43,7 @@ func CreateAuthenticatedLogSubscriptionPayload(args []interface{}, vk *viewingke
 	if !ok {
 		return nil, fmt.Errorf("invalid subscription")
 	}
-	fc := FromCriteria(filterCriteria)
+	fc := SerializableFilterCriteria(filterCriteria)
 	logSubscription.Filter = &fc
 	return logSubscription, nil
 }
@@ -59,7 +59,7 @@ type FilterCriteriaJSON struct {
 	Topics    [][]common.Hash  `json:"topics"`
 }
 
-func FromCriteria(crit FilterCriteria) FilterCriteriaJSON {
+func SerializableFilterCriteria(crit FilterCriteria) FilterCriteriaJSON {
 	var from *rpc.BlockNumber
 	if crit.FromBlock != nil {
 		f := (rpc.BlockNumber)(crit.FromBlock.Int64())

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -237,8 +237,6 @@ func loadLogs(ctx context.Context, db *sql.DB, requestingAccount *gethcommon.Add
 	query += whereCondition
 	queryParams = append(queryParams, whereParams...)
 
-	query += " order by b.height, tx.idx asc"
-
 	rows, err := db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -18,9 +18,9 @@ import (
 
 const (
 	baseEventsJoin = "from event_log e " +
-		"join receipt extx on e.receipt=extx.id" +
-		"	join tx on extx.tx=tx.id " +
-		"	join batch b on extx.batch=b.sequence " +
+		"join receipt rec on e.receipt=rec.id" +
+		"	join tx on rec.tx=tx.id " +
+		"	join batch b on rec.batch=b.sequence " +
 		"join event_type et on e.event_type=et.id " +
 		"	join contract c on et.contract=c.id " +
 		"left join event_topic t1 on e.topic1=t1.id " +

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -104,12 +104,12 @@ GRANT ALL ON obsdb.tx TO obscuro;
 
 create table if not exists obsdb.receipt
 (
-    id                       INTEGER AUTO_INCREMENT,
-    content                  mediumblob,
-    tx                       int,
-    batch                    int NOT NULL,
+    id      INTEGER AUTO_INCREMENT,
+    content mediumblob,
+    tx      int,
+    batch   int NOT NULL,
     INDEX (batch),
-    INDEX (tx),
+    INDEX (tx, batch),
     primary key (id)
 );
 GRANT ALL ON obsdb.receipt TO obscuro;
@@ -166,6 +166,7 @@ create table if not exists obsdb.event_log
     log_idx    INTEGER NOT NULL,
     receipt    INTEGER NOT NULL,
     primary key (id),
-    INDEX (receipt, event_type, topic1, topic2, topic3)
+    INDEX (receipt, event_type, topic1, topic2, topic3),
+    INDEX (event_type, topic1, topic2, topic3)
 );
 GRANT ALL ON obsdb.event_log TO obscuro;

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -984,22 +984,13 @@ func (s *storageImpl) FilterLogs(
 	if err != nil {
 		return nil, err
 	}
-	sort.Sort(sortByHeightAndIndex(logs))
+	sort.Slice(logs, func(i, j int) bool {
+		if logs[i].BlockNumber == logs[j].BlockNumber {
+			return logs[i].Index < logs[j].Index
+		}
+		return logs[i].BlockNumber < logs[j].BlockNumber
+	})
 	return logs, nil
-}
-
-type sortByHeightAndIndex []*types.Log
-
-func (c sortByHeightAndIndex) Len() int      { return len(c) }
-func (c sortByHeightAndIndex) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c sortByHeightAndIndex) Less(i, j int) bool {
-	if c[i].BlockNumber < c[j].BlockNumber {
-		return true
-	}
-	if c[i].BlockNumber == c[j].BlockNumber {
-		return c[i].Index < c[j].Index
-	}
-	return false
 }
 
 func (s *storageImpl) GetContractCount(ctx context.Context) (*big.Int, error) {

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -984,6 +984,8 @@ func (s *storageImpl) FilterLogs(
 	if err != nil {
 		return nil, err
 	}
+	// the database returns an unsorted list of event logs.
+	// we have to perform the sorting programatically
 	sort.Slice(logs, func(i, j int) bool {
 		if logs[i].BlockNumber == logs[j].BlockNumber {
 			return logs[i].Index < logs[j].Index

--- a/go/host/l1/statemachine.go
+++ b/go/host/l1/statemachine.go
@@ -17,8 +17,10 @@ import (
 	"github.com/ten-protocol/go-ten/go/ethadapter/mgmtcontractlib"
 )
 
-type ForkUniqueID = gethcommon.Hash
-type RollupNumber = uint64
+type (
+	ForkUniqueID = gethcommon.Hash
+	RollupNumber = uint64
+)
 
 type CrossChainStateMachine interface {
 	GetRollupData(number RollupNumber) (RollupInfo, error)
@@ -75,9 +77,11 @@ func NewCrossChainStateMachine(
 func (c *crossChainStateMachine) Start() error {
 	return nil
 }
+
 func (c *crossChainStateMachine) Stop() error {
 	return nil
 }
+
 func (c *crossChainStateMachine) HealthStatus(context.Context) host.HealthStatus {
 	errMsg := ""
 	if c.hostStopper.IsStopping() {
@@ -174,7 +178,7 @@ func (c *crossChainStateMachine) revertToLatestKnownCommonAncestorRollup() error
 
 	for forkHash != c.latestRollup.ForkUID {
 		// Revert to previous rollup; No need to wipe the map as the synchronization reinserts the latest rollup
-		c.latestRollup = c.rollupHistory[c.latestRollup.Number-1] //go to previous rollup
+		c.latestRollup = c.rollupHistory[c.latestRollup.Number-1] // go to previous rollup
 
 		hashBytes, _, err = managementContract.GetUniqueForkID(&bind.CallOpts{}, big.NewInt(0).SetUint64(c.latestRollup.Number))
 		if err != nil {

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -261,7 +261,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 	if err != nil {
 		return nil, err
 	}
-	audit(api.we, "RPC call. uid=%s, method=%s args=%v result=%s error=%s time=%d", hexutils.BytesToHex(userID), method, crit, res, err, time.Since(requestStartTime).Milliseconds())
+	audit(api.we, "RPC call. uid=%s, method=%s args=%v result=%s error=%v time=%d", hexutils.BytesToHex(userID), method, crit, res, err, time.Since(requestStartTime).Milliseconds())
 	return *res, err
 }
 

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -261,7 +261,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 	if err != nil {
 		return nil, err
 	}
-	audit(api.we, "RPC call. uid=%s, method=%s args=%v result=%s error=%v time=%d", hexutils.BytesToHex(userID), method, crit, res, err, time.Since(requestStartTime).Milliseconds())
+	audit(api.we, "RPC call. uid=%s, method=%s args=%v result=%v error=%v time=%d", hexutils.BytesToHex(userID), method, crit, res, err, time.Since(requestStartTime).Milliseconds())
 	return *res, err
 }
 

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -192,14 +192,18 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 		&ExecCfg{
 			cacheCfg: &CacheCfg{
 				CacheTypeDynamic: func() CacheStrategy {
-					// when the toBlock is not specified, the request is open-ended
 					if crit.ToBlock != nil && crit.ToBlock.Int64() > 0 {
 						return LongLiving
 					}
+					if crit.BlockHash != nil {
+						return LongLiving
+					}
+					// when the toBlock or the block Hash are not specified, the request is open-ended
 					return LatestBatch
 				},
 			},
-			tryUntilAuthorised: true,
+			tryAll:            true,
+			accumulateResults: true, // we want the events that are relevant to all accounts registered by the current user
 			adjustArgs: func(acct *GWAccount) []any {
 				// convert to something serializable
 				return []any{common.FromCriteria(crit)}


### PR DESCRIPTION
### Why this change is needed

- the event log query is inefficient because of the "order by" ( the database uses a temporary file).
- when no batch range is passed in, the getLogs query does not use the index, and performs a full table scan 
- the "getLogs" function does not concatenate the results of all the registered accounts for a user at the gateway level

### What changes were made as part of this PR

- remove the db order by, and sort in the code
- add more indexes 
- fix the "getLogs" function in the gateway to perform concatenation and deduplication

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


