### PR TITLE
tweak cache config

### DIFF
--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -62,9 +62,8 @@ type CacheService struct {
 func NewCacheService(logger gethlog.Logger) *CacheService {
 	// todo (tudor) figure out the config
 	ristrettoCache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 100_000_000,        // 10 times the expected elements
-		MaxCost:     1024 * 1024 * 1024, // allocate 1GB
-		BufferItems: 64,                 // number of keys per Get buffer.
+		NumCounters: 10 * 10 * 1000,    // 10 times the expected elements (10 caches * 1000 historic elements)
+		MaxCost:     512 * 1024 * 1024, // allocate 512MB
 	})
 	if err != nil {
 		logger.Crit("Could not initialise ristretto cache", log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

The testnet enclaves crash with OOM periodically.

### What changes were made as part of this PR

Tweak the cache config. Reduce the `NumCounters` and the total allocated size

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


