### PR TITLE
Lock down dependency.

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -28,6 +28,7 @@
     "ten-hardhat-plugin": "^0.0.9"
   },
   "peerDependencies": {
-    "@nomicfoundation/hardhat-verify" : "2.0.8"
+    "@nomicfoundation/hardhat-verify" : "2.0.8",
+    "@nomicfoundation/hardhat-ethers":"3.0.6"
   }
 }


### PR DESCRIPTION
### Why this change is needed

This change locks down the peer dependency for hardhat ethers to a concrete version that works with the current hardhat version we are using.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


