### PR TITLE
Enclave DB: add composite index for canonical batch height

### DIFF
--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -83,7 +83,8 @@ create table if not exists obsdb.batch
     INDEX USING HASH (hash),
     INDEX USING HASH (l1_proof_hash),
     INDEX (l1_proof),
-    INDEX (height)
+    INDEX (height),
+    INDEX (is_canonical, is_executed, height)
 );
 GRANT ALL ON obsdb.batch TO obscuro;
 

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -75,6 +75,7 @@ create index IDX_BATCH_HASH on batch (hash);
 create index IDX_BATCH_BLOCK on batch (l1_proof_hash);
 create index IDX_BATCH_L1 on batch (l1_proof);
 create index IDX_BATCH_HEIGHT on batch (height);
+create index IDX_BATCH_HEIGHT_COMP on batch (is_canonical, is_executed, height);
 
 create table if not exists tx
 (


### PR DESCRIPTION
### Why this change is needed

Slow queries for getting head batch (6+ seconds with 1million batches).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


