### PR TITLE
fix concurrency issue in SumComputeTime

### DIFF
--- a/tools/walletextension/ratelimiter/rate_limiter.go
+++ b/tools/walletextension/ratelimiter/rate_limiter.go
@@ -104,6 +104,9 @@ func (rl *RateLimiter) SumComputeTime(userID common.Address) time.Duration {
 
 	var totalComputeTime time.Duration
 	if user, exists := rl.users[userID]; exists {
+		user.mu.RLock() // lock the user to prevent changes while reading
+		defer user.mu.RUnlock()
+
 		cutoff := time.Now().Add(-rl.window)
 		for _, interval := range user.CurrentRequests {
 			// if the request has ended and it's within the window, add the compute time


### PR DESCRIPTION
### Why this change is needed

Last week I gateway crashed with the following error:

```
fatal error: concurrent map iteration and map write

goroutine 684 [running]:
github.com/ten-protocol/go-ten/tools/walletextension/ratelimiter.(*RateLimiter).SumComputeTime(0xc000440180, {0xb7, 0xe8, 0x4, 0xf1, 0x51, 0x44, 0xee, 0xe7, 0x5, ...})
	/home/obscuro/go-obscuro/tools/walletextension/ratelimiter/rate_limiter.go:108 +0x10f
github.com/ten-protocol/go-ten/tools/walletextension/ratelimiter.(*RateLimiter).Allow(0xc000440180, {0xb7, 0xe8, 0x4, 0xf1, 0x51, 0x44, 0xee, 0xe7, 0x5, ...})
	/home/obscuro/go-obscuro/tools/walletextension/ratelimiter/rate_limiter.go:197 +0x1a8
github.com/ten-protocol/go-ten/tools/walletextension/rpcapi.ExecAuthRPC[...]({0x1762fd0, 0xc0037ee690}, 0xc0005c0000, 0xc000297400, {0x13345f3, 0xe}, {0xc003a5cde0, 0x2, 0x2})
	/home/obscuro/go-obscuro/tools/walletextension/rpcapi/utils.go:107 +0x1a8
```

I found the issue and fixed it in this PR.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


