### PR TITLE
Minor logging improvements to the cross chain messaging components

### DIFF
--- a/contracts/deployment_scripts/testing/001_gas_testing_deployment.ts
+++ b/contracts/deployment_scripts/testing/001_gas_testing_deployment.ts
@@ -4,6 +4,7 @@ import { Receipt } from 'hardhat-deploy/dist/types';
 
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    return;
     const l2Network = hre; 
     const {deployer} = await hre.getNamedAccounts();
 

--- a/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
+++ b/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
@@ -62,7 +62,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const mbus = mbusBase.connect(await hre.ethers.provider.getSigner(deployer)); 
     const tx = await mbus.getFunction("sendValueToL2").send(deployer, 1000, { value: 1000});
     const receipt = await tx.wait()
-    console.log(`003_simple_withdrawal: Cross Chain send receipt status = ${receipt.status}`);
+    console.log(`003_simple_withdrawal: Cross Chain send ${tx.hash} receipt status = ${receipt.status}`);
 
     const block = await hre.ethers.provider.send('eth_getBlockByHash', [receipt.blockHash, true]);
     console.log(`Block received:       ${block.number}`)

--- a/go/common/crosschain.go
+++ b/go/common/crosschain.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -9,12 +10,24 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+type CrossChainRootHashes [][]byte
+
 type ExtCrossChainBundle struct {
 	LastBatchHash        gethcommon.Hash
 	Signature            []byte
-	L1BlockHash          gethcommon.Hash // The block hash that's expected to be canonical on signature submission
-	L1BlockNum           *big.Int        // The number of the block that has the block hash. This is used to verify the block hash.
-	CrossChainRootHashes [][]byte        // The CrossChainRoots of the batches that are being submitted
+	L1BlockHash          gethcommon.Hash      // The block hash that's expected to be canonical on signature submission
+	L1BlockNum           *big.Int             // The number of the block that has the block hash. This is used to verify the block hash.
+	CrossChainRootHashes CrossChainRootHashes // The CrossChainRoots of the batches that are being submitted
+}
+
+func (hashes CrossChainRootHashes) ToHexString() string {
+	hexStrings := make([]string, 0, len(hashes))
+
+	for _, hash := range hashes {
+		hexStrings = append(hexStrings, gethcommon.BytesToHash(hash).Hex())
+	}
+
+	return strings.Join(hexStrings, ",")
 }
 
 func (bundle ExtCrossChainBundle) HashPacked() common.Hash {

--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -386,12 +386,12 @@ func (executor *batchExecutor) populateOutboundCrossChainData(ctx context.Contex
 
 		batch.Header.CrossChainTree = encodedTree
 		xchainHash = gethcommon.BytesToHash(tree.GetRoot())
-		executor.logger.Info("[CrossChain] adding messages to batch")
+		executor.logger.Debug("[CrossChain] adding messages to batch", "encodedTree", encodedTree)
 	}
 	batch.Header.CrossChainMessages = crossChainMessages
 	batch.Header.CrossChainRoot = xchainHash
 
-	executor.logger.Trace(fmt.Sprintf("Added %d cross chain messages to batch.",
+	executor.logger.Debug(fmt.Sprintf("Added %d cross chain messages to batch.",
 		len(batch.Header.CrossChainMessages)), log.CmpKey, log.CrossChainCmp)
 
 	batch.Header.LatestInboundCrossChainHash = block.Hash()

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -523,6 +523,7 @@ func (s *sequencer) Close() error {
 }
 
 func (s *sequencer) ExportCrossChainData(ctx context.Context, fromSeqNo uint64, toSeqNo uint64) (*common.ExtCrossChainBundle, error) {
+	defer core.LogMethodDuration(s.logger, measure.NewStopwatch(), "ExportCrossChainData()", "fromSeqNo", fromSeqNo, "toSeqNo", toSeqNo)
 	bundle, err := ExportCrossChainData(ctx, s.storage, fromSeqNo, toSeqNo)
 	if err != nil {
 		return nil, err

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -313,8 +313,6 @@ func (p *Publisher) PublishCrossChainBundle(bundle *common.ExtCrossChainBundle, 
 
 	transactor.Nonce = big.NewInt(0).SetUint64(nonce)
 
-	p.logger.Debug("Adding cross chain roots to management contract", log.BundleHashKey, bundle.CrossChainRootHashes)
-
 	tx, err := managementCtr.AddCrossChainMessagesRoot(transactor, [32]byte(bundle.LastBatchHash.Bytes()), bundle.L1BlockHash, bundle.L1BlockNum, bundle.CrossChainRootHashes, bundle.Signature, rollupNum, forkID)
 	if err != nil {
 		if !errors.Is(err, errutil.ErrCrossChainBundleRepublished) {
@@ -331,7 +329,7 @@ func (p *Publisher) PublishCrossChainBundle(bundle *common.ExtCrossChainBundle, 
 		return fmt.Errorf("unable to get receipt for cross chain bundle transaction. Cause: %w", err)
 	}
 
-	p.logger.Info("Successfully submitted bundle", log.BundleHashKey, bundle.LastBatchHash)
+	p.logger.Info("Successfully submitted bundle", log.BundleHashKey, bundle.LastBatchHash, "bundleRoots", bundle.CrossChainRootHashes.ToHexString())
 	return nil
 }
 

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -329,7 +329,7 @@ func (p *Publisher) PublishCrossChainBundle(bundle *common.ExtCrossChainBundle, 
 		return fmt.Errorf("unable to get receipt for cross chain bundle transaction. Cause: %w", err)
 	}
 
-	p.logger.Info("Successfully submitted bundle", log.BundleHashKey, bundle.LastBatchHash, "bundleRoots", bundle.CrossChainRootHashes.ToHexString())
+	p.logger.Info("Successfully submitted bundle", log.BundleHashKey, bundle.LastBatchHash, "bundleRoots", bundle.CrossChainRootHashes.ToHexString(), "managementContract", *p.mgmtContractLib.GetContractAddr())
 	return nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Currently logging is insufficient for determining what is happening with cross chain messages. This PR adds some odd bits here and there in order to help us determine if a message has went in and was published.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


