### PR TITLE
remove the body of the l1 blocks from the payload sent into the enclave.

### DIFF
--- a/go/common/enclave.go
+++ b/go/common/enclave.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ten-protocol/go-ten/go/common/errutil"
 
 	"github.com/ten-protocol/go-ten/go/common/tracers"
@@ -22,6 +24,11 @@ type Status struct {
 	StatusCode StatusCode
 	L1Head     gethcommon.Hash
 	L2Head     *big.Int
+}
+
+type TxAndReceipt struct {
+	Tx      *types.Transaction
+	Receipt *types.Receipt
 }
 
 const (
@@ -55,7 +62,7 @@ type Enclave interface {
 	// It is the responsibility of the host to gossip the returned rollup
 	// For good functioning the caller should always submit blocks ordered by height
 	// submitting a block before receiving ancestors of it, will result in it being ignored
-	SubmitL1Block(ctx context.Context, block *L1Block, receipts L1Receipts, isLatest bool) (*BlockSubmissionResponse, SystemError)
+	SubmitL1Block(ctx context.Context, blockHeader *types.Header, receipts []*TxAndReceipt, isLatest bool) (*BlockSubmissionResponse, SystemError)
 
 	// SubmitTx - user transactions
 	SubmitTx(ctx context.Context, tx EncryptedTx) (*responses.RawTx, SystemError)

--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -343,7 +343,7 @@ func (executor *batchExecutor) CreateGenesisState(
 	return genesisBatch, deployTx, nil
 }
 
-func (executor *batchExecutor) populateOutboundCrossChainData(ctx context.Context, batch *core.Batch, block *types.Block, receipts types.Receipts) error {
+func (executor *batchExecutor) populateOutboundCrossChainData(ctx context.Context, batch *core.Batch, block *types.Header, receipts types.Receipts) error {
 	crossChainMessages, err := executor.crossChainProcessors.Local.ExtractOutboundMessages(ctx, receipts)
 	if err != nil {
 		executor.logger.Error("Failed extracting L2->L1 messages", log.ErrKey, err, log.CmpKey, log.CrossChainCmp)
@@ -395,7 +395,7 @@ func (executor *batchExecutor) populateOutboundCrossChainData(ctx context.Contex
 		len(batch.Header.CrossChainMessages)), log.CmpKey, log.CrossChainCmp)
 
 	batch.Header.LatestInboundCrossChainHash = block.Hash()
-	batch.Header.LatestInboundCrossChainHeight = block.Number()
+	batch.Header.LatestInboundCrossChainHeight = block.Number
 
 	return nil
 }

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -112,7 +112,7 @@ func (br *batchRegistry) HasGenesisBatch() (bool, error) {
 	return br.HeadBatchSeq() != nil, nil
 }
 
-func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Block, error) {
+func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Header, error) {
 	// sanity check
 	headBatch, err := br.storage.FetchBatchHeaderBySeqNo(ctx, br.HeadBatchSeq().Uint64())
 	if err != nil {
@@ -124,10 +124,10 @@ func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, up
 	}
 
 	resultBatches := make([]*core.Batch, 0)
-	resultBlocks := make([]*types.Block, 0)
+	resultBlocks := make([]*types.Header, 0)
 
 	currentBatchSeq := batchSeqNo
-	var currentBlock *types.Block
+	var currentBlock *types.Header
 	for currentBatchSeq <= headBatch.SequencerOrderNo.Uint64() {
 		batch, err := br.storage.FetchBatchBySeqNo(ctx, currentBatchSeq)
 		if err != nil {
@@ -142,7 +142,7 @@ func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, up
 				return nil, nil, fmt.Errorf("could not retrieve block. Cause: %w", err)
 			}
 			currentBlock = block
-			if block.NumberU64() > upToL1Height {
+			if block.Number.Uint64() > upToL1Height {
 				break
 			}
 			resultBlocks = append(resultBlocks, block)

--- a/go/enclave/components/consumer_test.go
+++ b/go/enclave/components/consumer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/trie"
 )
 
 func TestInvalidBlocksAreRejected(t *testing.T) {
@@ -25,7 +24,7 @@ func TestInvalidBlocksAreRejected(t *testing.T) {
 
 	for _, header := range invalidHeaders {
 		loopHeader := header
-		_, err := blockConsumer.ingestBlock(context.Background(), types.NewBlock(&loopHeader, nil, nil, &trie.StackTrie{}))
+		_, err := blockConsumer.ingestBlock(context.Background(), &loopHeader)
 		if err == nil {
 			t.Errorf("expected block with invalid header to be rejected but was accepted")
 		}

--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -26,7 +26,7 @@ type BlockIngestionType struct {
 	// ChainFork contains information about the status of the new block in the chain
 	ChainFork *common.ChainFork
 
-	// Block that is already on the canonical chain
+	// BlockHeader that is already on the canonical chain
 	OldCanonicalBlock bool
 }
 
@@ -39,14 +39,14 @@ func (bit *BlockIngestionType) IsFork() bool {
 
 type L1BlockProcessor interface {
 	Process(ctx context.Context, br *common.BlockAndReceipts) (*BlockIngestionType, error)
-	GetHead(context.Context) (*common.L1Block, error)
+	GetHead(context.Context) (*types.Header, error)
 	GetCrossChainContractAddress() *gethcommon.Address
 	HealthCheck() (bool, error)
 }
 
 // BatchExecutionContext - Contains all of the data that each batch depends on
 type BatchExecutionContext struct {
-	BlockPtr     common.L1BlockHash // Block is needed for the cross chain messages
+	BlockPtr     common.L1BlockHash // BlockHeader is needed for the cross chain messages
 	ParentPtr    common.L2BatchHash
 	Transactions common.L2Transactions
 	AtTime       uint64
@@ -88,7 +88,7 @@ type BatchExecutor interface {
 
 type BatchRegistry interface {
 	// BatchesAfter - Given a hash, will return batches following it until the head batch and the l1 blocks referenced by those batches
-	BatchesAfter(ctx context.Context, batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Block, error)
+	BatchesAfter(ctx context.Context, batchSeqNo uint64, upToL1Height uint64, rollupLimiter limiters.RollupLimiter) ([]*core.Batch, []*types.Header, error)
 
 	// GetBatchStateAtHeight - creates a stateDB for the block number
 	GetBatchStateAtHeight(ctx context.Context, blockNumber *gethrpc.BlockNumber) (*state.StateDB, error)

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -201,11 +201,11 @@ func (rc *RollupCompression) createRollupHeader(ctx context.Context, rollup *cor
 
 		// the first element is the actual height
 		if i == 0 {
-			l1HeightDeltas[i] = block.Number()
+			l1HeightDeltas[i] = block.Number
 		} else {
-			l1HeightDeltas[i] = big.NewInt(block.Number().Int64() - prevL1Height.Int64())
+			l1HeightDeltas[i] = big.NewInt(block.Number.Int64() - prevL1Height.Int64())
 		}
-		prevL1Height = block.Number()
+		prevL1Height = block.Number
 	}
 
 	l1DeltasBA := make([][]byte, len(l1HeightDeltas))
@@ -284,7 +284,7 @@ func (rc *RollupCompression) createIncompleteBatches(ctx context.Context, callda
 	}
 
 	// a cache of the l1 blocks used by the current rollup, indexed by their height
-	l1BlocksAtHeight := make(map[uint64]*types.Block)
+	l1BlocksAtHeight := make(map[uint64]*types.Header)
 	err = rc.calcL1AncestorsOfHeight(ctx, big.NewInt(int64(slices.Min(l1Heights))), rollupL1Block, l1BlocksAtHeight)
 	if err != nil {
 		return nil, err
@@ -353,7 +353,7 @@ func (rc *RollupCompression) createIncompleteBatches(ctx context.Context, callda
 			baseFee:      calldataRollupHeader.BaseFee,
 			gasLimit:     calldataRollupHeader.GasLimit,
 		}
-		rc.logger.Info("Rollup decompressed batch", log.BatchSeqNoKey, currentSeqNo, log.BatchHeightKey, currentHeight, "rollup_idx", currentBatchIdx, "l1_height", block.Number(), "l1_hash", block.Hash())
+		rc.logger.Info("Rollup decompressed batch", log.BatchSeqNoKey, currentSeqNo, log.BatchHeightKey, currentHeight, "rollup_idx", currentBatchIdx, "l1_height", block.Number, "l1_hash", block.Hash())
 	}
 	return incompleteBatches, nil
 }
@@ -388,12 +388,12 @@ func (rc *RollupCompression) calculateL1HeightsFromDeltas(calldataRollupHeader *
 	return l1Heights, nil
 }
 
-func (rc *RollupCompression) calcL1AncestorsOfHeight(ctx context.Context, fromHeight *big.Int, toBlock *types.Block, path map[uint64]*types.Block) error {
-	path[toBlock.NumberU64()] = toBlock
-	if toBlock.NumberU64() == fromHeight.Uint64() {
+func (rc *RollupCompression) calcL1AncestorsOfHeight(ctx context.Context, fromHeight *big.Int, toBlock *types.Header, path map[uint64]*types.Header) error {
+	path[toBlock.Number.Uint64()] = toBlock
+	if toBlock.Number.Uint64() == fromHeight.Uint64() {
 		return nil
 	}
-	p, err := rc.storage.FetchBlock(ctx, toBlock.ParentHash())
+	p, err := rc.storage.FetchBlock(ctx, toBlock.ParentHash)
 	if err != nil {
 		return err
 	}

--- a/go/enclave/components/rollup_producer.go
+++ b/go/enclave/components/rollup_producer.go
@@ -64,7 +64,7 @@ func (re *rollupProducerImpl) CreateInternalRollup(ctx context.Context, fromBatc
 	lastBatch := batches[len(batches)-1]
 	rh.LastBatchSeqNo = lastBatch.SeqNo().Uint64()
 
-	blockMap := map[common.L1BlockHash]*types.Block{}
+	blockMap := map[common.L1BlockHash]*types.Header{}
 	for _, b := range blocks {
 		blockMap[b.Hash()] = b
 	}

--- a/go/enclave/components/shared_secret_process.go
+++ b/go/enclave/components/shared_secret_process.go
@@ -36,14 +36,14 @@ func NewSharedSecretProcessor(mgmtcontractlib mgmtcontractlib.MgmtContractLib, a
 // ProcessNetworkSecretMsgs we watch for all messages that are requesting or receiving the secret and we store the nodes attested keys
 func (ssp *SharedSecretProcessor) ProcessNetworkSecretMsgs(ctx context.Context, br *common.BlockAndReceipts) []*common.ProducedSecretResponse {
 	var responses []*common.ProducedSecretResponse
-	transactions := br.SuccessfulTransactions()
-	block := br.Block
+	transactions := br.RelevantTransactions()
+	block := br.BlockHeader
 	for _, tx := range *transactions {
 		t := ssp.mgmtContractLib.DecodeTx(tx)
 
 		// this transaction is for a node that has joined the network and needs to be sent the network secret
 		if scrtReqTx, ok := t.(*ethadapter.L1RequestSecretTx); ok {
-			ssp.logger.Info("Process shared secret request.", log.BlockHeightKey, block.Number(), log.BlockHashKey, block.Hash(), log.TxKey, tx.Hash())
+			ssp.logger.Info("Process shared secret request.", log.BlockHeightKey, block.Number, log.BlockHashKey, block.Hash(), log.TxKey, tx.Hash())
 			resp, err := ssp.processSecretRequest(ctx, scrtReqTx)
 			if err != nil {
 				ssp.logger.Error("Failed to process shared secret request.", log.ErrKey, err)

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -96,7 +96,7 @@ func ToBatch(extBatch *common.ExtBatch, transactionBlobCrypto crypto.DataEncrypt
 
 func DeterministicEmptyBatch(
 	parent *common.BatchHeader,
-	block *types.Block,
+	block *types.Header,
 	time uint64,
 	sequencerNo *big.Int,
 	baseFee *big.Int,

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -12,7 +12,7 @@ import (
 type Rollup struct {
 	Header  *common.RollupHeader
 	Batches []*Batch
-	Blocks  map[common.L1BlockHash]*types.Block // these are the blocks required during compression. The key is the hash
+	Blocks  map[common.L1BlockHash]*types.Header // these are the blocks required during compression. The key is the hash
 	hash    atomic.Value
 }
 

--- a/go/enclave/crosschain/block_message_extractor.go
+++ b/go/enclave/crosschain/block_message_extractor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ten-protocol/go-ten/go/enclave/core"
 
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
@@ -37,8 +39,8 @@ func (m *blockMessageExtractor) Enabled() bool {
 	return m.GetBusAddress().Big().Cmp(gethcommon.Big0) != 0
 }
 
-func (m *blockMessageExtractor) StoreCrossChainValueTransfers(ctx context.Context, block *common.L1Block, receipts common.L1Receipts) error {
-	defer core.LogMethodDuration(m.logger, measure.NewStopwatch(), "Block value transfer messages processed", log.BlockHashKey, block.Hash())
+func (m *blockMessageExtractor) StoreCrossChainValueTransfers(ctx context.Context, block *types.Header, receipts common.L1Receipts) error {
+	defer core.LogMethodDuration(m.logger, measure.NewStopwatch(), "BlockHeader value transfer messages processed", log.BlockHashKey, block.Hash())
 
 	/*areReceiptsValid := common.VerifyReceiptHash(block, receipts)
 
@@ -76,8 +78,8 @@ func (m *blockMessageExtractor) StoreCrossChainValueTransfers(ctx context.Contex
 // The messages will be stored in DB storage for later usage.
 // block - the L1 block for which events are extracted.
 // receipts - all of the receipts for the corresponding block. This is validated.
-func (m *blockMessageExtractor) StoreCrossChainMessages(ctx context.Context, block *common.L1Block, receipts common.L1Receipts) error {
-	defer core.LogMethodDuration(m.logger, measure.NewStopwatch(), "Block cross chain messages processed", log.BlockHashKey, block.Hash())
+func (m *blockMessageExtractor) StoreCrossChainMessages(ctx context.Context, block *types.Header, receipts common.L1Receipts) error {
+	defer core.LogMethodDuration(m.logger, measure.NewStopwatch(), "BlockHeader cross chain messages processed", log.BlockHashKey, block.Hash())
 
 	if len(receipts) == 0 {
 		return nil
@@ -108,7 +110,7 @@ func (m *blockMessageExtractor) GetBusAddress() *common.L1Address {
 }
 
 // getCrossChainMessages - Converts the relevant logs from the appropriate message bus address to synthetic transactions and returns them
-func (m *blockMessageExtractor) getCrossChainMessages(block *common.L1Block, receipts common.L1Receipts) (common.CrossChainMessages, error) {
+func (m *blockMessageExtractor) getCrossChainMessages(block *types.Header, receipts common.L1Receipts) (common.CrossChainMessages, error) {
 	if len(receipts) == 0 {
 		return make(common.CrossChainMessages, 0), nil
 	}

--- a/go/enclave/crosschain/common.go
+++ b/go/enclave/crosschain/common.go
@@ -30,7 +30,7 @@ var (
 	ValueTransferEventID   = MessageBusABI.Events["ValueTransfer"].ID
 )
 
-func lazilyLogReceiptChecksum(block *common.L1Block, receipts types.Receipts, logger gethlog.Logger) {
+func lazilyLogReceiptChecksum(block *types.Header, receipts types.Receipts, logger gethlog.Logger) {
 	if logger.Enabled(context.Background(), gethlog.LevelTrace) {
 		logger.Trace("Processing block", log.BlockHashKey, block.Hash(), "nr_rec", len(receipts), "Hash", receiptsHash(receipts))
 	}

--- a/go/enclave/crosschain/interfaces.go
+++ b/go/enclave/crosschain/interfaces.go
@@ -3,6 +3,8 @@ package crosschain
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ten-protocol/go-ten/go/common"
@@ -16,9 +18,9 @@ type (
 
 type BlockMessageExtractor interface {
 	// StoreCrossChainMessages - Verifies receipts belong to block and saves the relevant cross chain messages from the receipts
-	StoreCrossChainMessages(ctx context.Context, block *common.L1Block, receipts common.L1Receipts) error
+	StoreCrossChainMessages(ctx context.Context, block *types.Header, receipts common.L1Receipts) error
 
-	StoreCrossChainValueTransfers(ctx context.Context, block *common.L1Block, receipts common.L1Receipts) error
+	StoreCrossChainValueTransfers(ctx context.Context, block *types.Header, receipts common.L1Receipts) error
 
 	// GetBusAddress - Returns the L1 message bus address.
 	GetBusAddress() *common.L1Address
@@ -53,5 +55,5 @@ type Manager interface {
 
 	ExecuteValueTransfers(ctx context.Context, transfers common.ValueTransferEvents, rollupState *state.StateDB)
 
-	RetrieveInboundMessages(ctx context.Context, fromBlock *common.L1Block, toBlock *common.L1Block, rollupState *state.StateDB) (common.CrossChainMessages, common.ValueTransferEvents)
+	RetrieveInboundMessages(ctx context.Context, fromBlock *types.Header, toBlock *types.Header, rollupState *state.StateDB) (common.CrossChainMessages, common.ValueTransferEvents)
 }

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -146,12 +146,12 @@ func (m *MessageBusManager) ExtractOutboundTransfers(_ context.Context, receipts
 // todo (@stefan) - fix ordering of messages, currently it is irrelevant.
 // todo (@stefan) - do not extract messages below their consistency level. Irrelevant security wise.
 // todo (@stefan) - surface errors
-func (m *MessageBusManager) RetrieveInboundMessages(ctx context.Context, fromBlock *common.L1Block, toBlock *common.L1Block, _ *state.StateDB) (common.CrossChainMessages, common.ValueTransferEvents) {
+func (m *MessageBusManager) RetrieveInboundMessages(ctx context.Context, fromBlock *types.Header, toBlock *types.Header, rollupState *state.StateDB) (common.CrossChainMessages, common.ValueTransferEvents) {
 	messages := make(common.CrossChainMessages, 0)
 	transfers := make(common.ValueTransferEvents, 0)
 
 	from := fromBlock.Hash()
-	height := fromBlock.NumberU64()
+	height := fromBlock.Number.Uint64()
 	if !m.storage.IsAncestor(ctx, toBlock, fromBlock) {
 		m.logger.Crit("Synthetic transactions can't be processed because the rollups are not on the same Ethereum fork. This should not happen.")
 	}
@@ -178,10 +178,10 @@ func (m *MessageBusManager) RetrieveInboundMessages(ctx context.Context, fromBlo
 		transfers = append(transfers, transfersForBlock...)
 
 		// No deposits before genesis.
-		if b.NumberU64() < height {
+		if b.Number.Uint64() < height {
 			m.logger.Crit("block height is less than genesis height")
 		}
-		p, err := m.storage.FetchBlock(ctx, b.ParentHash())
+		p, err := m.storage.FetchBlock(ctx, b.ParentHash)
 		if err != nil {
 			m.logger.Crit("Synthetic transactions can't be processed because the rollups are not on the same Ethereum fork")
 		}
@@ -192,7 +192,7 @@ func (m *MessageBusManager) RetrieveInboundMessages(ctx context.Context, fromBlo
 	if len(messages)+len(transfers) == 0 {
 		logf = m.logger.Debug
 	}
-	logf(fmt.Sprintf("Extracted cross chain messages for block height %d ->%d", fromBlock.NumberU64(), toBlock.NumberU64()), "no_msgs", len(messages), "no_value_transfers", len(transfers))
+	logf(fmt.Sprintf("Extracted cross chain messages for block height %d ->%d", fromBlock.Number.Uint64(), toBlock.Number.Uint64()), "no_msgs", len(messages), "no_value_transfers", len(transfers))
 
 	return messages, transfers
 }

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -415,7 +415,7 @@ func (e *enclaveImpl) StreamL2Updates() (chan common.StreamL2UpdatesResponse, fu
 }
 
 // SubmitL1Block is used to update the enclave with an additional L1 block.
-func (e *enclaveImpl) SubmitL1Block(ctx context.Context, block *common.L1Block, receipts common.L1Receipts, isLatest bool) (*common.BlockSubmissionResponse, common.SystemError) {
+func (e *enclaveImpl) SubmitL1Block(ctx context.Context, blockHeader *types.Header, receipts []*common.TxAndReceipt, isLatest bool) (*common.BlockSubmissionResponse, common.SystemError) {
 	if e.stopControl.IsStopping() {
 		return nil, responses.ToInternalError(fmt.Errorf("requested SubmitL1Block with the enclave stopping"))
 	}
@@ -423,10 +423,10 @@ func (e *enclaveImpl) SubmitL1Block(ctx context.Context, block *common.L1Block, 
 	e.mainMutex.Lock()
 	defer e.mainMutex.Unlock()
 
-	e.logger.Info("SubmitL1Block", log.BlockHeightKey, block.Number(), log.BlockHashKey, block.Hash())
+	e.logger.Info("SubmitL1Block", log.BlockHeightKey, blockHeader.Number, log.BlockHashKey, blockHeader.Hash())
 
 	// If the block and receipts do not match, reject the block.
-	br, err := common.ParseBlockAndReceipts(block, &receipts)
+	br, err := common.ParseBlockAndReceipts(blockHeader, receipts)
 	if err != nil {
 		return nil, e.rejectBlockErr(ctx, fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
@@ -437,10 +437,10 @@ func (e *enclaveImpl) SubmitL1Block(ctx context.Context, block *common.L1Block, 
 	}
 
 	if result.IsFork() {
-		e.logger.Info(fmt.Sprintf("Detected fork at block %s with height %d", block.Hash(), block.Number()))
+		e.logger.Info(fmt.Sprintf("Detected fork at block %s with height %d", blockHeader.Hash(), blockHeader.Number))
 	}
 
-	err = e.service.OnL1Block(ctx, block, result)
+	err = e.service.OnL1Block(ctx, blockHeader, result)
 	if err != nil {
 		return nil, e.rejectBlockErr(ctx, fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
@@ -450,14 +450,14 @@ func (e *enclaveImpl) SubmitL1Block(ctx context.Context, block *common.L1Block, 
 }
 
 func (e *enclaveImpl) ingestL1Block(ctx context.Context, br *common.BlockAndReceipts) (*components.BlockIngestionType, error) {
-	e.logger.Info("Start ingesting block", log.BlockHashKey, br.Block.Hash())
+	e.logger.Info("Start ingesting block", log.BlockHashKey, br.BlockHeader.Hash())
 	ingestion, err := e.l1BlockProcessor.Process(ctx, br)
 	if err != nil {
 		// only warn for unexpected errors
 		if errors.Is(err, errutil.ErrBlockAncestorNotFound) || errors.Is(err, errutil.ErrBlockAlreadyProcessed) {
-			e.logger.Debug("Did not ingest block", log.ErrKey, err, log.BlockHashKey, br.Block.Hash())
+			e.logger.Debug("Did not ingest block", log.ErrKey, err, log.BlockHashKey, br.BlockHeader.Hash())
 		} else {
-			e.logger.Warn("Failed ingesting block", log.ErrKey, err, log.BlockHashKey, br.Block.Hash())
+			e.logger.Warn("Failed ingesting block", log.ErrKey, err, log.BlockHashKey, br.BlockHeader.Hash())
 		}
 		return nil, err
 	}

--- a/go/enclave/gas/oracle.go
+++ b/go/enclave/gas/oracle.go
@@ -12,9 +12,9 @@ import (
 // Oracle - the interface for the future precompiled gas oracle contract
 // which will expose necessary l1 information.
 type Oracle interface {
-	ProcessL1Block(block *types.Block)
-	EstimateL1StorageGasCost(tx *types.Transaction, block *types.Block) (*big.Int, error)
-	EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *types.Block) (*big.Int, error)
+	ProcessL1Block(block *types.Header)
+	EstimateL1StorageGasCost(tx *types.Transaction, block *types.Header) (*big.Int, error)
+	EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *types.Header) (*big.Int, error)
 }
 
 type oracle struct {
@@ -30,30 +30,30 @@ func NewGasOracle() Oracle {
 // ProcessL1Block - should be used to update the gas oracle. Currently does not really
 // fit into phase 1 gas mechanics as the information needs to be available per block.
 // would be fixed when this becomes a smart contract using the stateDB
-func (o *oracle) ProcessL1Block(block *types.Block) {
-	blockBaseFee := block.BaseFee()
+func (o *oracle) ProcessL1Block(block *types.Header) {
+	blockBaseFee := block.BaseFee
 	if blockBaseFee != nil {
 		o.baseFee = blockBaseFee
 	}
 }
 
 // EstimateL1StorageGasCost - Returns the expected l1 gas cost for a transaction at a given l1 block.
-func (o *oracle) EstimateL1StorageGasCost(tx *types.Transaction, block *types.Block) (*big.Int, error) {
+func (o *oracle) EstimateL1StorageGasCost(tx *types.Transaction, block *types.Header) (*big.Int, error) {
 	encodedTx, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		return nil, err
 	}
 
-	blockBaseFee := block.BaseFee()
+	blockBaseFee := block.BaseFee
 	if blockBaseFee == nil {
 		return big.NewInt(0), nil
 	}
 
 	l1Gas := CalculateL1GasUsed(encodedTx, big.NewInt(0))
-	return big.NewInt(0).Mul(l1Gas, block.BaseFee()), nil
+	return big.NewInt(0).Mul(l1Gas, block.BaseFee), nil
 }
 
-func (o *oracle) EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *types.Block) (*big.Int, error) {
+func (o *oracle) EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *types.Header) (*big.Int, error) {
 	encoded := make([]byte, 0)
 	if args.Data != nil {
 		encoded = append(encoded, *args.Data...)
@@ -65,5 +65,5 @@ func (o *oracle) EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *type
 	nonZeroGas := big.NewInt(int64(params.TxDataNonZeroGasEIP2028))
 	overhead := big.NewInt(0).Mul(big.NewInt(150), nonZeroGas)
 	l1Gas := CalculateL1GasUsed(encoded, overhead)
-	return big.NewInt(0).Mul(l1Gas, block.BaseFee()), nil
+	return big.NewInt(0).Mul(l1Gas, block.BaseFee), nil
 }

--- a/go/enclave/nodetype/common.go
+++ b/go/enclave/nodetype/common.go
@@ -44,7 +44,7 @@ func ExportCrossChainData(ctx context.Context, storage storage.Storage, fromSeqN
 	bundle := &common.ExtCrossChainBundle{
 		LastBatchHash:        batchHash, // unused for now.
 		L1BlockHash:          block.Hash(),
-		L1BlockNum:           big.NewInt(0).Set(block.Header().Number),
+		L1BlockNum:           big.NewInt(0).Set(block.Number),
 		CrossChainRootHashes: crossChainHashes,
 	} // todo: check fromSeqNo
 	return bundle, nil

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -3,6 +3,8 @@ package nodetype
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ten-protocol/go-ten/go/common"
 	"github.com/ten-protocol/go-ten/go/enclave/components"
 	"github.com/ten-protocol/go-ten/go/enclave/core"
@@ -20,7 +22,7 @@ type NodeType interface {
 	OnL1Fork(ctx context.Context, fork *common.ChainFork) error
 
 	// OnL1Block - performed after the block was processed
-	OnL1Block(ctx context.Context, block *common.L1Block, result *components.BlockIngestionType) error
+	OnL1Block(ctx context.Context, block *types.Header, result *components.BlockIngestionType) error
 
 	ExportCrossChainData(context.Context, uint64, uint64) (*common.ExtCrossChainBundle, error)
 

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -133,7 +133,7 @@ func (s *sequencer) CreateBatch(ctx context.Context, skipBatchIfEmpty bool) erro
 // should only create batches and stateDBs but not commit them to the database,
 // this is the responsibility of the sequencer. Refactor the code so genesis state
 // won't be committed by the producer.
-func (s *sequencer) createGenesisBatch(ctx context.Context, block *common.L1Block) error {
+func (s *sequencer) createGenesisBatch(ctx context.Context, block *types.Header) error {
 	s.logger.Info("Initializing genesis state", log.BlockHashKey, block.Hash())
 	batch, msgBusTx, err := s.batchProducer.CreateGenesisState(
 		ctx,
@@ -200,7 +200,7 @@ func (s *sequencer) createGenesisBatch(ctx context.Context, block *common.L1Bloc
 	return nil
 }
 
-func (s *sequencer) createNewHeadBatch(ctx context.Context, l1HeadBlock *common.L1Block, skipBatchIfEmpty bool) error {
+func (s *sequencer) createNewHeadBatch(ctx context.Context, l1HeadBlock *types.Header, skipBatchIfEmpty bool) error {
 	headBatchSeq := s.batchRegistry.HeadBatchSeq()
 	if headBatchSeq == nil {
 		headBatchSeq = big.NewInt(int64(common.L2GenesisSeqNo))
@@ -353,7 +353,7 @@ func (s *sequencer) CreateRollup(ctx context.Context, lastBatchNo uint64) (*comm
 	if err != nil {
 		return nil, err
 	}
-	upToL1Height := currentL1Head.NumberU64() - RollupDelay
+	upToL1Height := currentL1Head.Number.Uint64() - RollupDelay
 	rollup, err := s.rollupProducer.CreateInternalRollup(ctx, lastBatchNo, upToL1Height, rollupLimiter)
 	if err != nil {
 		return nil, err
@@ -372,7 +372,7 @@ func (s *sequencer) CreateRollup(ctx context.Context, lastBatchNo uint64) (*comm
 	return extRollup, nil
 }
 
-func (s *sequencer) duplicateBatches(ctx context.Context, l1Head *types.Block, nonCanonicalL1Path []common.L1BlockHash, canonicalL1Path []common.L1BlockHash) error {
+func (s *sequencer) duplicateBatches(ctx context.Context, l1Head *types.Header, nonCanonicalL1Path []common.L1BlockHash, canonicalL1Path []common.L1BlockHash) error {
 	batchesToDuplicate := make([]*common.BatchHeader, 0)
 	batchesToExclude := make(map[uint64]*common.BatchHeader, 0)
 
@@ -513,7 +513,7 @@ func (s *sequencer) signCrossChainBundle(bundle *common.ExtCrossChainBundle) err
 	return nil
 }
 
-func (s *sequencer) OnL1Block(ctx context.Context, _ *common.L1Block, result *components.BlockIngestionType) error {
+func (s *sequencer) OnL1Block(ctx context.Context, block *types.Header, result *components.BlockIngestionType) error {
 	// nothing to do
 	return nil
 }

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ten-protocol/go-ten/go/enclave/crypto"
 	"github.com/ten-protocol/go-ten/go/enclave/txpool"
 
@@ -185,7 +187,7 @@ func (val *obsValidator) handleGenesis(ctx context.Context, batch *common.BatchH
 	return nil
 }
 
-func (val *obsValidator) OnL1Block(ctx context.Context, _ *common.L1Block, result *components.BlockIngestionType) error {
+func (val *obsValidator) OnL1Block(ctx context.Context, block *types.Header, result *components.BlockIngestionType) error {
 	return val.ExecuteStoredBatches(ctx)
 }
 

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -23,7 +23,7 @@ import (
 )
 
 func EstimateGasValidate(reqParams []any, builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64], _ *EncryptionManager) error {
-	// Parameters are [callMsg, Block number (optional)]
+	// Parameters are [callMsg, BlockHeader number (optional)]
 	if len(reqParams) < 1 {
 		builder.Err = fmt.Errorf("unexpected number of parameters")
 		return nil
@@ -40,10 +40,10 @@ func EstimateGasValidate(reqParams []any, builder *CallBuilder[CallParamsWithBlo
 		return nil
 	}
 
-	// extract optional Block number - defaults to the latest Block if not avail
+	// extract optional BlockHeader number - defaults to the latest BlockHeader if not avail
 	blockNumber, err := gethencoding.ExtractOptionalBlockNumber(reqParams, 1)
 	if err != nil {
-		builder.Err = fmt.Errorf("unable to extract requested Block number - %w", err)
+		builder.Err = fmt.Errorf("unable to extract requested BlockHeader number - %w", err)
 		return nil
 	}
 
@@ -68,7 +68,7 @@ func EstimateGasExecute(builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64
 	}
 
 	// The message is run through the l1 publishing cost estimation for the current
-	// known head Block.
+	// known head BlockHeader.
 	l1Cost, err := rpc.gasOracle.EstimateL1CostForMsg(txArgs, block)
 	if err != nil {
 		return err

--- a/go/enclave/rpc/GetBalance.go
+++ b/go/enclave/rpc/GetBalance.go
@@ -32,7 +32,7 @@ func GetBalanceValidate(reqParams []any, builder *CallBuilder[BalanceReq, hexuti
 
 	blockNumber, err := gethencoding.ExtractBlockNumber(reqParams[1])
 	if err != nil {
-		builder.Err = fmt.Errorf("unable to extract requested Block number - %w", err)
+		builder.Err = fmt.Errorf("unable to extract requested BlockHeader number - %w", err)
 		return nil
 	}
 	builder.Param = &BalanceReq{

--- a/go/enclave/rpc/GetTransactionCount.go
+++ b/go/enclave/rpc/GetTransactionCount.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetTransactionCountValidate(reqParams []any, builder *CallBuilder[uint64, string], rpc *EncryptionManager) error {
-	// Parameters are [Address, Block?]
+	// Parameters are [Address, BlockHeader?]
 	if len(reqParams) < 1 {
 		builder.Err = fmt.Errorf("unexpected number of parameters")
 		return nil

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -478,8 +478,8 @@ func (s *RPCServer) EnclavePublicConfig(ctx context.Context, _ *generated.Enclav
 	return &generated.EnclavePublicConfigResponse{L2MessageBusAddress: enclaveCfg.L2MessageBusAddress.Bytes()}, nil
 }
 
-func (s *RPCServer) decodeBlock(encodedBlock []byte) (*types.Block, error) {
-	block := types.Block{}
+func (s *RPCServer) decodeBlock(encodedBlock []byte) (*types.Header, error) {
+	block := types.Header{}
 	err := rlp.DecodeBytes(encodedBlock, &block)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode block, bytes=%x, err=%w", encodedBlock, err)
@@ -488,8 +488,8 @@ func (s *RPCServer) decodeBlock(encodedBlock []byte) (*types.Block, error) {
 }
 
 // decodeReceipts - converts the rlp encoded bytes to receipts if possible.
-func (s *RPCServer) decodeReceipts(encodedReceipts []byte) (types.Receipts, error) {
-	receipts := make(types.Receipts, 0)
+func (s *RPCServer) decodeReceipts(encodedReceipts []byte) ([]*common.TxAndReceipt, error) {
+	receipts := make([]*common.TxAndReceipt, 0)
 
 	err := rlp.DecodeBytes(encodedReceipts, &receipts)
 	if err != nil {

--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -30,7 +30,7 @@ const (
 type CacheService struct {
 	// cache for the immutable blocks and batches.
 	// this avoids a trip to the database.
-	blockCache *cache.Cache[*types.Block]
+	blockCache *cache.Cache[*types.Header]
 
 	// stores batches using the sequence number as key
 	batchCacheBySeqNo *cache.Cache[*common.BatchHeader]
@@ -71,7 +71,7 @@ func NewCacheService(logger gethlog.Logger) *CacheService {
 	}
 	ristrettoStore := ristretto_store.NewRistretto(ristrettoCache)
 	return &CacheService{
-		blockCache:               cache.New[*types.Block](ristrettoStore),
+		blockCache:               cache.New[*types.Header](ristrettoStore),
 		batchCacheBySeqNo:        cache.New[*common.BatchHeader](ristrettoStore),
 		seqCacheByHash:           cache.New[*big.Int](ristrettoStore),
 		seqCacheByHeight:         cache.New[*big.Int](ristrettoStore),
@@ -84,7 +84,7 @@ func NewCacheService(logger gethlog.Logger) *CacheService {
 	}
 }
 
-func (cs *CacheService) CacheBlock(ctx context.Context, b *types.Block) {
+func (cs *CacheService) CacheBlock(ctx context.Context, b *types.Header) {
 	cacheValue(ctx, cs.blockCache, cs.logger, b.Hash(), b, blockCost)
 }
 
@@ -96,7 +96,7 @@ func (cs *CacheService) CacheBatch(ctx context.Context, batch *core.Batch) {
 	cacheValue(ctx, cs.seqCacheByHeight, cs.logger, batch.NumberU64()+1, batch.SeqNo(), idCost)
 }
 
-func (cs *CacheService) ReadBlock(ctx context.Context, key gethcommon.Hash, onCacheMiss func(any) (*types.Block, error)) (*types.Block, error) {
+func (cs *CacheService) ReadBlock(ctx context.Context, key gethcommon.Hash, onCacheMiss func(any) (*types.Header, error)) (*types.Header, error) {
 	return getCachedValue(ctx, cs.blockCache, cs.logger, key, blockCost, onCacheMiss)
 }
 

--- a/go/enclave/storage/enclavedb/block.go
+++ b/go/enclave/storage/enclavedb/block.go
@@ -83,12 +83,11 @@ func HandleBlockArrivedAfterBatches(ctx context.Context, dbtx *sql.Tx, blockId i
 	return err
 }
 
-// todo - remove this. For now creates a "block" but without a body.
-func FetchBlock(ctx context.Context, db *sql.DB, hash common.L1BlockHash) (*types.Block, error) {
+func FetchBlockHeader(ctx context.Context, db *sql.DB, hash common.L1BlockHash) (*types.Header, error) {
 	return fetchBlock(ctx, db, " where hash=?", hash.Bytes())
 }
 
-func FetchHeadBlock(ctx context.Context, db *sql.DB) (*types.Block, error) {
+func FetchHeadBlock(ctx context.Context, db *sql.DB) (*types.Header, error) {
 	return fetchBlock(ctx, db, "order by id desc limit 1")
 }
 
@@ -242,10 +241,6 @@ func fetchBlockHeader(ctx context.Context, db *sql.DB, whereQuery string, args .
 	return h, nil
 }
 
-func fetchBlock(ctx context.Context, db *sql.DB, whereQuery string, args ...any) (*types.Block, error) {
-	h, err := fetchBlockHeader(ctx, db, whereQuery, args...)
-	if err != nil {
-		return nil, err
-	}
-	return types.NewBlockWithHeader(h), nil
+func fetchBlock(ctx context.Context, db *sql.DB, whereQuery string, args ...any) (*types.Header, error) {
+	return fetchBlockHeader(ctx, db, whereQuery, args...)
 }

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -20,21 +20,21 @@ import (
 
 // BlockResolver stores new blocks and returns information on existing blocks
 type BlockResolver interface {
-	// FetchBlock returns the L1 Block with the given hash.
-	FetchBlock(ctx context.Context, blockHash common.L1BlockHash) (*types.Block, error)
+	// FetchBlock returns the L1 BlockHeader with the given hash.
+	FetchBlock(ctx context.Context, blockHash common.L1BlockHash) (*types.Header, error)
 	IsBlockCanonical(ctx context.Context, blockHash common.L1BlockHash) (bool, error)
 	// FetchCanonicaBlockByHeight - self explanatory
-	FetchCanonicaBlockByHeight(ctx context.Context, height *big.Int) (*types.Block, error)
+	FetchCanonicaBlockByHeight(ctx context.Context, height *big.Int) (*types.Header, error)
 	// FetchHeadBlock - returns the head of the current chain.
-	FetchHeadBlock(ctx context.Context) (*types.Block, error)
-	// StoreBlock persists the L1 Block and updates the canonical ancestors if there was a fork
-	StoreBlock(ctx context.Context, block *types.Block, fork *common.ChainFork) error
-	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
-	IsAncestor(ctx context.Context, block *types.Block, maybeAncestor *types.Block) bool
-	// IsBlockAncestor returns true if maybeAncestor is an ancestor of the L1 Block, and false otherwise
-	// Takes into consideration that the Block to verify might be on a branch we haven't received yet
+	FetchHeadBlock(ctx context.Context) (*types.Header, error)
+	// StoreBlock persists the L1 BlockHeader and updates the canonical ancestors if there was a fork
+	StoreBlock(ctx context.Context, block *types.Header, fork *common.ChainFork) error
+	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 BlockHeader, and false otherwise
+	IsAncestor(ctx context.Context, block *types.Header, maybeAncestor *types.Header) bool
+	// IsBlockAncestor returns true if maybeAncestor is an ancestor of the L1 BlockHeader, and false otherwise
+	// Takes into consideration that the BlockHeader to verify might be on a branch we haven't received yet
 	// todo (low priority) - this is super confusing, analyze the usage
-	IsBlockAncestor(ctx context.Context, block *types.Block, maybeAncestor common.L1BlockHash) bool
+	IsBlockAncestor(ctx context.Context, block *types.Header, maybeAncestor common.L1BlockHash) bool
 }
 
 type BatchResolver interface {

--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -84,7 +84,7 @@ func (e *gethRPCClient) Info() Info {
 	}
 }
 
-func (e *gethRPCClient) BlocksBetween(startingBlock *types.Block, lastBlock *types.Block) []*types.Block {
+func (e *gethRPCClient) BlocksBetween(startingBlock *types.Header, lastBlock *types.Block) []*types.Block {
 	var blocksBetween []*types.Block
 	var err error
 

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -25,11 +25,11 @@ type EthClient interface {
 	BalanceAt(account gethcommon.Address, blockNumber *big.Int) (*big.Int, error) // fetches the balance of the account
 	GetLogs(q ethereum.FilterQuery) ([]types.Log, error)                          // fetches the logs for a given query
 
-	Info() Info                                                         // retrieves the node Info
-	FetchHeadBlock() (*types.Block, error)                              // retrieves the block at head height
-	BlocksBetween(block *types.Block, head *types.Block) []*types.Block // returns the blocks between two blocks
-	IsBlockAncestor(block *types.Block, proof common.L1BlockHash) bool  // returns if the node considers a block the ancestor
-	BlockListener() (chan *types.Header, ethereum.Subscription)         // subscribes to new blocks and returns a listener with the blocks heads and the subscription handler
+	Info() Info                                                          // retrieves the node Info
+	FetchHeadBlock() (*types.Block, error)                               // retrieves the block at head height
+	BlocksBetween(block *types.Header, head *types.Block) []*types.Block // returns the blocks between two blocks
+	IsBlockAncestor(block *types.Block, proof common.L1BlockHash) bool   // returns if the node considers a block the ancestor
+	BlockListener() (chan *types.Header, ethereum.Subscription)          // subscribes to new blocks and returns a listener with the blocks heads and the subscription handler
 
 	CallContract(msg ethereum.CallMsg) ([]byte, error) // Runs the provided call message on the latest block.
 

--- a/go/host/l1/blockrepository.go
+++ b/go/host/l1/blockrepository.go
@@ -131,6 +131,9 @@ func (r *Repository) latestCanonAncestor(blkHash gethcommon.Hash) (*types.Block,
 // FetchObscuroReceipts returns all obscuro-relevant receipts for an L1 block
 func (r *Repository) FetchObscuroReceipts(block *common.L1Block) (types.Receipts, error) {
 	receipts := make([]*types.Receipt, len(block.Transactions()))
+	if len(block.Transactions()) == 0 {
+		return receipts, nil
+	}
 
 	blkHash := block.Hash()
 	// we want to send receipts for any transactions that produced obscuro-relevant log events

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ten-protocol/go-ten/go/enclave/core"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -195,9 +197,9 @@ func (c *Client) EnclaveID(ctx context.Context) (common.EnclaveID, common.System
 	return common.EnclaveID(response.EnclaveID), nil
 }
 
-func (c *Client) SubmitL1Block(ctx context.Context, block *common.L1Block, receipts common.L1Receipts, isLatest bool) (*common.BlockSubmissionResponse, common.SystemError) {
+func (c *Client) SubmitL1Block(ctx context.Context, blockHeader *types.Header, receipts []*common.TxAndReceipt, isLatest bool) (*common.BlockSubmissionResponse, common.SystemError) {
 	var buffer bytes.Buffer
-	if err := block.EncodeRLP(&buffer); err != nil {
+	if err := blockHeader.EncodeRLP(&buffer); err != nil {
 		return nil, fmt.Errorf("could not encode block. Cause: %w", err)
 	}
 

--- a/integration/ethereummock/db.go
+++ b/integration/ethereummock/db.go
@@ -6,8 +6,6 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/ten-protocol/go-ten/go/enclave/storage"
-
 	"github.com/ten-protocol/go-ten/go/common/log"
 
 	"github.com/ten-protocol/go-ten/go/common/errutil"
@@ -37,7 +35,7 @@ func (n *blockResolverInMem) Proof(_ context.Context, _ *core.Rollup) (*types.Bl
 	panic("implement me")
 }
 
-func NewResolver() storage.BlockResolver {
+func NewResolver() *blockResolverInMem {
 	return &blockResolverInMem{
 		blockCache: map[common.L1BlockHash]*types.Block{},
 		m:          sync.RWMutex{},
@@ -161,7 +159,7 @@ func (m *Node) removeCommittedTransactions(
 	ctx context.Context,
 	cb *types.Block,
 	mempool []*types.Transaction,
-	resolver storage.BlockResolver,
+	resolver *blockResolverInMem,
 	db TxDB,
 ) []*types.Transaction {
 	if cb.NumberU64() <= common.HeightCommittedBlocks {

--- a/integration/ethereummock/gethutil.go
+++ b/integration/ethereummock/gethutil.go
@@ -1,10 +1,8 @@
-package gethutil
+package ethereummock
 
 import (
 	"context"
 	"fmt"
-
-	"github.com/ten-protocol/go-ten/go/enclave/storage"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -18,46 +16,46 @@ var EmptyHash = gethcommon.Hash{}
 
 // LCA - returns the latest common ancestor of the 2 blocks or an error if no common ancestor is found
 // it also returns the blocks that became canonical, and the once that are now the fork
-func LCA(ctx context.Context, newCanonical *types.Header, oldCanonical *types.Header, resolver storage.BlockResolver) (*common.ChainFork, error) {
+func LCA(ctx context.Context, newCanonical *types.Block, oldCanonical *types.Block, resolver *blockResolverInMem) (*common.ChainFork, error) {
 	b, cp, ncp, err := internalLCA(ctx, newCanonical, oldCanonical, resolver, []common.L1BlockHash{}, []common.L1BlockHash{})
 	return &common.ChainFork{
-		NewCanonical:     newCanonical,
-		OldCanonical:     oldCanonical,
-		CommonAncestor:   b,
+		NewCanonical:     newCanonical.Header(),
+		OldCanonical:     oldCanonical.Header(),
+		CommonAncestor:   b.Header(),
 		CanonicalPath:    cp,
 		NonCanonicalPath: ncp,
 	}, err
 }
 
-func internalLCA(ctx context.Context, newCanonical *types.Header, oldCanonical *types.Header, resolver storage.BlockResolver, canonicalPath []common.L1BlockHash, nonCanonicalPath []common.L1BlockHash) (*types.Header, []common.L1BlockHash, []common.L1BlockHash, error) {
-	if newCanonical.Number.Uint64() == common.L1GenesisHeight || oldCanonical.Number.Uint64() == common.L1GenesisHeight {
+func internalLCA(ctx context.Context, newCanonical *types.Block, oldCanonical *types.Block, resolver *blockResolverInMem, canonicalPath []common.L1BlockHash, nonCanonicalPath []common.L1BlockHash) (*types.Block, []common.L1BlockHash, []common.L1BlockHash, error) {
+	if newCanonical.NumberU64() == common.L1GenesisHeight || oldCanonical.NumberU64() == common.L1GenesisHeight {
 		return newCanonical, canonicalPath, nonCanonicalPath, nil
 	}
 	if newCanonical.Hash() == oldCanonical.Hash() {
 		// this is where we reach the common ancestor, which we add to the canonical path
 		return newCanonical, append(canonicalPath, newCanonical.Hash()), nonCanonicalPath, nil
 	}
-	if newCanonical.Number.Uint64() > oldCanonical.Number.Uint64() {
-		p, err := resolver.FetchBlock(ctx, newCanonical.ParentHash)
+	if newCanonical.NumberU64() > oldCanonical.NumberU64() {
+		p, err := resolver.FetchBlock(ctx, newCanonical.ParentHash())
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash, err)
 		}
 
 		return internalLCA(ctx, p, oldCanonical, resolver, append(canonicalPath, newCanonical.Hash()), nonCanonicalPath)
 	}
-	if oldCanonical.Number.Uint64() > newCanonical.Number.Uint64() {
-		p, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash)
+	if oldCanonical.NumberU64() > newCanonical.NumberU64() {
+		p, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash())
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash, err)
 		}
 
 		return internalLCA(ctx, newCanonical, p, resolver, canonicalPath, append(nonCanonicalPath, oldCanonical.Hash()))
 	}
-	parentBlockA, err := resolver.FetchBlock(ctx, newCanonical.ParentHash)
+	parentBlockA, err := resolver.FetchBlock(ctx, newCanonical.ParentHash())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash, err)
 	}
-	parentBlockB, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash)
+	parentBlockB, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash, err)
 	}

--- a/integration/ethereummock/gethutil.go
+++ b/integration/ethereummock/gethutil.go
@@ -38,7 +38,7 @@ func internalLCA(ctx context.Context, newCanonical *types.Block, oldCanonical *t
 	if newCanonical.NumberU64() > oldCanonical.NumberU64() {
 		p, err := resolver.FetchBlock(ctx, newCanonical.ParentHash())
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash, err)
+			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash(), err)
 		}
 
 		return internalLCA(ctx, p, oldCanonical, resolver, append(canonicalPath, newCanonical.Hash()), nonCanonicalPath)
@@ -46,18 +46,18 @@ func internalLCA(ctx context.Context, newCanonical *types.Block, oldCanonical *t
 	if oldCanonical.NumberU64() > newCanonical.NumberU64() {
 		p, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash())
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash, err)
+			return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash(), err)
 		}
 
 		return internalLCA(ctx, newCanonical, p, resolver, canonicalPath, append(nonCanonicalPath, oldCanonical.Hash()))
 	}
 	parentBlockA, err := resolver.FetchBlock(ctx, newCanonical.ParentHash())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash, err)
+		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", newCanonical.ParentHash(), err)
 	}
 	parentBlockB, err := resolver.FetchBlock(ctx, oldCanonical.ParentHash())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash, err)
+		return nil, nil, nil, fmt.Errorf("could not retrieve parent block %s. Cause: %w", oldCanonical.ParentHash(), err)
 	}
 
 	return internalLCA(ctx, parentBlockA, parentBlockB, resolver, append(canonicalPath, newCanonical.Hash()), append(nonCanonicalPath, oldCanonical.Hash()))

--- a/integration/ethereummock/utils.go
+++ b/integration/ethereummock/utils.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ten-protocol/go-ten/go/enclave/storage"
-
 	"github.com/ten-protocol/go-ten/go/common"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -13,12 +11,12 @@ import (
 
 // findNotIncludedTxs - given a list of transactions, it keeps only the ones that were not included in the block
 // todo (#1491) - inefficient
-func findNotIncludedTxs(head *types.Block, txs []*types.Transaction, r storage.BlockResolver, db TxDB) []*types.Transaction {
+func findNotIncludedTxs(head *types.Block, txs []*types.Transaction, r *blockResolverInMem, db TxDB) []*types.Transaction {
 	included := allIncludedTransactions(head, r, db)
 	return removeExisting(txs, included)
 }
 
-func allIncludedTransactions(b *types.Block, r storage.BlockResolver, db TxDB) map[common.TxHash]*types.Transaction {
+func allIncludedTransactions(b *types.Block, r *blockResolverInMem, db TxDB) map[common.TxHash]*types.Transaction {
 	val, found := db.Txs(b)
 	if found {
 		return val

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -102,7 +102,7 @@ func (s *Simulation) waitForTenGenesisOnL1() {
 			panic(fmt.Errorf("could not fetch head block. Cause: %w", err))
 		}
 		if err == nil {
-			for _, b := range client.BlocksBetween(ethereummock.MockGenesisBlock, head) {
+			for _, b := range client.BlocksBetween(ethereummock.MockGenesisBlock.Header(), head) {
 				for _, tx := range b.Transactions() {
 					t := s.Params.MgmtContractLib.DecodeTx(tx)
 					if t == nil {

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -255,7 +255,7 @@ func ExtractDataFromEthereumChain(
 	rollupReceipts := make(types.Receipts, 0)
 	totalDeposited := big.NewInt(0)
 
-	blockchain := node.BlocksBetween(startBlock, endBlock)
+	blockchain := node.BlocksBetween(startBlock.Header(), endBlock)
 	successfulDeposits := uint64(0)
 	for _, block := range blockchain {
 		for _, tx := range block.Transactions() {

--- a/tools/walletextension/main/main.go
+++ b/tools/walletextension/main/main.go
@@ -17,7 +17,7 @@ const (
 	tcp = "tcp"
 	// @fixme -
 	// this is a temporary fix as out forked version of log.go does not map with gethlog.Level<Level>
-	//and should be fixed as part of logging refactoring in the future
+	// and should be fixed as part of logging refactoring in the future
 	legacyLevelDebug = 4
 	legacyLevelError = 1
 )


### PR DESCRIPTION
### Why this change is needed

- There is a memory leak somewhere in the RLP code.
- The enclave doesn't need the body of the L1 blocks because it doesn't execute those transactions.

### What changes were made as part of this PR

- only send the block header and the ten-specific transactions
- change a lot of method signatures to use `types.Header` instead of `types.Block`, plus a few changes to get the height or the hash
- duplicate some logic to be used for the mock ethereum nodes which use blocks

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


