### PR TITLE
Beacon health check

### DIFF
--- a/integration/constants.go
+++ b/integration/constants.go
@@ -24,6 +24,7 @@ const (
 	DefaultGethHTTPPortOffset       = 400
 	DefaultPrysmP2PPortOffset       = 500
 	DefaultPrysmRPCPortOffset       = 550
+	DefaultPrysmGatewayPortOffset   = 560
 	DefaultHostP2pOffset            = 600 // The default offset for the host P2p
 	DefaultEnclaveOffset            = 700 // The default offset between a Geth nodes port and the enclave ports. Used in Socket Simulations.
 	DefaultHostRPCHTTPOffset        = 800 // The default offset for the host's RPC HTTP port

--- a/integration/eth2network/main/cli.go
+++ b/integration/eth2network/main/cli.go
@@ -27,6 +27,9 @@ const (
 	prysmBeaconRPCStartPortName  = "prysmBeaconRPCStartPort"
 	prysmBeaconRPCStartPortUsage = "The initial port to start allocating prysm rpc port"
 
+	prysmBeaconGatewayStartPortName  = "prysmBeaconGatewayStartPort"
+	prysmBeaconGatewayStartPortUsage = "The gateway port to connect to prysm"
+
 	prysmBeaconP2PStartPortName  = "prysmBeaconP2PtartPort"
 	prysmBeaconP2PStartPortUsage = "The p2p udp prysm port"
 
@@ -38,28 +41,30 @@ const (
 )
 
 type ethConfig struct {
-	chainID                 int
-	gethHTTPStartPort       int
-	gethWSStartPort         int
-	gethAuthRPCStartPort    int
-	gethNetworkStartPort    int
-	prysmBeaconRPCStartPort int
-	prysmBeaconP2PStartPort int
-	logLevel                int
-	prefundedAddrs          []string
+	chainID                     int
+	gethHTTPStartPort           int
+	gethWSStartPort             int
+	gethAuthRPCStartPort        int
+	gethNetworkStartPort        int
+	prysmBeaconRPCStartPort     int
+	prysmBeaconP2PStartPort     int
+	prysmBeaconGatewayStartPort int
+	logLevel                    int
+	prefundedAddrs              []string
 }
 
 func defaultConfig() *ethConfig {
 	return &ethConfig{
-		chainID:                 1337,
-		gethHTTPStartPort:       12000,
-		gethWSStartPort:         12100,
-		gethAuthRPCStartPort:    12200,
-		gethNetworkStartPort:    12300,
-		prysmBeaconRPCStartPort: 12400,
-		prysmBeaconP2PStartPort: 12500,
-		prefundedAddrs:          []string{},
-		logLevel:                int(gethlog.LvlDebug),
+		chainID:                     1337,
+		gethHTTPStartPort:           12000,
+		gethWSStartPort:             12100,
+		gethAuthRPCStartPort:        12200,
+		gethNetworkStartPort:        12300,
+		prysmBeaconRPCStartPort:     12400,
+		prysmBeaconP2PStartPort:     12500,
+		prysmBeaconGatewayStartPort: 12600,
+		prefundedAddrs:              []string{},
+		logLevel:                    int(gethlog.LvlDebug),
 	}
 }
 
@@ -73,6 +78,7 @@ func parseCLIArgs() *ethConfig {
 	gethNetworkStartPort := flag.Int(gethNetworkStartPortName, defaultConfig.gethNetworkStartPort, gethNetworkStartPortUsage)
 	prysmBeaconP2PStartPort := flag.Int(prysmBeaconP2PStartPortName, defaultConfig.prysmBeaconP2PStartPort, prysmBeaconP2PStartPortUsage)
 	prysmBeaconRPCStartPort := flag.Int(prysmBeaconRPCStartPortName, defaultConfig.prysmBeaconRPCStartPort, prysmBeaconRPCStartPortUsage)
+	prysmBeaconGatewayStartPort := flag.Int(prysmBeaconGatewayStartPortName, defaultConfig.prysmBeaconGatewayStartPort, prysmBeaconGatewayStartPortUsage)
 	logLevel := flag.Int(logLevelName, defaultConfig.logLevel, logLevelUsage)
 	prefundedAddrs := flag.String(prefundedAddrsName, "", prefundedAddrsUsage)
 
@@ -91,14 +97,15 @@ func parseCLIArgs() *ethConfig {
 	}
 
 	return &ethConfig{
-		chainID:                 *chainID,
-		gethHTTPStartPort:       *gethHTTPPort,
-		gethWSStartPort:         *gethWSPort,
-		gethAuthRPCStartPort:    *gethAuthRPCStartPort,
-		gethNetworkStartPort:    *gethNetworkStartPort,
-		prysmBeaconRPCStartPort: *prysmBeaconRPCStartPort,
-		prysmBeaconP2PStartPort: *prysmBeaconP2PStartPort,
-		logLevel:                *logLevel,
-		prefundedAddrs:          parsedPrefundedAddrs,
+		chainID:                     *chainID,
+		gethHTTPStartPort:           *gethHTTPPort,
+		gethWSStartPort:             *gethWSPort,
+		gethAuthRPCStartPort:        *gethAuthRPCStartPort,
+		gethNetworkStartPort:        *gethNetworkStartPort,
+		prysmBeaconRPCStartPort:     *prysmBeaconRPCStartPort,
+		prysmBeaconP2PStartPort:     *prysmBeaconP2PStartPort,
+		prysmBeaconGatewayStartPort: *prysmBeaconGatewayStartPort,
+		logLevel:                    *logLevel,
+		prefundedAddrs:              parsedPrefundedAddrs,
 	}
 }

--- a/integration/eth2network/main/main.go
+++ b/integration/eth2network/main/main.go
@@ -30,7 +30,7 @@ func main() {
 		config.gethHTTPStartPort,
 		config.prysmBeaconRPCStartPort,
 		config.chainID,
-		6*time.Minute,
+		3*time.Minute,
 		config.prefundedAddrs...,
 	)
 

--- a/integration/eth2network/main/main.go
+++ b/integration/eth2network/main/main.go
@@ -29,6 +29,7 @@ func main() {
 		config.gethWSStartPort,
 		config.gethHTTPStartPort,
 		config.prysmBeaconRPCStartPort,
+		config.prysmBeaconGatewayStartPort,
 		config.chainID,
 		3*time.Minute,
 		config.prefundedAddrs...,

--- a/integration/eth2network/pos_eth2_network_test.go
+++ b/integration/eth2network/pos_eth2_network_test.go
@@ -48,6 +48,7 @@ func TestStartPosEth2Network(t *testing.T) {
 		_startPort+integration.DefaultGethWSPortOffset,
 		_startPort+integration.DefaultGethHTTPPortOffset,
 		_startPort+integration.DefaultPrysmRPCPortOffset,
+		_startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 	)

--- a/integration/eth2network/pos_eth2_network_test.go
+++ b/integration/eth2network/pos_eth2_network_test.go
@@ -49,7 +49,7 @@ func TestStartPosEth2Network(t *testing.T) {
 		_startPort+integration.DefaultGethHTTPPortOffset,
 		_startPort+integration.DefaultPrysmRPCPortOffset,
 		integration.EthereumChainID,
-		6*time.Minute,
+		3*time.Minute,
 	)
 
 	// wait until the merge has happened

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -7,6 +7,7 @@ GETH_HTTP_PORT=8025
 GETH_WS_PORT=9000
 GETH_RPC_PORT=8552
 BEACON_RPC_PORT=4000
+BEACON_GATEWAY_PORT=3500
 CHAIN_ID=1337
 BUILD_DIR="./build"
 BASE_PATH="./"
@@ -50,6 +51,7 @@ while [[ "$#" -gt 0 ]]; do
         --geth-network) GETH_NETWORK_PORT="$2"; shift ;;
         --beacon-p2p) BEACON_P2P_PORT="$2"; shift ;;
         --beacon-rpc) BEACON_RPC_PORT="$2"; shift ;;
