### PR TITLE
fix: replaced datadog agent with promtail

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -228,20 +228,49 @@ jobs:
             && chown obscurouser:obscurouser /home/obscurouser/edb-connect.sh \
             && chmod u+x /home/obscurouser/edb-connect.sh \
             && docker network create --driver bridge node_network || true \
-            && docker run -d --name datadog-agent \
-               --network node_network \
-               -e DD_API_KEY=${{ secrets.DD_API_KEY }} \
-               -e DD_LOGS_ENABLED=true \
-               -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
-               -e DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true \
-               -e DD_CONTAINER_EXCLUDE_LOGS="name:datadog-agent" \
-               -e DD_SITE="datadoghq.eu"  \
-               -v /var/run/docker.sock:/var/run/docker.sock:ro \
-               -v /proc/:/host/proc/:ro \
-               -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-               --log-opt max-file=3 --log-opt max-size=10m \
-               datadog/agent:latest \
+            && echo "
+            server:
+              http_listen_port: 9080
+              grpc_listen_port: 0
+
+            positions:
+              filename: /tmp/positions.yaml
+
+            clients:
+              - url: ${{ vars.METRICS_URI }}
+                batchwait: 3s
+                batchsize: 1048576
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: ${{ secrets.LOKI_USER }}
+                  password: ${{ secrets.LOKI_PASSWORD }}
+
+              scrape_configs:
+                - job_name: flog_scrape
+                  docker_sd_configs:
+                    - host: unix:///var/run/docker.sock
+                      refresh_interval: 5s
+                  relabel_configs:
+                    - source_labels: ['__meta_docker_container_name']
+                      regex: '/(.*)'
+                      target_label: 'container'
+                    - source_labels: ['__meta_docker_container_log_stream']
+                      target_label: 'logstream'
+                    - source_labels: ['__meta_docker_container_label_logging_jobname']
+                      target_label: 'job'
+                    - replacement: ${HOSTNAME}
+                      target_label: node_name
+                " > /home/obscuro/promtail/promtail-config.yaml \
+            && docker run -d --name promtail \
+              --network ten_node \
+              -e HOSTNAME=${HOSTNAME} \
+              -v /var/log:/var/log \
+              -v /home/obscuro/promtail:/etc/promtail \
+              -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              grafana/promtail:latest \
+              -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true' \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
                -is_genesis=${{ matrix.is_genesis }} \


### PR DESCRIPTION
### Why this change is needed

As part of our initiative to transition from Datadog to a more open-source solution, we are replacing the Datadog agent with Promtail, which is the preferred log collector for Loki. This will streamline our log aggregation process and improve integration with our existing Loki-based monitoring infrastructure.

### What changes were made as part of this PR

manual-deploy-testnet-l2 workflow

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


