### PR TITLE
increase new heads timeout

### DIFF
--- a/tools/walletextension/rpcapi/wallet_extension.go
+++ b/tools/walletextension/rpcapi/wallet_extension.go
@@ -147,7 +147,7 @@ func subscribeToNewHeadsWithRetry(ch chan *tencommon.BatchHeader, services Servi
 			}
 			return err
 		},
-		retry.NewTimeoutStrategy(10*time.Minute, 1*time.Second),
+		retry.NewTimeoutStrategy(20*time.Minute, 1*time.Second),
 	)
 	if err != nil {
 		logger.Error("could not subscribe for new head blocks.", log.ErrKey, err)


### PR DESCRIPTION
### Why this change is needed

Gateway usually crashed when doing L2 deploy or especially L2 upgrade.
This was due to:
```
CRIT [08-01|12:46:52.745] could not connect to new heads:          component=wallet_extension err="cannot subscribe to new heads to the backend timed out after 10m0s (16 attempts) - latest error: cannot fetch rpc connection to backend node could not create RPC client on ws://erpc.dev-testnet.obscu.ro:81. Cause: dial tcp 51.11.135.65:81: connect: connection timed out"
```

Increasing timeout to 20 minutes solves this issue.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


