### PR TITLE
disable rate limiting on local testnet

### DIFF
--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -191,6 +191,7 @@ func (t *Testnet) Start() error {
 			gateway.WithTenNodeHTTPPort(13010),
 			gateway.WithTenNodeWSPort(13011),
 			gateway.WithTenNodeHost("validator-host"),
+			gateway.WithRateLimitUserComputeTime(0), // disable rate limiting for local network
 			gateway.WithDockerImage("testnetobscuronet.azurecr.io/obscuronet/obscuro_gateway:latest"),
 		),
 	)

--- a/testnet/launcher/gateway/config.go
+++ b/testnet/launcher/gateway/config.go
@@ -1,16 +1,19 @@
 package gateway
 
+import "time"
+
 // Option is a function that applies configs to a Config Object
 type Option = func(c *Config)
 
 // Config holds the properties that configure the package
 type Config struct {
-	tenNodeHost     string
-	tenNodeHTTPPort int
-	tenNodeWSPort   int
-	gatewayHTTPPort int
-	gatewayWSPort   int
-	dockerImage     string
+	tenNodeHost              string
+	tenNodeHTTPPort          int
+	tenNodeWSPort            int
+	gatewayHTTPPort          int
+	gatewayWSPort            int
+	rateLimitUserComputeTime time.Duration
+	dockerImage              string
 }
 
 func NewGatewayConfig(opts ...Option) *Config {
@@ -56,5 +59,11 @@ func WithGatewayHTTPPort(i int) Option {
 func WithGatewayWSPort(i int) Option {
 	return func(c *Config) {
 		c.gatewayWSPort = i
+	}
+}
+
+func WithRateLimitUserComputeTime(d time.Duration) Option {
+	return func(c *Config) {
+		c.rateLimitUserComputeTime = d
 	}
 }

--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -33,6 +33,7 @@ func (n *DockerGateway) Start() error {
 		"--nodeHost", n.cfg.tenNodeHost,
 		"--dbType", "sqlite",
 		"--logPath", "sys_out",
+		"--rateLimitUserComputeTime", fmt.Sprintf("%d", n.cfg.rateLimitUserComputeTime),
 	}
 
 	_, err := docker.StartNewContainer("gateway", n.cfg.dockerImage, cmds, []int{n.cfg.gatewayHTTPPort, n.cfg.gatewayWSPort}, nil, nil, nil)

--- a/tools/walletextension/ratelimiter/rate_limiter.go
+++ b/tools/walletextension/ratelimiter/rate_limiter.go
@@ -220,7 +220,7 @@ func (rl *RateLimiter) periodicPrune() {
 	}
 
 	for {
-		time.Sleep(rl.window * 10)
+		time.Sleep(rl.window / 2)
 		rl.PruneRequests()
 	}
 }

--- a/tools/walletextension/ratelimiter/rate_limiter.go
+++ b/tools/walletextension/ratelimiter/rate_limiter.go
@@ -28,6 +28,10 @@ var zeroUUID uuid.UUID
 
 // AddRequest adds a new request interval to a user's current requests and returns the UUID.
 func (rl *RateLimiter) AddRequest(userID common.Address, interval RequestInterval) uuid.UUID {
+	// If the userComputeTime is 0, do nothing (rate limiting is disabled)
+	if rl.GetUserComputeTime() == 0 {
+		return zeroUUID
+	}
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
@@ -45,6 +49,11 @@ func (rl *RateLimiter) AddRequest(userID common.Address, interval RequestInterva
 
 // SetRequestEnd updates the end time of a request interval given its UUID.
 func (rl *RateLimiter) SetRequestEnd(userID common.Address, id uuid.UUID) {
+	// If the userComputeTime is 0, do nothing (rate limiting is disabled)
+	if rl.GetUserComputeTime() == 0 {
+		return
+	}
+
 	if user, userExists := rl.users[userID]; userExists {
 		if request, requestExists := user.CurrentRequests[id]; requestExists {
 			rl.mu.Lock()
@@ -205,6 +214,11 @@ func (rl *RateLimiter) PruneRequests() {
 
 // periodically prunes the requests that have ended before the rate limiter's window every 10 * window milliseconds
 func (rl *RateLimiter) periodicPrune() {
+	// If the userComputeTime is 0, do nothing (rate limiting is disabled)
+	if rl.GetUserComputeTime() == 0 {
+		return
+	}
+
 	for {
 		time.Sleep(rl.window * 10)
 		rl.PruneRequests()
@@ -212,6 +226,11 @@ func (rl *RateLimiter) periodicPrune() {
 }
 
 func (rl *RateLimiter) logRateLimitedStats() {
+	// If the userComputeTime is 0, do nothing (rate limiting is disabled)
+	if rl.GetUserComputeTime() == 0 {
+		return
+	}
+
 	for {
 		time.Sleep(30 * time.Minute)
 		rl.mu.Lock()

--- a/tools/walletextension/ratelimiter/rate_limiter.go
+++ b/tools/walletextension/ratelimiter/rate_limiter.go
@@ -217,7 +217,7 @@ func (rl *RateLimiter) PruneRequests() {
 	}
 }
 
-// periodically prunes the requests that have ended before the rate limiter's window every 10 * window milliseconds
+// periodically prunes the requests that have ended before the rate limiter's window milliseconds
 func (rl *RateLimiter) periodicPrune() {
 	for {
 		time.Sleep(rl.window / 2)


### PR DESCRIPTION
### Why this change is needed

Disable rate limiting on local testnet by default, because we run some tests that require a lot of requests.
It includes also:
- usage of read locks where possible in rate limiting

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


