### PR TITLE
only configure docker autorestart on the main containers

### DIFF
--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -130,7 +130,7 @@ func (d *DockerNode) startHost() error {
 		d.cfg.hostP2PPort,
 	}
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-host", d.cfg.hostImage, cmd, exposedPorts, nil, nil, nil)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-host", d.cfg.hostImage, cmd, exposedPorts, nil, nil, nil, true)
 
 	return err
 }
@@ -195,7 +195,7 @@ func (d *DockerNode) startEnclave() error {
 
 	// we need the enclave volume to store the db credentials
 	enclaveVolume := map[string]string{d.cfg.nodeName + "-enclave-volume": _enclaveDataDir}
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-enclave", d.cfg.enclaveImage, cmd, exposedPorts, envs, devices, enclaveVolume, true)
 
 	return err
 }
@@ -222,7 +222,7 @@ func (d *DockerNode) startEdgelessDB() error {
 	//dbVolume := map[string]string{d.cfg.nodeName + "-db-volume": "/data"}
 	//_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, dbVolume)
 
-	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil)
+	_, err := docker.StartNewContainer(d.cfg.nodeName+"-edgelessdb", d.cfg.edgelessDBImage, nil, nil, envs, devices, nil, true)
 
 	return err
 }

--- a/testnet/launcher/eth2network/docker.go
+++ b/testnet/launcher/eth2network/docker.go
@@ -48,7 +48,7 @@ func (n *Eth2Network) Start() error {
 	// keep a volume of binaries to avoid downloading
 	volume := map[string]string{"eth2_bin": "/home/obscuro/go-obscuro/integration/.build/eth2_bin/"}
 
-	_, err := docker.StartNewContainer("eth2network", "testnetobscuronet.azurecr.io/obscuronet/eth2network:latest", cmds, exposedPorts, nil, nil, volume)
+	_, err := docker.StartNewContainer("eth2network", "testnetobscuronet.azurecr.io/obscuronet/eth2network:latest", cmds, exposedPorts, nil, nil, volume, false)
 	return err
 }
 

--- a/testnet/launcher/faucet/docker.go
+++ b/testnet/launcher/faucet/docker.go
@@ -32,7 +32,7 @@ func (n *DockerFaucet) Start() error {
 		"--serverPort", fmt.Sprintf("%d", n.cfg.faucetPort),
 	}
 
-	_, err := docker.StartNewContainer("faucet", n.cfg.dockerImage, cmds, []int{n.cfg.faucetPort}, nil, nil, nil)
+	_, err := docker.StartNewContainer("faucet", n.cfg.dockerImage, cmds, []int{n.cfg.faucetPort}, nil, nil, nil, false)
 	return err
 }
 

--- a/testnet/launcher/fundsrecovery/docker.go
+++ b/testnet/launcher/fundsrecovery/docker.go
@@ -52,7 +52,7 @@ func (n *FundsRecovery) Start() error {
 `, n.cfg.l1HTTPURL, n.cfg.l1privateKey),
 	}
 
-	containerID, err := docker.StartNewContainer("recover-funds", n.cfg.dockerImage, cmds, nil, envs, nil, nil)
+	containerID, err := docker.StartNewContainer("recover-funds", n.cfg.dockerImage, cmds, nil, envs, nil, nil, false)
 	if err != nil {
 		return err
 	}

--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -35,7 +35,7 @@ func (n *DockerGateway) Start() error {
 		"--logPath", "sys_out",
 	}
 
-	_, err := docker.StartNewContainer("gateway", n.cfg.dockerImage, cmds, []int{n.cfg.gatewayHTTPPort, n.cfg.gatewayWSPort}, nil, nil, nil)
+	_, err := docker.StartNewContainer("gateway", n.cfg.dockerImage, cmds, []int{n.cfg.gatewayHTTPPort, n.cfg.gatewayWSPort}, nil, nil, nil, true)
 	return err
 }
 

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -58,7 +58,7 @@ func (n *ContractDeployer) Start() error {
 `, n.cfg.l1HTTPURL, n.cfg.privateKey),
 	}
 
-	containerID, err := docker.StartNewContainer("hh-l1-deployer", n.cfg.dockerImage, cmds, ports, envs, nil, nil)
+	containerID, err := docker.StartNewContainer("hh-l1-deployer", n.cfg.dockerImage, cmds, ports, envs, nil, nil, false)
 	if err != nil {
 		return err
 	}

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -82,7 +82,7 @@ func (n *ContractDeployer) Start() error {
 `, n.cfg.l1HTTPURL, n.cfg.l1privateKey, n.cfg.l2PrivateKey, n.cfg.hocPKString, n.cfg.pocPKString),
 	}
 
-	containerID, err := docker.StartNewContainer("hh-l2-deployer", n.cfg.dockerImage, cmds, ports, envs, nil, nil)
+	containerID, err := docker.StartNewContainer("hh-l2-deployer", n.cfg.dockerImage, cmds, ports, envs, nil, nil, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Why this change is needed

We only need the main containers to restart. Currently, even the helper containers have the setting, which is causing unexpected behaviour.



