### PR TITLE
Remove Decryption feature from Tenscan frontend

### DIFF
--- a/tools/tenscan/frontend/src/routes/index.ts
+++ b/tools/tenscan/frontend/src/routes/index.ts
@@ -86,11 +86,6 @@ export const NavLinks: NavLink[] = [
     isDropdown: true,
     subNavLinks: [
       {
-        href: "/resources/decrypt",
-        label: "Decrypt",
-        isExternal: false,
-      },
-      {
         href: "/resources/verified-data",
         label: "Verified Data",
         isExternal: false,


### PR DESCRIPTION
Quick Fix/mask for anti-cheat of battleship

### Why this change is needed

To prevent cheating on Battleships Game using the decryption feature

### What changes were made as part of this PR

Temporarily removed the "Decrypt" option from the frontend

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


