### PR TITLE
Stopped returning errors on republish.

### DIFF
--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -316,7 +316,8 @@ func (p *Publisher) PublishCrossChainBundle(bundle *common.ExtCrossChainBundle, 
 	tx, err := managementCtr.AddCrossChainMessagesRoot(transactor, [32]byte(bundle.LastBatchHash.Bytes()), bundle.L1BlockHash, bundle.L1BlockNum, bundle.CrossChainRootHashes, bundle.Signature, rollupNum, forkID)
 	if err != nil {
 		if !errors.Is(err, errutil.ErrCrossChainBundleRepublished) {
-			p.logger.Error("Error with submitting cross chain bundle transaction.", log.ErrKey, err, log.BundleHashKey, bundle.LastBatchHash)
+			p.logger.Info("Cross chain bundle already published. Proceeding without publishing", log.ErrKey, err, log.BundleHashKey, bundle.LastBatchHash)
+			return nil
 		}
 		p.hostWallet.SetNonce(p.hostWallet.GetNonce() - 1)
 		return fmt.Errorf("unable to submit cross chain bundle transaction. Cause: %w", err)

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -32,7 +32,7 @@ const (
 // Spins up a local network with a gateway, with all processes debuggable. The network will run until the test is stopped.
 // Note: If you want to access the gateway frontend you need to `npm run build` its frontend with NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:11180
 func TestRunLocalNetwork(t *testing.T) {
-	//networktest.TestOnlyRunsInIDE(t)
+	networktest.TestOnlyRunsInIDE(t)
 	networktest.EnsureTestLogsSetUp("local-geth-network")
 	networkConnector, cleanUp, err := env.LocalDevNetwork(devnetwork.WithGateway()).Prepare()
 	if err != nil {

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -32,7 +32,7 @@ const (
 // Spins up a local network with a gateway, with all processes debuggable. The network will run until the test is stopped.
 // Note: If you want to access the gateway frontend you need to `npm run build` its frontend with NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:11180
 func TestRunLocalNetwork(t *testing.T) {
-	networktest.TestOnlyRunsInIDE(t)
+	//networktest.TestOnlyRunsInIDE(t)
 	networktest.EnsureTestLogsSetUp("local-geth-network")
 	networkConnector, cleanUp, err := env.LocalDevNetwork(devnetwork.WithGateway()).Prepare()
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

UAT and Sepolia get stuck when publishing bundles due to a lacking return nil statement for republished bundles. This stuck happens on restart, as the node restarts from the 0th bundle and keeps forwarding until it synchronizes the state. 

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


