### PR TITLE
add dummy fields to keep ethers6 happy

### DIFF
--- a/tools/walletextension/rpcapi/blockchain_api.go
+++ b/tools/walletextension/rpcapi/blockchain_api.go
@@ -116,6 +116,11 @@ func (api *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.Block
 	// convert to geth header and marshall
 	header := subscription.ConvertBatchHeader(resp)
 	fields := RPCMarshalHeader(header)
+
+	// dummy fields
+	fields["size"] = hexutil.Uint64(0)
+	fields["transactions"] = []any{}
+
 	addExtraTenFields(fields, resp)
 	return fields, err
 }
@@ -129,6 +134,11 @@ func (api *BlockChainAPI) GetBlockByHash(ctx context.Context, hash gethcommon.Ha
 	// convert to geth header and marshall
 	header := subscription.ConvertBatchHeader(resp)
 	fields := RPCMarshalHeader(header)
+
+	// dummy fields
+	fields["size"] = hexutil.Uint64(0)
+	fields["transactions"] = []any{}
+
 	addExtraTenFields(fields, resp)
 	return fields, err
 }


### PR DESCRIPTION
### Why this change is needed

Ethers6 tries to read the `transactions` field of the returned "block" and fails 

### What changes were made as part of this PR

- add the dummy field

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