+        --grpc-gateway-port) BEACON_GATEWAY_PORT="$2"; shift ;;
         --geth-http) GETH_HTTP_PORT="$2"; shift ;;
         --geth-ws) GETH_WS_PORT="$2"; shift ;;
         --geth-rpc) GETH_RPC_PORT="$2"; shift ;;
@@ -106,6 +108,7 @@ ${BEACON_BINARY} --datadir="${BEACONDATA_DIR}" \
                --rpc-host=127.0.0.1 \
                --rpc-port="${BEACON_RPC_PORT}" \
                --p2p-udp-port="${BEACON_P2P_PORT}" \
+               --grpc-gateway-port=${BEACON_GATEWAY_PORT} \
                --accept-terms-of-use \
                --jwt-secret "${BASE_PATH}/jwt.hex" \
                --suggested-fee-recipient 0x123463a4B065722E99115D6c222f267d9cABb524 \

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -48,6 +48,7 @@ func TestCanStartStandaloneTenHostAndEnclave(t *testing.T) {
 		_startPort+integration.DefaultGethWSPortOffset,
 		_startPort+integration.DefaultGethHTTPPortOffset,
 		_startPort+integration.DefaultPrysmRPCPortOffset,
+		_startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 	)

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -64,10 +64,11 @@ func StartGethNetwork(wallets *params.SimWallets, startPort int) (eth2network.Po
 		binDir,
 		startPort+integration.DefaultGethNetworkPortOffset,
 		startPort+integration.DefaultPrysmP2PPortOffset,
-		startPort+integration.DefaultGethAUTHPortOffset, // RPC
+		startPort+integration.DefaultGethAUTHPortOffset,
 		startPort+integration.DefaultGethWSPortOffset,
 		startPort+integration.DefaultGethHTTPPortOffset,
-		startPort+integration.DefaultPrysmRPCPortOffset, // RPC
+		startPort+integration.DefaultPrysmRPCPortOffset,
+		startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 		walletAddresses...,

--- a/integration/simulation/network/geth_utils.go
+++ b/integration/simulation/network/geth_utils.go
@@ -69,7 +69,7 @@ func StartGethNetwork(wallets *params.SimWallets, startPort int) (eth2network.Po
 		startPort+integration.DefaultGethHTTPPortOffset,
 		startPort+integration.DefaultPrysmRPCPortOffset, // RPC
 		integration.EthereumChainID,
-		6*time.Minute,
+		3*time.Minute,
 		walletAddresses...,
 	)
 

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -62,7 +62,8 @@ func runGethNetwork(t *testing.T) *netInfo {
 		_startPort+integration.DefaultGethAUTHPortOffset, // RPC
 		_startPort+integration.DefaultGethWSPortOffset,
 		_startPort+integration.DefaultGethHTTPPortOffset,
-		_startPort+integration.DefaultPrysmRPCPortOffset, // RPC
+		_startPort+integration.DefaultPrysmRPCPortOffset,
+		_startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 		workerWallet.Address().String(),


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3777

### What changes were made as part of this PR

* Check for active beacon network on startup
* Dial beacon network after startup
* Reduce unnecessarily long timeouts since merge happens in 2min

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


