### PR TITLE
Fix geth network on PR build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -77,6 +77,7 @@ jobs:
             integration/.build/noderunner/noderunner-*.txt
             integration/.build/wallet_extension/wal-ext-*.txt
             integration/.build/eth2/*
+            !integration/.build/eth2/**/geth.ipc
             integration/.build/faucet/*
             integration/.build/tenscan/*
             integration/.build/tengateway/*

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,9 +36,9 @@ jobs:
       # Close specified ports using lsof before testing / local port list compiled from ./integration/constants.go
       - name: Close Integration Test Ports
         run: |
-          killall -9 geth || true
-          killall -9 beacon || true
-          killall -9 validator || true
+          pkill -9 geth || true
+          pkill -9 beacon-chain || true
+          pkill -9 validator || true
           
           lowest_port=8000  # Lowest starting port
           highest_port=58000 # Highest port considering the offset

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -1,23 +1,8 @@
 package integration
 
-// Tracks the start ports handed out to different tests, in a bid to minimise conflicts.
-// Note: the max should not exceed 30000 because the OS can use those ports and we'll get conflicts
-const (
-	StartPortEth2NetworkTests      = 10000
-	StartPortTenscanUnitTest       = 11000
-	StartPortNodeRunnerTest        = 12000
-	StartPortSimulationGethInMem   = 14000
-	StartPortSimulationInMem       = 15000
-	StartPortSimulationFullNetwork = 16000
-	DoNotUse                       = 17000 // port conflict on this address
-	StartPortSmartContractTests    = 18000
-	StartPortContractDeployerTest1 = 19000
-	StartPortContractDeployerTest2 = 21000
-	StartPortFaucetUnitTest        = 22000
-	StartPortFaucetHTTPUnitTest    = 23000
-	StartPortTenGatewayUnitTest    = 24000
-	StartPortNetworkTests          = 25000
+import "reflect"
 
+const (
 	DefaultGethWSPortOffset         = 100
 	DefaultGethAUTHPortOffset       = 200
 	DefaultGethNetworkPortOffset    = 300
@@ -43,3 +28,52 @@ const (
 	GethNodeAddress = "0x123463a4b065722e99115d6c222f267d9cabb524"
 	GethNodePK      = "2e0834786285daccd064ca17f1654f67b4aef298acbb82cef9ec422fb4975622"
 )
+
+type Ports struct {
+	TestStartPosEth2NetworkPort                 int
+	TestTenscanPort                             int
+	TestCanStartStandaloneTenHostAndEnclavePort int
+	TestGethSimulationPort                      int
+	TestInMemoryMonteCarloSimulationPort        int
+	TestFullNetworkMonteCarloSimulationPort     int
+	DoNotUSePort                                int
+	TestManagementContractPort                  int
+	TestCanDeployLayer2ERC20ContractPort        int
+	TestFaucetSendsFundsOnlyIfNeededPort        int
+	TestFaucetPort                              int
+	TestFaucetHTTPPort                          int
+	TestTenGatewayPort                          int
+	NetworkTestsPort                            int
+}
+
+var TestPorts = Ports{
+	TestStartPosEth2NetworkPort:                 10000,
+	TestTenscanPort:                             11000,
+	TestCanStartStandaloneTenHostAndEnclavePort: 12000,
+	TestGethSimulationPort:                      14000,
+	TestInMemoryMonteCarloSimulationPort:        15000,
+	TestFullNetworkMonteCarloSimulationPort:     16000,
+	DoNotUSePort:                                17000,
+	TestManagementContractPort:                  18000,
+	TestCanDeployLayer2ERC20ContractPort:        19000,
+	TestFaucetSendsFundsOnlyIfNeededPort:        21000,
+	TestFaucetPort:                              22000,
+	TestFaucetHTTPPort:                          23000,
+	TestTenGatewayPort:                          24000,
+	NetworkTestsPort:                            25000,
+}
+
+// GetTestName looks up the test name from the port number using reflection
+func GetTestName(port int) string {
+	port = port - DefaultGethNetworkPortOffset
+	val := reflect.ValueOf(TestPorts)
+	typ := reflect.TypeOf(TestPorts)
+
+	for i := 0; i < val.NumField(); i++ {
+		fieldValue, ok := val.Field(i).Interface().(int)
+		if ok && fieldValue == port {
+			return typ.Field(i).Name
+		}
+	}
+	return "UnknownTest"
+}

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -34,22 +34,6 @@ const (
 	DefaultTenGatewayWSPortOffset   = 952
 )
 
-var PortToTestName = map[int]string{
-	10000: "TestStartPosEth2Network",
-	11000: "TestTenscan",
-	12000: "TestCanStartStandaloneTenHostAndEnclave",
-	14000: "TestGethSimulation",
-	15000: "TestInMemoryMonteCarloSimulation",
-	16000: "TestFullNetworkMonteCarloSimulation",
-	17000: "DoNotUse",
-	18000: "TestManagementContract",
-	19000: "TestCanDeployLayer2ERC20Contract",
-	21000: "TestFaucetSendsFundsOnlyIfNeeded",
-	22000: "TestFaucet",
-	24000: "TestTenGateway",
-	25000: "NetworkTests",
-}
-
 const (
 	EthereumChainID = 1337
 	TenChainID      = 443

--- a/integration/constants.go
+++ b/integration/constants.go
@@ -34,6 +34,22 @@ const (
 	DefaultTenGatewayWSPortOffset   = 952
 )
 
+var PortToTestName = map[int]string{
+	10000: "TestStartPosEth2Network",
+	11000: "TestTenscan",
+	12000: "TestCanStartStandaloneTenHostAndEnclave",
+	14000: "TestGethSimulation",
+	15000: "TestInMemoryMonteCarloSimulation",
+	16000: "TestFullNetworkMonteCarloSimulation",
+	17000: "DoNotUse",
+	18000: "TestManagementContract",
+	19000: "TestCanDeployLayer2ERC20Contract",
+	21000: "TestFaucetSendsFundsOnlyIfNeeded",
+	22000: "TestFaucet",
+	24000: "TestTenGateway",
+	25000: "NetworkTests",
+}
+
 const (
 	EthereumChainID = 1337
 	TenChainID      = 443

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -45,7 +45,7 @@ func init() { //nolint:gochecknoinits
 }
 
 func TestCanDeployLayer2ERC20Contract(t *testing.T) {
-	startPort := integration.StartPortContractDeployerTest1
+	startPort := integration.TestPorts.TestCanDeployLayer2ERC20ContractPort
 	hostWSPort := startPort + integration.DefaultHostRPCWSOffset
 	creatTenNetwork(t, startPort)
 	// This sleep is required to ensure the initial rollup exists, and thus contract deployer can check its balance.
@@ -81,7 +81,7 @@ func TestCanDeployLayer2ERC20Contract(t *testing.T) {
 }
 
 func TestFaucetSendsFundsOnlyIfNeeded(t *testing.T) {
-	startPort := integration.StartPortContractDeployerTest2
+	startPort := integration.TestPorts.TestFaucetSendsFundsOnlyIfNeededPort
 	hostWSPort := startPort + integration.DefaultHostRPCWSOffset
 	creatTenNetwork(t, startPort)
 

--- a/integration/eth2network/build_number.go
+++ b/integration/eth2network/build_number.go
@@ -30,7 +30,7 @@ func getBuildNumber() (int, error) {
 			break
 		}
 		buildNumber++
-		if buildNumber > 9999 {
+		if buildNumber > 99 {
 			buildNumber = 1
 		}
 	}

--- a/integration/eth2network/pos_eth2_network.go
+++ b/integration/eth2network/pos_eth2_network.go
@@ -164,10 +164,6 @@ func (n *PosImpl) Start() error {
 		time.Sleep(time.Second)
 	}()
 
-	println("Geth process ID: ", n.gethProcessID)
-	println("Beacon process ID: ", n.gethProcessID)
-	println("Validator process ID: ", n.validatorProcessID)
-
 	if err != nil {
 		return fmt.Errorf("could not run the script to start l1 pos network. Cause: %s", err.Error())
 	}

--- a/integration/eth2network/pos_eth2_network.go
+++ b/integration/eth2network/pos_eth2_network.go
@@ -164,6 +164,10 @@ func (n *PosImpl) Start() error {
 		time.Sleep(time.Second)
 	}()
 
+	println("Geth process ID: ", n.gethProcessID)
+	println("Beacon process ID: ", n.gethProcessID)
+	println("Validator process ID: ", n.validatorProcessID)
+
 	if err != nil {
 		return fmt.Errorf("could not run the script to start l1 pos network. Cause: %s", err.Error())
 	}

--- a/integration/eth2network/pos_eth2_network.go
+++ b/integration/eth2network/pos_eth2_network.go
@@ -99,7 +99,7 @@ func NewPosEth2Network(binDir string, gethNetworkPort, beaconP2PPort, gethRPCPor
 		panic(err)
 	}
 
-	testName := reverseLookupTestName(gethNetworkPort)
+	testName := integration.GetTestName(gethNetworkPort)
 
 	gethLogFile := path.Join(buildDir, "geth.log")
 	prysmBeaconLogFile := path.Join(buildDir, "beacon-chain.log")
@@ -415,13 +415,4 @@ func kill(pid int) {
 	if err != nil {
 		fmt.Printf("Error releasing process with PID %d: %v\n", pid, err)
 	}
-}
-
-// Lookup test name from the port so geth/ beacon logs are easier to cross reference
-func reverseLookupTestName(port int) string {
-	startPort := port - integration.DefaultGethNetworkPortOffset
-	if testName, exists := integration.PortToTestName[startPort]; exists {
-		return testName
-	}
-	return "UnknownTest"
 }

--- a/integration/eth2network/pos_eth2_network_test.go
+++ b/integration/eth2network/pos_eth2_network_test.go
@@ -26,10 +26,6 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-const (
-	_startPort = integration.StartPortEth2NetworkTests
-)
-
 func TestEnsureBinariesAreAvail(t *testing.T) {
 	path, err := EnsureBinariesExist()
 	assert.Nil(t, err)
@@ -40,15 +36,16 @@ func TestStartPosEth2Network(t *testing.T) {
 	binDir, err := EnsureBinariesExist()
 	assert.Nil(t, err)
 
+	startPort := integration.TestPorts.TestStartPosEth2NetworkPort
 	network := NewPosEth2Network(
 		binDir,
-		_startPort+integration.DefaultGethNetworkPortOffset,
-		_startPort+integration.DefaultPrysmP2PPortOffset,
-		_startPort+integration.DefaultGethAUTHPortOffset,
-		_startPort+integration.DefaultGethWSPortOffset,
-		_startPort+integration.DefaultGethHTTPPortOffset,
-		_startPort+integration.DefaultPrysmRPCPortOffset,
-		_startPort+integration.DefaultPrysmGatewayPortOffset,
+		startPort+integration.DefaultGethNetworkPortOffset,
+		startPort+integration.DefaultPrysmP2PPortOffset,
+		startPort+integration.DefaultGethAUTHPortOffset,
+		startPort+integration.DefaultGethWSPortOffset,
+		startPort+integration.DefaultGethHTTPPortOffset,
+		startPort+integration.DefaultPrysmRPCPortOffset,
+		startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 	)
@@ -60,12 +57,12 @@ func TestStartPosEth2Network(t *testing.T) {
 
 	// test input configurations
 	t.Run("areConfigsUphold", func(t *testing.T) {
-		areConfigsUphold(t, gethcommon.HexToAddress(integration.GethNodeAddress), integration.EthereumChainID)
+		areConfigsUphold(t, startPort, gethcommon.HexToAddress(integration.GethNodeAddress), integration.EthereumChainID)
 	})
 
 	// test number of nodes
 	t.Run("numberOfNodes", func(t *testing.T) {
-		numberOfNodes(t)
+		numberOfNodes(t, startPort)
 	})
 
 	minerWallet := wallet.NewInMemoryWalletFromConfig(
@@ -74,12 +71,12 @@ func TestStartPosEth2Network(t *testing.T) {
 		gethlog.New())
 
 	t.Run("txsAreMinted", func(t *testing.T) {
-		txsAreMinted(t, minerWallet)
+		txsAreMinted(t, startPort, minerWallet)
 	})
 }
 
-func areConfigsUphold(t *testing.T, addr gethcommon.Address, chainID int) {
-	url := fmt.Sprintf("http://127.0.0.1:%d", _startPort+integration.DefaultGethHTTPPortOffset)
+func areConfigsUphold(t *testing.T, startPort int, addr gethcommon.Address, chainID int) {
+	url := fmt.Sprintf("http://127.0.0.1:%d", startPort+integration.DefaultGethHTTPPortOffset)
 	conn, err := ethclient.Dial(url)
 	assert.Nil(t, err)
 
@@ -92,8 +89,8 @@ func areConfigsUphold(t *testing.T, addr gethcommon.Address, chainID int) {
 	assert.Equal(t, int64(chainID), id.Int64())
 }
 
-func numberOfNodes(t *testing.T) {
-	url := fmt.Sprintf("http://127.0.0.1:%d", _startPort+integration.DefaultGethHTTPPortOffset)
+func numberOfNodes(t *testing.T, startPort int) {
+	url := fmt.Sprintf("http://127.0.0.1:%d", startPort+integration.DefaultGethHTTPPortOffset)
 
 	req, err := http.NewRequestWithContext(
 		context.Background(),
@@ -122,10 +119,10 @@ func numberOfNodes(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("0x%x", 0), res["result"])
 }
 
-func txsAreMinted(t *testing.T, w wallet.Wallet) {
+func txsAreMinted(t *testing.T, startPort int, w wallet.Wallet) {
 	var err error
 
-	ethClient, err := ethadapter.NewEthClient("127.0.0.1", uint(_startPort+integration.DefaultGethWSPortOffset), 30*time.Second, common.L2Address{}, gethlog.New())
+	ethClient, err := ethadapter.NewEthClient("127.0.0.1", uint(startPort+integration.DefaultGethWSPortOffset), 30*time.Second, common.L2Address{}, gethlog.New())
 	assert.Nil(t, err)
 
 	toAddr := datagenerator.RandomAddress()

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -149,7 +149,6 @@ ${GETH_BINARY} --http \
        --nodiscover \
        --syncmode full \
        --allow-insecure-unlock \
-#       --ipcdisable \
        --unlock 0x123463a4b065722e99115d6c222f267d9cabb524 \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -141,6 +141,7 @@ ${GETH_BINARY} --http \
        --ws.origins "*" \
        --authrpc.jwtsecret "${BASE_PATH}/jwt.hex" \
        --authrpc.port "${GETH_RPC_PORT}" \
+       --authrpc.vhosts "*" \
        --port="${GETH_NETWORK_PORT}" \
        --datadir="${GETHDATA_DIR}" \
        --networkid="${CHAIN_ID}" \

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -150,4 +150,8 @@ ${GETH_BINARY} --http \
        --unlock 0x123463a4b065722e99115d6c222f267d9cabb524 \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!
+
+# attach the geth ipc
+${GETH_BINARY} attach "${GETHDATA_DIR}/geth.ipc"
+
 echo "GETH PID $geth_pid"

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -147,6 +147,7 @@ ${GETH_BINARY} --http \
        --nodiscover \
        --syncmode full \
        --allow-insecure-unlock \
+       --ipcdisable \
        --unlock 0x123463a4b065722e99115d6c222f267d9cabb524 \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -151,7 +151,4 @@ ${GETH_BINARY} --http \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!
 
-## attach the geth ipc
-#${GETH_BINARY} attach "${GETHDATA_DIR}/geth.ipc"
-
 echo "GETH PID $geth_pid"

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -115,7 +115,8 @@ ${BEACON_BINARY} --datadir="${BEACONDATA_DIR}" \
                --minimum-peers-per-subnet 0 \
                --enable-debug-rpc-endpoints \
                --verbosity=debug \
-               --execution-endpoint "http://127.0.0.1:${GETH_RPC_PORT}/ " > "${BEACON_LOG_FILE}" 2>&1 &
+                --execution-endpoint "${GETHDATA_DIR}/geth.ipc" > "${BEACON_LOG_FILE}" 2>&1 &
+#               --execution-endpoint "http://127.0.0.1:${GETH_RPC_PORT}/ " > "${BEACON_LOG_FILE}" 2>&1 &
 beacon_pid=$!
 echo "BEACON PID $beacon_pid"
 
@@ -148,9 +149,8 @@ ${GETH_BINARY} --http \
        --nodiscover \
        --syncmode full \
        --allow-insecure-unlock \
-       --ipcdisable \
+#       --ipcdisable \
        --unlock 0x123463a4b065722e99115d6c222f267d9cabb524 \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!
-
 echo "GETH PID $geth_pid"

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -21,6 +21,7 @@ GETH_LOG_FILE="./geth.log"
 GETHDATA_DIR="/gethdata"
 BEACONDATA_DIR="/beacondata"
 VALIDATORDATA_DIR="/validatordata"
+TEST_LOG_FILE="./test.log"
 
 # Function to display usage
 usage() {
@@ -68,6 +69,7 @@ while [[ "$#" -gt 0 ]]; do
         --gethdata-dir) GETHDATA_DIR="$2"; shift ;;
         --beacondata-dir) BEACONDATA_DIR="$2"; shift ;;
         --validatordata-dir) VALIDATORDATA_DIR="$2"; shift ;;
+        --test-log) TEST_LOG_FILE="$2"; shift ;;
         *) usage ;;
     esac
     shift
@@ -76,6 +78,9 @@ done
 mkdir -p "$(dirname "${BEACON_LOG_FILE}")"
 mkdir -p "$(dirname "${VALIDATOR_LOG_FILE}")"
 mkdir -p "$(dirname "${GETH_LOG_FILE}")"
+mkdir -p "$(dirname "${TEST_LOG_FILE}")"
+
+echo "Test" > "${TEST_LOG_FILE}" 2>&1 &
 
 ${PRYSMCTL_BINARY} testnet generate-genesis \
            --fork deneb \
@@ -115,8 +120,7 @@ ${BEACON_BINARY} --datadir="${BEACONDATA_DIR}" \
                --minimum-peers-per-subnet 0 \
                --enable-debug-rpc-endpoints \
                --verbosity=debug \
-                --execution-endpoint "${GETHDATA_DIR}/geth.ipc" > "${BEACON_LOG_FILE}" 2>&1 &
-#               --execution-endpoint "http://127.0.0.1:${GETH_RPC_PORT}/ " > "${BEACON_LOG_FILE}" 2>&1 &
+               --execution-endpoint "${GETHDATA_DIR}/geth.ipc" > "${BEACON_LOG_FILE}" 2>&1 &
 beacon_pid=$!
 echo "BEACON PID $beacon_pid"
 

--- a/integration/eth2network/start-pos-network.sh
+++ b/integration/eth2network/start-pos-network.sh
@@ -115,7 +115,7 @@ ${BEACON_BINARY} --datadir="${BEACONDATA_DIR}" \
                --minimum-peers-per-subnet 0 \
                --enable-debug-rpc-endpoints \
                --verbosity=debug \
-               --execution-endpoint "${GETHDATA_DIR}/geth.ipc" > "${BEACON_LOG_FILE}" 2>&1 &
+               --execution-endpoint "http://127.0.0.1:${GETH_RPC_PORT}/ " > "${BEACON_LOG_FILE}" 2>&1 &
 beacon_pid=$!
 echo "BEACON PID $beacon_pid"
 
@@ -151,7 +151,7 @@ ${GETH_BINARY} --http \
        --password "${BASE_PATH}/password.txt" > "${GETH_LOG_FILE}" 2>&1 &
 geth_pid=$!
 
-# attach the geth ipc
-${GETH_BINARY} attach "${GETHDATA_DIR}/geth.ipc"
+## attach the geth ipc
+#${GETH_BINARY} attach "${GETHDATA_DIR}/geth.ipc"
 
 echo "GETH PID $geth_pid"

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -43,7 +43,7 @@ const (
 func TestFaucet(t *testing.T) {
 	t.Skip("Skipping because it is too flaky")
 
-	startPort := integration.StartPortFaucetUnitTest
+	startPort := integration.TestPorts.TestFaucetPort
 	createObscuroNetwork(t, startPort)
 	// This sleep is required to ensure the initial rollup exists, and thus contract deployer can check its balance.
 	time.Sleep(2 * time.Second)
@@ -54,7 +54,7 @@ func TestFaucet(t *testing.T) {
 		PK:                "0x" + contractDeployerPrivateKeyHex,
 		JWTSecret:         "This_is_secret",
 		ChainID:           big.NewInt(integration.TenChainID),
-		ServerPort:        integration.StartPortFaucetHTTPUnitTest,
+		ServerPort:        integration.TestPorts.TestFaucetHTTPPort,
 		DefaultFundAmount: new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)),
 	}
 	faucetContainer, err := container.NewFaucetContainerFromConfig(faucetConfig)

--- a/integration/noderunner/noderunner_test.go
+++ b/integration/noderunner/noderunner_test.go
@@ -20,7 +20,6 @@ import (
 const (
 	_testLogs  = "../.build/noderunner/"
 	_localhost = "127.0.0.1"
-	_startPort = integration.StartPortNodeRunnerTest
 )
 
 // A smoke test to check that we can stand up a standalone TEN host and enclave.
@@ -31,9 +30,9 @@ func TestCanStartStandaloneTenHostAndEnclave(t *testing.T) {
 		TestSubtype: "test",
 		LogLevel:    gethlog.LvlInfo,
 	})
-
-	// todo run the noderunner test with different obscuro node instances
-	newNode := createInMemoryNode()
+	startPort := integration.TestPorts.TestCanStartStandaloneTenHostAndEnclavePort
+	// todo run the noderunner test with different TEN node instances
+	newNode := createInMemoryNode(startPort)
 
 	binDir, err := eth2network.EnsureBinariesExist()
 	if err != nil {
@@ -42,13 +41,13 @@ func TestCanStartStandaloneTenHostAndEnclave(t *testing.T) {
 
 	network := eth2network.NewPosEth2Network(
 		binDir,
-		_startPort+integration.DefaultGethNetworkPortOffset,
-		_startPort+integration.DefaultPrysmP2PPortOffset,
-		_startPort+integration.DefaultGethAUTHPortOffset,
-		_startPort+integration.DefaultGethWSPortOffset,
-		_startPort+integration.DefaultGethHTTPPortOffset,
-		_startPort+integration.DefaultPrysmRPCPortOffset,
-		_startPort+integration.DefaultPrysmGatewayPortOffset,
+		startPort+integration.DefaultGethNetworkPortOffset,
+		startPort+integration.DefaultPrysmP2PPortOffset,
+		startPort+integration.DefaultGethAUTHPortOffset,
+		startPort+integration.DefaultGethWSPortOffset,
+		startPort+integration.DefaultGethHTTPPortOffset,
+		startPort+integration.DefaultPrysmRPCPortOffset,
+		startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 	)
@@ -66,7 +65,7 @@ func TestCanStartStandaloneTenHostAndEnclave(t *testing.T) {
 	}
 
 	// we create the node RPC client
-	wsURL := fmt.Sprintf("ws://127.0.0.1:%d", _startPort+integration.DefaultGethWSPortOffset)
+	wsURL := fmt.Sprintf("ws://127.0.0.1:%d", startPort+integration.DefaultGethWSPortOffset)
 	var tenClient rpc.Client
 	wait := 30 // max wait in seconds
 	for {
@@ -109,14 +108,14 @@ func TestCanStartStandaloneTenHostAndEnclave(t *testing.T) {
 	t.Fatalf("Zero rollups have been produced after ten seconds. Something is wrong. Latest error was: %s", err)
 }
 
-func createInMemoryNode() node.Node {
+func createInMemoryNode(startPort int) node.Node {
 	nodeCfg := node.NewNodeConfig(
 		node.WithPrivateKey(integration.GethNodePK),
 		node.WithHostID(integration.GethNodeAddress),
-		node.WithEnclaveWSPort(_startPort+integration.DefaultEnclaveOffset),
-		node.WithHostHTTPPort(_startPort+integration.DefaultHostRPCHTTPOffset),
-		node.WithHostWSPort(_startPort+integration.DefaultHostRPCWSOffset),
-		node.WithL1WebsocketURL(fmt.Sprintf("ws://%s:%d", _localhost, _startPort+integration.DefaultGethWSPortOffset)),
+		node.WithEnclaveWSPort(startPort+integration.DefaultEnclaveOffset),
+		node.WithHostHTTPPort(startPort+integration.DefaultHostRPCHTTPOffset),
+		node.WithHostWSPort(startPort+integration.DefaultHostRPCWSOffset),
+		node.WithL1WebsocketURL(fmt.Sprintf("ws://%s:%d", _localhost, startPort+integration.DefaultGethWSPortOffset)),
 		node.WithGenesis(true),
 		node.WithProfiler(true),
 		node.WithL1BlockTime(1*time.Second),

--- a/integration/simulation/devnetwork/config.go
+++ b/integration/simulation/devnetwork/config.go
@@ -42,7 +42,7 @@ type TenConfig struct {
 
 func DefaultTenConfig() *TenConfig {
 	return &TenConfig{
-		PortStart:          integration.StartPortNetworkTests,
+		PortStart:          integration.TestPorts.NetworkTestsPort,
 		NumNodes:           4,
 		InitNumValidators:  3,
 		BatchInterval:      1 * time.Second,
@@ -72,7 +72,7 @@ func LocalDevNetwork(tenConfigOpts ...TenConfigOption) *InMemDevNetwork {
 	}
 
 	l1Config := &L1Config{
-		PortStart:        integration.StartPortNetworkTests,
+		PortStart:        integration.TestPorts.NetworkTestsPort,
 		NumNodes:         tenConfig.NumNodes, // we'll have 1 L1 node per L2 node
 		AvgBlockDuration: 1 * time.Second,
 	}

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -150,7 +150,7 @@ func (s *InMemDevNetwork) Start() {
 		// this is a new network, deploy the contracts to the L1
 		fmt.Println("Deploying TEN contracts to L1")
 		s.deployTenNetworkContracts()
-		fmt.Printf("L1 Port - %d\n", integration.StartPortNetworkTests)
+		fmt.Printf("L1 Port - %d\n", integration.TestPorts.NetworkTestsPort)
 	}
 	fmt.Println("Starting TEN nodes")
 	s.startNodes()

--- a/integration/simulation/simulation_full_network_test.go
+++ b/integration/simulation/simulation_full_network_test.go
@@ -28,7 +28,7 @@ func TestFullNetworkMonteCarloSimulation(t *testing.T) {
 		SimulationTime:             120 * time.Second,
 		L1EfficiencyThreshold:      0.2,
 		Wallets:                    wallets,
-		StartPort:                  integration.StartPortSimulationFullNetwork,
+		StartPort:                  integration.TestPorts.TestFullNetworkMonteCarloSimulationPort,
 		ReceiptTimeout:             20 * time.Second,
 		StoppingDelay:              15 * time.Second,
 		NodeWithInboundP2PDisabled: 2,

--- a/integration/simulation/simulation_geth_in_mem_test.go
+++ b/integration/simulation/simulation_geth_in_mem_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/ten-protocol/go-ten/integration/simulation/params"
 )
 
-const gethTestEnv = "GETH_TEST_ENABLED"
+const (
+	gethTestEnv = "GETH_TEST_ENABLED"
+)
 
 // TestGethSimulation runs the simulation against a private geth network using Clique (PoA)
 func TestGethSimulation(t *testing.T) {
@@ -31,7 +33,7 @@ func TestGethSimulation(t *testing.T) {
 		SimulationTime:        35 * time.Second,
 		L1EfficiencyThreshold: 0.2,
 		Wallets:               wallets,
-		StartPort:             integration.StartPortSimulationGethInMem,
+		StartPort:             integration.TestPorts.TestGethSimulationPort,
 		IsInMem:               true,
 		ReceiptTimeout:        30 * time.Second,
 		StoppingDelay:         10 * time.Second,

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -32,7 +32,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 		MgmtContractLib:            ethereummock.NewMgmtContractLibMock(),
 		ERC20ContractLib:           ethereummock.NewERC20ContractLibMock(),
 		Wallets:                    wallets,
-		StartPort:                  integration.StartPortSimulationInMem,
+		StartPort:                  integration.TestPorts.TestInMemoryMonteCarloSimulationPort,
 		IsInMem:                    true,
 		L1TenData:                  &params.L1TenData{},
 		ReceiptTimeout:             5 * time.Second,

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -24,8 +24,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-const _startPort = integration.StartPortSmartContractTests
-
 // netInfo is a bag holder struct for output data from the execution/run of a network
 type netInfo struct {
 	ethClients  []ethadapter.EthClient
@@ -55,15 +53,16 @@ func runGethNetwork(t *testing.T) *netInfo {
 	// prefund one wallet as the worker wallet
 	workerWallet := datagenerator.RandomWallet(integration.EthereumChainID)
 
+	startPort := integration.TestPorts.TestManagementContractPort
 	eth2Network := eth2network.NewPosEth2Network(
 		binDir,
-		_startPort+integration.DefaultGethNetworkPortOffset,
-		_startPort+integration.DefaultPrysmP2PPortOffset,
-		_startPort+integration.DefaultGethAUTHPortOffset, // RPC
-		_startPort+integration.DefaultGethWSPortOffset,
-		_startPort+integration.DefaultGethHTTPPortOffset,
-		_startPort+integration.DefaultPrysmRPCPortOffset,
-		_startPort+integration.DefaultPrysmGatewayPortOffset,
+		startPort+integration.DefaultGethNetworkPortOffset,
+		startPort+integration.DefaultPrysmP2PPortOffset,
+		startPort+integration.DefaultGethAUTHPortOffset, // RPC
+		startPort+integration.DefaultGethWSPortOffset,
+		startPort+integration.DefaultGethHTTPPortOffset,
+		startPort+integration.DefaultPrysmRPCPortOffset,
+		startPort+integration.DefaultPrysmGatewayPortOffset,
 		integration.EthereumChainID,
 		3*time.Minute,
 		workerWallet.Address().String(),
@@ -74,7 +73,7 @@ func runGethNetwork(t *testing.T) *netInfo {
 	}
 
 	// create a client that is connected to node 0 of the network
-	client, err := ethadapter.NewEthClient("127.0.0.1", integration.StartPortSmartContractTests+100, 60*time.Second, gethcommon.HexToAddress("0x0"), testlog.Logger())
+	client, err := ethadapter.NewEthClient("127.0.0.1", uint(startPort+100), 60*time.Second, gethcommon.HexToAddress("0x0"), testlog.Logger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/tenscan/tenscan_test.go
+++ b/integration/tenscan/tenscan_test.go
@@ -48,8 +48,8 @@ const (
 )
 
 func TestTenscan(t *testing.T) {
-	startPort := integration.StartPortTenscanUnitTest
-	createTenNetwork(t, startPort)
+	startPort := integration.TestPorts.TestTenscanPort
+	createTenNetwork(t, integration.TestPorts.TestTenscanPort)
 
 	tenScanConfig := &config.Config{
 		NodeHostAddress: fmt.Sprintf("http://127.0.0.1:%d", startPort+integration.DefaultHostRPCHTTPOffset),


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3897

### What changes were made as part of this PR

* Filter out the upload of `geth.ipc` on failure as this broke the build
* Add test name to l1 logs so you can tell which test is running for that scenario 
* Switch to `pkill` from `killall` on closing of processes so we don't have to exactly match the versions

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


