### PR TITLE
TEN RPC: replace custom query with personal transactions

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -141,9 +141,8 @@ type EnclaveScan interface {
 	// GetTotalContractCount returns the total number of contracts that have been deployed
 	GetTotalContractCount(context.Context) (*big.Int, SystemError)
 
-	// GetCustomQuery returns the data of a custom query
-	// todo - better name and description
-	GetCustomQuery(ctx context.Context, encryptedParams EncryptedParamsGetStorageAt) (*responses.PrivateQueryResponse, SystemError)
+	// GetPersonalTransactions returns the user's recent transactions according to specified pagination
+	GetPersonalTransactions(ctx context.Context, encryptedParams EncryptedParamsGetPersonalTransactions) (*responses.PersonalTransactionsResponse, SystemError)
 
 	// EnclavePublicConfig returns network data that is known to the enclave but can be shared publicly
 	EnclavePublicConfig(context.Context) (*EnclavePublicConfig, SystemError)

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -345,20 +345,10 @@ func (enc *gethEncodingServiceImpl) CreateEthBlockFromBatch(ctx context.Context,
 	return (*types.Block)(unsafe.Pointer(&lb)), nil
 }
 
-// ExtractPrivateCustomQuery is designed to support a wide range of custom Ten queries.
+// ExtractPrivateTransactionsQuery is designed to support a wide range of custom Ten queries.
 // The first parameter here is the method name, which is used to determine the query type.
 // The second parameter is the query parameters.
-func ExtractPrivateCustomQuery(methodName any, queryParams any) (*common.ListPrivateTransactionsQueryParams, error) {
-	// we expect the first parameter to be a string
-	methodNameStr, ok := methodName.(string)
-	if !ok {
-		return nil, fmt.Errorf("expected methodName as string but was type %T", methodName)
-	}
-	// currently we only have to support this custom query method in the enclave
-	if methodNameStr != common.ListPrivateTransactionsCQMethod {
-		return nil, fmt.Errorf("unsupported method %s", methodNameStr)
-	}
-
+func ExtractPrivateTransactionsQuery(methodName any, queryParams any) (*common.ListPrivateTransactionsQueryParams, error) {
 	// we expect second param to be a json string
 	queryParamsStr, ok := queryParams.(string)
 	if !ok {

--- a/go/common/gethencoding/geth_encoding.go
+++ b/go/common/gethencoding/geth_encoding.go
@@ -348,7 +348,7 @@ func (enc *gethEncodingServiceImpl) CreateEthBlockFromBatch(ctx context.Context,
 // ExtractPrivateTransactionsQuery is designed to support a wide range of custom Ten queries.
 // The first parameter here is the method name, which is used to determine the query type.
 // The second parameter is the query parameters.
-func ExtractPrivateTransactionsQuery(methodName any, queryParams any) (*common.ListPrivateTransactionsQueryParams, error) {
+func ExtractPrivateTransactionsQuery(queryParams any) (*common.ListPrivateTransactionsQueryParams, error) {
 	// we expect second param to be a json string
 	queryParamsStr, ok := queryParams.(string)
 	if !ok {

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -63,16 +63,16 @@ type (
 	EncryptedTx           []byte // A single transaction, encoded as a JSON list of transaction binary hexes and encrypted using the enclave's public key
 	EncryptedTransactions []byte // A blob of encrypted transactions, as they're stored in the rollup, with the nonce prepended.
 
-	EncryptedParamsGetBalance      []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
-	EncryptedParamsCall            []byte // As above, but for an RPC call request.
-	EncryptedParamsGetTxByHash     []byte // As above, but for an RPC getTransactionByHash request.
-	EncryptedParamsGetTxReceipt    []byte // As above, but for an RPC getTransactionReceipt request.
-	EncryptedParamsLogSubscription []byte // As above, but for an RPC logs subscription request.
-	EncryptedParamsSendRawTx       []byte // As above, but for an RPC sendRawTransaction request.
-	EncryptedParamsGetTxCount      []byte // As above, but for an RPC getTransactionCount request.
-	EncryptedParamsEstimateGas     []byte // As above, but for an RPC estimateGas request.
-	EncryptedParamsGetLogs         []byte // As above, but for an RPC getLogs request.
-	EncryptedParamsGetStorageAt    []byte
+	EncryptedParamsGetBalance              []byte // The params for an RPC getBalance request, as a JSON object encrypted with the public key of the enclave.
+	EncryptedParamsCall                    []byte // As above, but for an RPC call request.
+	EncryptedParamsGetTxByHash             []byte // As above, but for an RPC getTransactionByHash request.
+	EncryptedParamsGetTxReceipt            []byte // As above, but for an RPC getTransactionReceipt request.
+	EncryptedParamsLogSubscription         []byte // As above, but for an RPC logs subscription request.
+	EncryptedParamsSendRawTx               []byte // As above, but for an RPC sendRawTransaction request.
+	EncryptedParamsGetTxCount              []byte // As above, but for an RPC getTransactionCount request.
+	EncryptedParamsEstimateGas             []byte // As above, but for an RPC estimateGas request.
+	EncryptedParamsGetLogs                 []byte // As above, but for an RPC getLogs request.
+	EncryptedParamsGetPersonalTransactions []byte
 
 	Nonce               = uint64
 	EncodedRollup       []byte

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -855,15 +855,14 @@ func (e *enclaveImpl) GetTotalContractCount(ctx context.Context) (*big.Int, comm
 	return e.storage.GetContractCount(ctx)
 }
 
-// GetCustomQuery is a generic query method for queries that don't match the eth API.
-// todo: get rid of this method and use specific methods for each query (e.g. GetPersonalTransactions)
-func (e *enclaveImpl) GetCustomQuery(ctx context.Context, encryptedParams common.EncryptedParamsGetStorageAt) (*responses.PrivateQueryResponse, common.SystemError) {
+// GetPersonalTransactions returns the recent private transactions for the given account
+func (e *enclaveImpl) GetPersonalTransactions(ctx context.Context, encryptedParams common.EncryptedParamsGetPersonalTransactions) (*responses.PersonalTransactionsResponse, common.SystemError) {
 	// ensure the enclave is running
 	if e.stopControl.IsStopping() {
 		return nil, responses.ToInternalError(fmt.Errorf("requested GetPrivateTransactions with the enclave stopping"))
 	}
 
-	return rpc.WithVKEncryption(ctx, e.rpcEncryptionManager, encryptedParams, rpc.GetCustomQueryValidate, rpc.GetCustomQueryExecute)
+	return rpc.WithVKEncryption(ctx, e.rpcEncryptionManager, encryptedParams, rpc.GetPersonalTransactionsValidate, rpc.GetPersonalTransactionsExecute)
 }
 
 func (e *enclaveImpl) EnclavePublicConfig(context.Context) (*common.EnclavePublicConfig, common.SystemError) {

--- a/go/enclave/rpc/GetCustomQuery.go
+++ b/go/enclave/rpc/GetCustomQuery.go
@@ -7,14 +7,14 @@ import (
 	"github.com/ten-protocol/go-ten/go/common/gethencoding"
 )
 
-func GetCustomQueryValidate(reqParams []any, builder *CallBuilder[common.ListPrivateTransactionsQueryParams, common.PrivateTransactionsQueryResponse], _ *EncryptionManager) error {
+func GetPersonalTransactionsValidate(reqParams []any, builder *CallBuilder[common.ListPrivateTransactionsQueryParams, common.PrivateTransactionsQueryResponse], _ *EncryptionManager) error {
 	// Parameters are [PrivateCustomQueryHeader, PrivateCustomQueryArgs, null]
 	if len(reqParams) != 3 {
 		builder.Err = fmt.Errorf("unexpected number of parameters (expected %d, got %d)", 3, len(reqParams))
 		return nil
 	}
 
-	privateCustomQuery, err := gethencoding.ExtractPrivateCustomQuery(reqParams[0], reqParams[1])
+	privateCustomQuery, err := gethencoding.ExtractPrivateTransactionsQuery(reqParams[0], reqParams[1])
 	if err != nil {
 		builder.Err = fmt.Errorf("unable to extract query - %w", err)
 		return nil
@@ -25,7 +25,7 @@ func GetCustomQueryValidate(reqParams []any, builder *CallBuilder[common.ListPri
 	return nil
 }
 
-func GetCustomQueryExecute(builder *CallBuilder[common.ListPrivateTransactionsQueryParams, common.PrivateTransactionsQueryResponse], rpc *EncryptionManager) error {
+func GetPersonalTransactionsExecute(builder *CallBuilder[common.ListPrivateTransactionsQueryParams, common.PrivateTransactionsQueryResponse], rpc *EncryptionManager) error {
 	err := authenticateFrom(builder.VK, builder.From)
 	if err != nil {
 		builder.Err = err

--- a/go/enclave/rpc/GetPersonalTransactions.go
+++ b/go/enclave/rpc/GetPersonalTransactions.go
@@ -8,13 +8,13 @@ import (
 )
 
 func GetPersonalTransactionsValidate(reqParams []any, builder *CallBuilder[common.ListPrivateTransactionsQueryParams, common.PrivateTransactionsQueryResponse], _ *EncryptionManager) error {
-	// Parameters are [PrivateCustomQueryHeader, PrivateCustomQueryArgs, null]
-	if len(reqParams) != 3 {
-		builder.Err = fmt.Errorf("unexpected number of parameters (expected %d, got %d)", 3, len(reqParams))
+	// Parameters are [PrivateTransactionListParams]
+	if len(reqParams) != 1 {
+		builder.Err = fmt.Errorf("unexpected number of parameters (expected %d, got %d)", 1, len(reqParams))
 		return nil
 	}
 
-	privateCustomQuery, err := gethencoding.ExtractPrivateTransactionsQuery(reqParams[0], reqParams[1])
+	privateCustomQuery, err := gethencoding.ExtractPrivateTransactionsQuery(reqParams[0])
 	if err != nil {
 		builder.Err = fmt.Errorf("unable to extract query - %w", err)
 		return nil

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -452,7 +452,7 @@ func (s *RPCServer) GetTotalContractCount(ctx context.Context, _ *generated.GetT
 }
 
 func (s *RPCServer) GetReceiptsByAddress(ctx context.Context, req *generated.GetReceiptsByAddressRequest) (*generated.GetReceiptsByAddressResponse, error) {
-	enclaveResp, sysError := s.enclave.GetCustomQuery(ctx, req.EncryptedParams)
+	enclaveResp, sysError := s.enclave.GetPersonalTransactions(ctx, req.EncryptedParams)
 	if sysError != nil {
 		s.logger.Error("Error getting receipt", log.ErrKey, sysError)
 		return &generated.GetReceiptsByAddressResponse{SystemError: toRPCError(sysError)}, nil

--- a/go/host/rpc/clientapi/client_api_eth.go
+++ b/go/host/rpc/clientapi/client_api_eth.go
@@ -178,9 +178,9 @@ func (api *EthereumAPI) GetTransactionByHash(ctx context.Context, encryptedParam
 	return *enclaveResponse, nil
 }
 
-// GetStorageAt is a reused method for listing the users transactions
-func (api *EthereumAPI) GetStorageAt(ctx context.Context, encryptedParams common.EncryptedParamsGetStorageAt) (*responses.Receipts, error) {
-	return api.host.EnclaveClient().GetCustomQuery(ctx, encryptedParams)
+// GetStorageAt is not currently supported (some narrow version of it may be supported in the future for proxy contracts).
+func (api *EthereumAPI) GetStorageAt(ctx context.Context, encryptedParams common.EncryptedParamsGetPersonalTransactions) (*responses.Receipts, error) {
+	return nil, fmt.Errorf("GetStorageAt is not supported on TEN")
 }
 
 // FeeHistory is a placeholder for an RPC method required by MetaMask/Remix.

--- a/go/host/rpc/clientapi/client_api_scan.go
+++ b/go/host/rpc/clientapi/client_api_scan.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ten-protocol/go-ten/go/responses"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/go/common"
@@ -117,4 +118,11 @@ func (s *ScanAPI) GetRollupBatches(rollupHash gethcommon.Hash) (*common.BatchLis
 // GetBatchTransactions returns the public tx data of all txs present in a rollup given its hash
 func (s *ScanAPI) GetBatchTransactions(batchHash gethcommon.Hash) (*common.TransactionListingResponse, error) {
 	return s.host.Storage().FetchBatchTransactions(batchHash)
+}
+
+// These methods are for private user data, they will need to be requested with VK (e.g. via the gateway)
+
+// GetPersonalTransactions gets the private transactions data for a given user
+func (s *ScanAPI) GetPersonalTransactions(ctx context.Context, encryptedParams common.EncryptedParamsGetPersonalTransactions) (*responses.Receipts, error) {
+	return s.host.EnclaveClient().GetPersonalTransactions(ctx, encryptedParams)
 }

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -587,7 +587,7 @@ func (c *Client) GetTotalContractCount(ctx context.Context) (*big.Int, common.Sy
 	return big.NewInt(response.Count), nil
 }
 
-func (c *Client) GetCustomQuery(ctx context.Context, encryptedParams common.EncryptedParamsGetStorageAt) (*responses.PrivateQueryResponse, common.SystemError) {
+func (c *Client) GetPersonalTransactions(ctx context.Context, encryptedParams common.EncryptedParamsGetPersonalTransactions) (*responses.PersonalTransactionsResponse, common.SystemError) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, c.enclaveRPCTimeout)
 	defer cancel()
 

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -261,8 +261,7 @@ func (ac *AuthObsClient) GetPrivateTransactions(ctx context.Context, address *ge
 		return nil, 0, fmt.Errorf("unable to marshal query params - %w", err)
 	}
 	var result common.PrivateTransactionsQueryResponse
-	// todo @matt don't use the string method name here and avoid stringifying the params
-	err = ac.rpcClient.CallContext(ctx, &result, rpc.GetPersonalTransactions, common.ListPrivateTransactionsCQMethod, string(queryParamStr), nil)
+	err = ac.rpcClient.CallContext(ctx, &result, rpc.GetPersonalTransactions, queryParamStr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/obsclient/authclient.go
+++ b/go/obsclient/authclient.go
@@ -261,7 +261,8 @@ func (ac *AuthObsClient) GetPrivateTransactions(ctx context.Context, address *ge
 		return nil, 0, fmt.Errorf("unable to marshal query params - %w", err)
 	}
 	var result common.PrivateTransactionsQueryResponse
-	err = ac.rpcClient.CallContext(ctx, &result, rpc.GetStorageAt, common.ListPrivateTransactionsCQMethod, string(queryParamStr), nil)
+	// todo @matt don't use the string method name here and avoid stringifying the params
+	err = ac.rpcClient.CallContext(ctx, &result, rpc.GetPersonalTransactions, common.ListPrivateTransactionsCQMethod, string(queryParamStr), nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/responses/types.go
+++ b/go/responses/types.go
@@ -24,16 +24,16 @@ func (ur *UserResponse[T]) Error() error {
 // Responses
 
 type (
-	Balance              = EnclaveResponse // The response for an RPC getBalance request, as a JSON object encrypted with the viewing key of the user.
-	Call                 = EnclaveResponse // As above, but for an RPC call request.
-	TxReceipt            = EnclaveResponse // As above, but for an RPC getTransactionReceipt request.
-	RawTx                = EnclaveResponse // As above, but for an RPC sendRawTransaction request.
-	TxByHash             = EnclaveResponse // As above, but for an RPC getTransactionByHash request.
-	TxCount              = EnclaveResponse // As above, but for an RPC getTransactionCount request.
-	Gas                  = EnclaveResponse // As above, but for an RPC estimateGas response.
-	Logs                 = EnclaveResponse
-	Receipts             = EnclaveResponse
-	PrivateQueryResponse = EnclaveResponse
+	Balance                      = EnclaveResponse // The response for an RPC getBalance request, as a JSON object encrypted with the viewing key of the user.
+	Call                         = EnclaveResponse // As above, but for an RPC call request.
+	TxReceipt                    = EnclaveResponse // As above, but for an RPC getTransactionReceipt request.
+	RawTx                        = EnclaveResponse // As above, but for an RPC sendRawTransaction request.
+	TxByHash                     = EnclaveResponse // As above, but for an RPC getTransactionByHash request.
+	TxCount                      = EnclaveResponse // As above, but for an RPC getTransactionCount request.
+	Gas                          = EnclaveResponse // As above, but for an RPC estimateGas response.
+	Logs                         = EnclaveResponse
+	Receipts                     = EnclaveResponse
+	PersonalTransactionsResponse = EnclaveResponse
 )
 
 // Data Types

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -44,12 +44,13 @@ const (
 	GetBatchByHeight         = "scan_getBatchByHeight"
 	GetTransaction           = "scan_getTransaction"
 
-	GetRollupListing     = "scan_getRollupListing"
-	GetBatchListingNew   = "scan_getBatchListingNew"
-	GetRollupByHash      = "scan_getRollupByHash"
-	GetRollupBatches     = "scan_getRollupBatches"
-	GetRollupBySeqNo     = "scan_getRollupBySeqNo"
-	GetBatchTransactions = "scan_getBatchTransactions"
+	GetRollupListing        = "scan_getRollupListing"
+	GetBatchListingNew      = "scan_getBatchListingNew"
+	GetRollupByHash         = "scan_getRollupByHash"
+	GetRollupBatches        = "scan_getRollupBatches"
+	GetRollupBySeqNo        = "scan_getRollupBySeqNo"
+	GetBatchTransactions    = "scan_getBatchTransactions"
+	GetPersonalTransactions = "scan_getPersonalTransactions"
 )
 
 // Client is used by client applications to interact with the Ten node

--- a/go/rpc/encrypted_client.go
+++ b/go/rpc/encrypted_client.go
@@ -41,6 +41,7 @@ var SensitiveMethods = []string{
 	EstimateGas,
 	GetLogs,
 	GetStorageAt,
+	GetPersonalTransactions,
 }
 
 // EncRPCClient is a Client wrapper that implements Client but also has extra functionality for managing viewing key registration and decryption

--- a/tools/walletextension/rpcapi/blockchain_api.go
+++ b/tools/walletextension/rpcapi/blockchain_api.go
@@ -165,7 +165,7 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address gethcommon.A
 		if err != nil {
 			return nil, fmt.Errorf("unable to extract address from custom query params: %w", err)
 		}
-		resp, err := ExecAuthRPC[any](ctx, api.we, &ExecCfg{account: userAddr}, "scan_getPersonalTransactions", address.Hex(), params, nil)
+		resp, err := ExecAuthRPC[any](ctx, api.we, &ExecCfg{account: userAddr}, "scan_getPersonalTransactions", params)
 		if err != nil {
 			return nil, fmt.Errorf("unable to execute custom query: %w", err)
 		}

--- a/tools/walletextension/rpcapi/blockchain_api.go
+++ b/tools/walletextension/rpcapi/blockchain_api.go
@@ -165,8 +165,7 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address gethcommon.A
 		if err != nil {
 			return nil, fmt.Errorf("unable to extract address from custom query params: %w", err)
 		}
-		// todo: we should be calling something like `ten_getPrivateTransactions` here, this custom query stuff only needs to be in the gateway layer
-		resp, err := ExecAuthRPC[any](ctx, api.we, &ExecCfg{account: userAddr}, "eth_getStorageAt", address.Hex(), params, nil)
+		resp, err := ExecAuthRPC[any](ctx, api.we, &ExecCfg{account: userAddr}, "scan_getPersonalTransactions", address.Hex(), params, nil)
 		if err != nil {
 			return nil, fmt.Errorf("unable to execute custom query: %w", err)
 		}


### PR DESCRIPTION
### Why this change is needed

Custom query is a tunnel through the ETH RPC API, it shouldn't be mentioned on the node. TEN RPC can support GetPersonalTransactions explicitly.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


