### PR TITLE
Fix for empty messages.

### DIFF
--- a/go/enclave/crosschain/common.go
+++ b/go/enclave/crosschain/common.go
@@ -221,7 +221,7 @@ func (ms MessageStructs) HashPacked(index int) gethcommon.Hash {
 	addrType, _ := abi.NewType("address", "", nil)
 	uint64Type, _ := abi.NewType("uint64", "", nil)
 	uint32Type, _ := abi.NewType("uint32", "", nil)
-	uint8Type, _ := abi.NewType("uint32", "", nil)
+	uint8Type, _ := abi.NewType("uint8", "", nil)
 	bytesType, _ := abi.NewType("bytes", "", nil)
 	args := abi.Arguments{
 		{
@@ -245,7 +245,10 @@ func (ms MessageStructs) HashPacked(index int) gethcommon.Hash {
 	}
 
 	// todo @siliev: err
-	packed, _ := args.Pack(messageStruct.Sender, messageStruct.Sequence, messageStruct.Nonce, messageStruct.Topic, messageStruct.Payload, messageStruct.ConsistencyLevel)
+	packed, err := args.Pack(messageStruct.Sender, messageStruct.Sequence, messageStruct.Nonce, messageStruct.Topic, messageStruct.Payload, messageStruct.ConsistencyLevel)
+	if err != nil {
+		panic(err)
+	}
 	hash := crypto.Keccak256Hash(packed)
 	return hash
 }
@@ -298,7 +301,10 @@ func (vt ValueTransfers) HashPacked(index int) gethcommon.Hash {
 		},
 	}
 
-	bytes, _ := args.Pack(valueTransfer.Sender, valueTransfer.Receiver, valueTransfer.Amount, valueTransfer.Sequence)
+	bytes, err := args.Pack(valueTransfer.Sender, valueTransfer.Receiver, valueTransfer.Amount, valueTransfer.Sequence)
+	if err != nil {
+		panic(err)
+	}
 
 	hash := crypto.Keccak256Hash(bytes)
 	return hash

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -202,6 +202,7 @@ const BalanceIncreaseXChainValueTransfer tracing.BalanceChangeReason = 110
 func (m *MessageBusManager) ExecuteValueTransfers(ctx context.Context, transfers common.ValueTransferEvents, rollupState *state.StateDB) {
 	for _, transfer := range transfers {
 		rollupState.AddBalance(transfer.Receiver, uint256.MustFromBig(transfer.Amount), BalanceIncreaseXChainValueTransfer)
+		m.logger.Debug(fmt.Sprintf("Executed cross chain value transfer from %s to %s with amount %s", transfer.Sender.Hex(), transfer.Receiver.Hex(), transfer.Amount.String()))
 	}
 }
 


### PR DESCRIPTION
### Why this change is needed

There is an issue with representing cross chain messages's hashes currently. When encoded to the batch tree, they end up listed as hash of empty value. This PR addresses this;
### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


