### PR TITLE
Fix for hardhat deployer dependency being incorrect.

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -26,5 +26,8 @@
     "ethers": "^6.6.0",
     "hardhat-ignore-warnings": "^0.2.6",
     "ten-hardhat-plugin": "^0.0.9"
+  },
+  "peerDependencies": {
+    "@nomicfoundation/hardhat-verify" : "2.0.8"
   }
 }


### PR DESCRIPTION
### Why this change is needed

One of the dependencies has a soft lock on a dependency version, which was going too high up and being incompatible with the rest of our stuff.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


