### PR TITLE
Gateway: allow CORS all origins to fix firefox error

### DIFF
--- a/lib/gethfork/node/rpc_server.go
+++ b/lib/gethfork/node/rpc_server.go
@@ -53,14 +53,15 @@ func NewServer(config *RPCConfig, logger gethlog.Logger) Server {
 	if config.EnableHTTP {
 		rpcConfig.HTTPHost = config.Host
 		rpcConfig.HTTPPort = config.HTTPPort
-		// todo (@pedro) - review if this poses a security issue
+		// todo - review if this poses a security issue
+		rpcConfig.HTTPCors = []string{allOrigins}
 		rpcConfig.HTTPVirtualHosts = []string{allOrigins}
 		rpcConfig.HTTPPathPrefix = config.HTTPPath
 	}
 	if config.EnableWs {
 		rpcConfig.WSHost = config.Host
 		rpcConfig.WSPort = config.WsPort
-		// todo (@pedro) - review if this poses a security issue
+		// todo - review if this poses a security issue
 		rpcConfig.WSOrigins = []string{allOrigins}
 		rpcConfig.WSPathPrefix = config.WsPath
 	}


### PR DESCRIPTION
### Why this change is needed

Metamask RPC requests from Firefox were failing with CORS errors so TEN Gateway was unusable with FF.

### What changes were made as part of this PR

Permit all CORS origins (there is a todo above the line already to review this at some point for safety, for now this unblocks testnet users).

![image](https://github.com/user-attachments/assets/1d7941ed-0006-4107-abe3-f5c33c46edac)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


