### PR TITLE
Fix gateway logging and remove Datadog agents from gateway

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway-database.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway-database.yml
@@ -90,20 +90,6 @@ jobs:
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && git clone --depth 1 -b ${{ env.BRANCH_NAME }} https://github.com/ten-protocol/go-ten.git /home/obscuro/go-obscuro \
             && docker network create --driver bridge node_network || true \
-            && docker run -d --name datadog-agent \
-               --network node_network \
-               -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
-               -e DD_LOGS_ENABLED=true \
-               -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
-               -e DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true \
-               -e DD_CONTAINER_EXCLUDE_LOGS="name:datadog-agent" \
-               -e DD_SITE="datadoghq.eu"  \
-               -v /var/run/docker.sock:/var/run/docker.sock:ro \
-               -v /proc/:/host/proc/:ro \
-               -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-               --log-opt max-file=3 --log-opt max-size=10m \
-               datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/ \
             && docker run -d --name ${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }} \
                 -p 3306:3306 \

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -205,20 +205,6 @@ jobs:
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && git clone --depth 1 -b ${{ env.BRANCH_NAME }} https://github.com/ten-protocol/go-ten.git /home/obscuro/go-obscuro \
             && docker network create --driver bridge node_network || true \
-            && docker run -d --name datadog-agent \
-               --network node_network \
-               -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
-               -e DD_LOGS_ENABLED=true \
-               -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
-               -e DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true \
-               -e DD_CONTAINER_EXCLUDE_LOGS="name:datadog-agent" \
-               -e DD_SITE="datadoghq.eu"  \
-               -v /var/run/docker.sock:/var/run/docker.sock:ro \
-               -v /proc/:/host/proc/:ro \
-               -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-               --log-opt max-file=3 --log-opt max-size=10m \
-               datadog/agent:latest \
             && cd /home/obscuro/go-obscuro/ \
             && docker run -d -p 80:80 -p 81:81 --name "${{ env.VM_NAME }}" \
               -e OBSCURO_GATEWAY_VERSION="${{ GITHUB.RUN_NUMBER }}-${{ GITHUB.SHA }}" \

--- a/go/common/log/log.go
+++ b/go/common/log/log.go
@@ -52,6 +52,7 @@ const (
 )
 
 // New - helper function used to create a top level logger for a component.
+// Note: this expects legacy geth log levels, you will get unexpected behaviour if you use gethlog.<LEVEL> directly.
 func New(component string, level int, out string, ctx ...interface{}) gethlog.Logger {
 	logFile := ""
 	if out != SysOut {

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/tools/walletextension/common"
-
-	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
 const (
 	tcp = "tcp"
+	// @fixme -
+	// this is a temporary fix as out forked version of log.go does not map with gethlog.Level<Level>
+	//and should be fixed as part of logging refactoring in the future
+	legacyLevelDebug = 4
+	legacyLevelError = 1
 )
 
 func main() {
@@ -53,11 +56,11 @@ func main() {
 		}
 	}
 
-	logLvl := gethlog.LevelError
+	logLvl := legacyLevelError
 	if config.VerboseFlag {
-		logLvl = gethlog.LevelDebug
+		logLvl = legacyLevelDebug
 	}
-	logger := log.New(log.WalletExtCmp, int(logLvl), config.LogPath)
+	logger := log.New(log.WalletExtCmp, logLvl, config.LogPath)
 
 	walletExtContainer := walletextension.NewContainerFromConfig(config, logger)
 

--- a/tools/walletextension/rpcapi/wallet_extension.go
+++ b/tools/walletextension/rpcapi/wallet_extension.go
@@ -166,6 +166,7 @@ func (w *Services) Logger() gethlog.Logger {
 
 // GenerateAndStoreNewUser generates new key-pair and userID, stores it in the database and returns hex encoded userID and error
 func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
+	audit(w, "Generating and storing new user")
 	requestStartTime := time.Now()
 	// generate new key-pair
 	viewingKeyPrivate, err := crypto.GenerateKey()
@@ -191,6 +192,7 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
 func (w *Services) AddAddressToUser(userID []byte, address string, signature []byte, signatureType viewingkey.SignatureType) error {
+	audit(w, "Adding address to user: %s, address: %s", hexutils.BytesToHex(userID), address)
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
@@ -273,6 +275,7 @@ func (w *Services) Version() string {
 }
 
 func (w *Services) GetTenNodeHealthStatus() (bool, error) {
+	audit(w, "Getting Ten node health status")
 	res, err := withPlainRPCConnection[bool](context.Background(), w, func(client *gethrpc.Client) (*bool, error) {
 		res, err := obsclient.NewObsClient(client).Health()
 		return &res, err
@@ -281,6 +284,7 @@ func (w *Services) GetTenNodeHealthStatus() (bool, error) {
 }
 
 func (w *Services) GetTenNetworkConfig() (tencommon.TenNetworkInfo, error) {
+	audit(w, "Getting Ten network config")
 	res, err := withPlainRPCConnection[tencommon.TenNetworkInfo](context.Background(), w, func(client *gethrpc.Client) (*tencommon.TenNetworkInfo, error) {
 		res, err := obsclient.NewObsClient(client).GetConfig()
 		return res, err
@@ -289,6 +293,7 @@ func (w *Services) GetTenNetworkConfig() (tencommon.TenNetworkInfo, error) {
 }
 
 func (w *Services) GenerateUserMessageToSign(encryptionToken []byte, formatsSlice []string) (string, error) {
+	audit(w, "Generating user message to sign")
 	// Check if the formats are valid
 	for _, format := range formatsSlice {
 		if _, exists := viewingkey.SignatureTypeMap[format]; !exists {


### PR DESCRIPTION
### Why this change is needed

There is an issue with Logging. 

`gethlog.<LEVEL>` does not translate correctly to actual log levels used in `log.New`.
I temporary fixed this, but bigger logging refactoring will be required in the future.

+ I removed also Datadog agents on the gateway as there is no use for them (we don't use Datadog anymore) and we switched to Grafana.  

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


