### PR TITLE
Set Restart policy on docker containers

### DIFF
--- a/go/common/docker/docker.go
+++ b/go/common/docker/docker.go
@@ -104,10 +104,11 @@ func StartNewContainer(containerName, image string, cmds []string, ports []int, 
 		Env:          envVars,
 	},
 		&container.HostConfig{
-			PortBindings: portBindings,
-			Mounts:       mountVolumes,
-			Resources:    container.Resources{Devices: deviceMapping},
-			LogConfig:    container.LogConfig{Type: "json-file", Config: logOptions},
+			PortBindings:  portBindings,
+			Mounts:        mountVolumes,
+			RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+			Resources:     container.Resources{Devices: deviceMapping},
+			LogConfig:     container.LogConfig{Type: "json-file", Config: logOptions},
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{


### PR DESCRIPTION
### Why this change is needed

Add resilience to jammed services. First mitigation is to restart.

### What changes were made as part of this PR

Changed the Host Config of the Go docker client to add restart policy

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


