### PR TITLE
filter out irrelevant l1 txs, before sending into the enclave

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -125,7 +125,7 @@ type (
 // To work properly, all of the receipts are required, due to rlp encoding pruning some of the information.
 // The receipts must also be in the correct order.
 type BlockAndReceipts struct {
-	Block                  *types.Block
+	Block                  *L1Block
 	ReceiptsMap            map[int]*types.Receipt // sparse map with obscuro-relevant receipts in it
 	Receipts               *types.Receipts
 	successfulTransactions *types.Transactions

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -3,7 +3,6 @@ package nodetype
 import (
 	"context"
 
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ten-protocol/go-ten/go/common"
 	"github.com/ten-protocol/go-ten/go/enclave/components"
 	"github.com/ten-protocol/go-ten/go/enclave/core"
@@ -21,7 +20,7 @@ type NodeType interface {
 	OnL1Fork(ctx context.Context, fork *common.ChainFork) error
 
 	// OnL1Block - performed after the block was processed
-	OnL1Block(ctx context.Context, block *types.Block, result *components.BlockIngestionType) error
+	OnL1Block(ctx context.Context, block *common.L1Block, result *components.BlockIngestionType) error
 
 	ExportCrossChainData(context.Context, uint64, uint64) (*common.ExtCrossChainBundle, error)
 

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -513,7 +513,7 @@ func (s *sequencer) signCrossChainBundle(bundle *common.ExtCrossChainBundle) err
 	return nil
 }
 
-func (s *sequencer) OnL1Block(ctx context.Context, block *types.Block, result *components.BlockIngestionType) error {
+func (s *sequencer) OnL1Block(ctx context.Context, _ *common.L1Block, result *components.BlockIngestionType) error {
 	// nothing to do
 	return nil
 }

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -9,8 +9,6 @@ import (
 	"github.com/ten-protocol/go-ten/go/enclave/crypto"
 	"github.com/ten-protocol/go-ten/go/enclave/txpool"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ten-protocol/go-ten/go/common/errutil"
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/signature"
@@ -187,7 +185,7 @@ func (val *obsValidator) handleGenesis(ctx context.Context, batch *common.BatchH
 	return nil
 }
 
-func (val *obsValidator) OnL1Block(ctx context.Context, block *types.Block, result *components.BlockIngestionType) error {
+func (val *obsValidator) OnL1Block(ctx context.Context, _ *common.L1Block, result *components.BlockIngestionType) error {
 	return val.ExecuteStoredBatches(ctx)
 }
 

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -425,6 +425,15 @@ func (g *Guardian) submitL1Block(block *common.L1Block, isLatest bool) (bool, er
 		g.submitDataLock.Unlock() // lock must be released before returning
 		return false, fmt.Errorf("could not fetch obscuro receipts for block=%s - %w", block.Hash(), err)
 	}
+	// only submit the relevant transactions to the enclave
+	// nullify all non-relevant transactions
+	txs := block.Transactions()
+	for i, rec := range receipts {
+		if rec == nil {
+			txs[i] = nil
+		}
+	}
+
 	resp, err := g.enclaveClient.SubmitL1Block(context.Background(), block, receipts, isLatest)
 	g.submitDataLock.Unlock() // lock is only guarding the enclave call, so we can release it now
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

We have a memory leak which kills our node every few days on sepolia.
Upon investigation, it turns out there is a memory leak inside RLP decoding when submitting a sepolia block. More specifically when decoding the L1 transactions.
We only need very few L1 transactions inside the enclave, and we are sending all of them. 

### What changes were made as part of this PR

Filter out transactions that are irrelevant before submitting an L1 block to the enclave.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


