### PR TITLE
use "_" instead of "-" in Github env variables for the gateway

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -59,8 +59,8 @@ jobs:
           INSTANCE_PREFIX=""
 
           if [[ "${{ github.event.inputs.instance_type }}" != "primary" ]]; then
-            INSTANCE_SUFFIX="-${{ github.event.inputs.instance_type }}"
-            INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}-"
+            INSTANCE_SUFFIX="_${{ github.event.inputs.instance_type }}"
+            INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}_"
           fi
 
           echo "INSTANCE_SUFFIX=$INSTANCE_SUFFIX" >> $GITHUB_ENV


### PR DESCRIPTION
### Why this change is needed

Chenged the format of env variable names to include `_` instead of `-`.
Github only allows aplhanumeric + `_` in env var names.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


