### PR TITLE
add plumbing for visibility config

### DIFF
--- a/design/architecture/db_schema.puml
+++ b/design/architecture/db_schema.puml
@@ -53,7 +53,7 @@ class event_topic {
 class event_type {
    contract: integer
    event_sig: binary(32)
-   lifecycle_event: boolean
+   public: boolean
    id: integer
 }
 class externally_owned_account {

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -86,7 +86,7 @@ func (br *batchRegistry) OnL1Reorg(_ *BlockIngestionType) {
 	br.headBatchSeq = headBatch.SequencerOrderNo
 }
 
-func (br *batchRegistry) OnBatchExecuted(batchHeader *common.BatchHeader, receipts types.Receipts) {
+func (br *batchRegistry) OnBatchExecuted(batchHeader *common.BatchHeader, txExecResults []*core.TxExecResult) {
 	defer core.LogMethodDuration(br.logger, measure.NewStopwatch(), "OnBatchExecuted", log.BatchHashKey, batchHeader.Hash())
 	br.callbackMutex.RLock()
 	defer br.callbackMutex.RUnlock()
@@ -102,7 +102,11 @@ func (br *batchRegistry) OnBatchExecuted(batchHeader *common.BatchHeader, receip
 			Header:       batchHeader,
 			Transactions: txs,
 		}
-		br.batchesCallback(batch, receipts)
+		txReceipts := make([]*types.Receipt, len(txExecResults))
+		for i, txExecResult := range txExecResults {
+			txReceipts[i] = txExecResult.Receipt
+		}
+		br.batchesCallback(batch, txReceipts)
 	}
 
 	br.lastExecutedBatch.Mark()

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -470,7 +470,7 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 			if err != nil {
 				return err
 			}
-			err = rc.storage.StoreExecutedBatch(ctx, genBatch.Header, nil, nil)
+			err = rc.storage.StoreExecutedBatch(ctx, genBatch.Header, nil)
 			if err != nil {
 				return err
 			}
@@ -514,7 +514,7 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 			if err != nil {
 				return err
 			}
-			err = rc.storage.StoreExecutedBatch(ctx, computedBatch.Batch.Header, computedBatch.Receipts, computedBatch.CreatedContracts)
+			err = rc.storage.StoreExecutedBatch(ctx, computedBatch.Batch.Header, computedBatch.TxExecResults)
 			if err != nil {
 				return err
 			}

--- a/go/enclave/core/event_types.go
+++ b/go/enclave/core/event_types.go
@@ -5,18 +5,19 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// EventVisibilityConfig - configuration per event by the dApp developer
 type EventVisibilityConfig struct {
-	AutoConfig                                  bool
+	AutoConfig                                  bool  // true for events that have no explicit configuration
 	Public                                      bool  // everyone can see and query for this event
-	Topic1CanView, Topic2CanView, Topic3CanView *bool // If the event is private, and this is true, it means that the address from topic1 is an EOA that can view this event
+	Topic1CanView, Topic2CanView, Topic3CanView *bool // If the event is not public, and this is true, it means that the address from topicI is an EOA that can view this event
 	SenderCanView                               *bool // if true, the tx signer will see this event. Default false
 }
 
 // ContractVisibilityConfig represents the configuration as defined by the dApp developer in the smart contract
 type ContractVisibilityConfig struct {
-	AutoConfig   bool // true - if the platform has to autodetect
-	Transparent  *bool
-	EventConfigs map[gethcommon.Hash]*EventVisibilityConfig
+	AutoConfig   bool                                       // true for contracts that have no explicit configuration
+	Transparent  *bool                                      // users can configure contracts to be fully transparent. All events will be public, and it will expose the internal storage.
+	EventConfigs map[gethcommon.Hash]*EventVisibilityConfig // map from the event log signature (topics[0]) to the settings
 }
 
 type TxExecResult struct {

--- a/go/enclave/core/event_types.go
+++ b/go/enclave/core/event_types.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type EventVisibilityConfig struct {
+	AutoConfig                                  bool
+	Public                                      bool  // everyone can see and query for this event
+	Topic1CanView, Topic2CanView, Topic3CanView *bool // If the event is private, and this is true, it means that the address from topic1 is an EOA that can view this event
+	SenderCanView                               *bool // if true, the tx signer will see this event. Default false
+}
+
+// ContractVisibilityConfig represents the configuration as defined by the dApp developer in the smart contract
+type ContractVisibilityConfig struct {
+	AutoConfig   bool // true - if the platform has to autodetect
+	Transparent  *bool
+	EventConfigs map[gethcommon.Hash]*EventVisibilityConfig
+}
+
+type TxExecResult struct {
+	Receipt          *types.Receipt
+	CreatedContracts map[gethcommon.Address]*ContractVisibilityConfig
+	Err              error
+}

--- a/go/enclave/core/utils.go
+++ b/go/enclave/core/utils.go
@@ -62,8 +62,6 @@ func LogMethodDuration(logger gethlog.Logger, stopWatch *measure.Stopwatch, msg 
 
 // GetTxSigner returns the address that signed a transaction
 func GetTxSigner(tx *common.L2Tx) (gethcommon.Address, error) {
-	// TODO - Once the enclave's genesis.json is set, retrieve the signer type using `types.MakeSigner`.
-
 	from, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
 	if err != nil {
 		return gethcommon.Address{}, fmt.Errorf("could not recover sender for transaction. Cause: %w", err)

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -971,7 +971,7 @@ func replayBatchesToValidState(ctx context.Context, storage storage.Storage, reg
 		}
 
 		// calculate the stateDB after this batch and store it in the cache
-		_, _, err := batchExecutor.ExecuteBatch(ctx, batch)
+		_, err := batchExecutor.ExecuteBatch(ctx, batch)
 		if err != nil {
 			return err
 		}

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -241,6 +241,8 @@ func executeTransaction(
 		return &core.TxExecResult{Receipt: receipt, Err: err}
 	}
 
+	// todo - placeholder for calling the visibility config function on the newly created contracts
+	// this is step 1 of the transition to configured visibility rules. The auto-detection of the visibility rules
 	contractsWithVisibility := make(map[gethcommon.Address]*core.ContractVisibilityConfig)
 	for _, contractAddress := range createdContracts {
 		contractsWithVisibility[*contractAddress] = &core.ContractVisibilityConfig{AutoConfig: true}

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -38,12 +38,6 @@ import (
 
 var ErrGasNotEnoughForL1 = errors.New("gas limit too low to pay for execution and l1 fees")
 
-type TxExecResult struct {
-	Receipt          *types.Receipt
-	CreatedContracts []*gethcommon.Address
-	Err              error
-}
-
 // ExecuteTransactions
 // header - the header of the rollup where this transaction will be included
 // fromTxIndex - for the receipts and events, the evm needs to know for each transaction the order in which it was executed in the block.
@@ -60,12 +54,12 @@ func ExecuteTransactions(
 	noBaseFee bool,
 	batchGasLimit uint64,
 	logger gethlog.Logger,
-) (map[common.TxHash]*TxExecResult, error) {
+) (map[common.TxHash]*core.TxExecResult, error) {
 	chain, vmCfg := initParams(storage, gethEncodingService, config, noBaseFee, logger)
 	gp := gethcore.GasPool(batchGasLimit)
 	zero := uint64(0)
 	usedGas := &zero
-	result := map[common.TxHash]*TxExecResult{}
+	result := map[common.TxHash]*core.TxExecResult{}
 
 	ethHeader, err := gethEncodingService.CreateEthHeaderForBatch(ctx, header)
 	if err != nil {
@@ -83,9 +77,7 @@ func ExecuteTransactions(
 	// this should not open up any attack vectors on the randomness.
 	tCountRollback := 0
 	for i, t := range txs {
-		txResult := &TxExecResult{}
-		result[t.Tx.Hash()] = txResult
-		r, createdContracts, err := executeTransaction(
+		txResult := executeTransaction(
 			s,
 			chainConfig,
 			chain,
@@ -98,21 +90,18 @@ func ExecuteTransactions(
 			hash,
 			header.Number.Uint64(),
 		)
-		if err != nil {
+		result[t.Tx.Hash()] = txResult
+		if txResult.Err != nil {
 			tCountRollback++
-			txResult.Err = err
 			// only log tx execution errors if they are unexpected
 			logFailedTx := logger.Info
-			if errors.Is(err, gethcore.ErrNonceTooHigh) || errors.Is(err, gethcore.ErrNonceTooLow) || errors.Is(err, gethcore.ErrFeeCapTooLow) || errors.Is(err, ErrGasNotEnoughForL1) {
+			if errors.Is(txResult.Err, gethcore.ErrNonceTooHigh) || errors.Is(txResult.Err, gethcore.ErrNonceTooLow) || errors.Is(txResult.Err, gethcore.ErrFeeCapTooLow) || errors.Is(txResult.Err, ErrGasNotEnoughForL1) {
 				logFailedTx = logger.Debug
 			}
 			logFailedTx("Failed to execute tx:", log.TxKey, t.Tx.Hash(), log.CtrErrKey, err)
 			continue
 		}
-
-		logReceipt(r, logger)
-		txResult.Receipt = r
-		txResult.CreatedContracts = createdContracts
+		logReceipt(txResult.Receipt, logger)
 	}
 	s.Finalise(true)
 	return result, nil
@@ -137,12 +126,12 @@ func executeTransaction(
 	tCount int,
 	batchHash common.L2BatchHash,
 	batchHeight uint64,
-) (*types.Receipt, []*gethcommon.Address, error) {
+) *core.TxExecResult {
 	var createdContracts []*gethcommon.Address
 	rules := cc.Rules(big.NewInt(0), true, 0)
 	from, err := types.Sender(types.LatestSigner(cc), t.Tx)
 	if err != nil {
-		return nil, nil, err
+		return &core.TxExecResult{nil, nil, err}
 	}
 	s.Prepare(rules, from, gethcommon.Address{}, t.Tx.To(), nil, nil)
 	snap := s.Snapshot()
@@ -249,10 +238,15 @@ func executeTransaction(
 	header.MixDigest = before
 	if err != nil {
 		s.RevertToSnapshot(snap)
-		return receipt, nil, err
+		return &core.TxExecResult{receipt, nil, err}
 	}
 
-	return receipt, createdContracts, nil
+	contractsWithVisibility := make(map[gethcommon.Address]*core.ContractVisibilityConfig)
+	for _, contractAddress := range createdContracts {
+		contractsWithVisibility[*contractAddress] = &core.ContractVisibilityConfig{AutoConfig: true}
+	}
+
+	return &core.TxExecResult{receipt, contractsWithVisibility, nil}
 }
 
 func logReceipt(r *types.Receipt, logger gethlog.Logger) {

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -131,7 +131,7 @@ func executeTransaction(
 	rules := cc.Rules(big.NewInt(0), true, 0)
 	from, err := types.Sender(types.LatestSigner(cc), t.Tx)
 	if err != nil {
-		return &core.TxExecResult{nil, nil, err}
+		return &core.TxExecResult{Err: err}
 	}
 	s.Prepare(rules, from, gethcommon.Address{}, t.Tx.To(), nil, nil)
 	snap := s.Snapshot()
@@ -238,7 +238,7 @@ func executeTransaction(
 	header.MixDigest = before
 	if err != nil {
 		s.RevertToSnapshot(snap)
-		return &core.TxExecResult{receipt, nil, err}
+		return &core.TxExecResult{Receipt: receipt, Err: err}
 	}
 
 	contractsWithVisibility := make(map[gethcommon.Address]*core.ContractVisibilityConfig)
@@ -246,7 +246,7 @@ func executeTransaction(
 		contractsWithVisibility[*contractAddress] = &core.ContractVisibilityConfig{AutoConfig: true}
 	}
 
-	return &core.TxExecResult{receipt, contractsWithVisibility, nil}
+	return &core.TxExecResult{Receipt: receipt, CreatedContracts: contractsWithVisibility}
 }
 
 func logReceipt(r *types.Receipt, logger gethlog.Logger) {

--- a/go/enclave/l2chain/interfaces.go
+++ b/go/enclave/l2chain/interfaces.go
@@ -16,13 +16,6 @@ import (
 // ObscuroChain - the interface that provides the data access layer to the obscuro l2.
 // Operations here should be read only.
 type ObscuroChain interface {
-	// AccountOwner - returns the account that owns the address.
-	// For EOA - the actual address.
-	// For Contracts - the address of the deployer.
-	// Note - this might be subject to change if we implement a more flexible mechanism
-	// todo - support BlockNumberOrHash
-	AccountOwner(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error)
-
 	// GetBalanceAtBlock - will return the balance of a specific address at the specific given block number (batch number).
 	GetBalanceAtBlock(ctx context.Context, accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*hexutil.Big, error)
 

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ten-protocol/go-ten/go/common/errutil"
-
 	"github.com/ten-protocol/go-ten/go/config"
 
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
@@ -64,19 +62,6 @@ func NewChain(
 		Registry:            registry,
 		gasEstimationCap:    gasEstimationCap,
 	}
-}
-
-func (oc *obscuroChain) AccountOwner(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error) {
-	// check if the account is a contract and return the owner
-	owner, err := oc.storage.ReadContractOwner(ctx, address)
-	if err != nil {
-		// it is not a contract, so it's an EOA
-		if errors.Is(err, errutil.ErrNotFound) {
-			return &address, nil
-		}
-		return nil, fmt.Errorf("could not read account owner. cause: %w", err)
-	}
-	return owner, nil
 }
 
 func (oc *obscuroChain) GetBalanceAtBlock(ctx context.Context, accountAddr gethcommon.Address, blockNumber *gethrpc.BlockNumber) (*hexutil.Big, error) {

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -150,7 +150,7 @@ func (s *sequencer) createGenesisBatch(ctx context.Context, block *types.Header)
 		return fmt.Errorf("failed signing created batch. Cause: %w", err)
 	}
 
-	if err := s.StoreExecutedBatch(ctx, batch, nil, nil); err != nil {
+	if err := s.StoreExecutedBatch(ctx, batch, nil); err != nil {
 		return fmt.Errorf("1. failed storing batch. Cause: %w", err)
 	}
 
@@ -189,13 +189,13 @@ func (s *sequencer) createGenesisBatch(ctx context.Context, block *types.Header)
 		return fmt.Errorf(" failed producing batch. Cause: %w", err)
 	}
 
-	if len(cb.Receipts) == 0 || cb.Receipts[0].TxHash.Hex() != msgBusTx.Hash().Hex() {
+	if len(cb.TxExecResults) == 0 || cb.TxExecResults[0].Receipt.TxHash.Hex() != msgBusTx.Hash().Hex() {
 		err = fmt.Errorf("message Bus contract not minted - no receipts in batch")
 		s.logger.Error(err.Error())
 		return err
 	}
 
-	s.logger.Info("Message Bus Contract minted successfully", "address", cb.Receipts[0].ContractAddress.Hex())
+	s.logger.Info("Message Bus Contract minted successfully", "address", cb.TxExecResults[0].Receipt.ContractAddress.Hex())
 
 	return nil
 }
@@ -301,7 +301,7 @@ func (s *sequencer) produceBatch(
 		return nil, fmt.Errorf("failed signing created batch. Cause: %w", err)
 	}
 
-	if err := s.StoreExecutedBatch(ctx, cb.Batch, cb.Receipts, cb.CreatedContracts); err != nil {
+	if err := s.StoreExecutedBatch(ctx, cb.Batch, cb.TxExecResults); err != nil {
 		return nil, fmt.Errorf("2. failed storing batch. Cause: %w", err)
 	}
 
@@ -319,7 +319,7 @@ func (s *sequencer) produceBatch(
 
 // StoreExecutedBatch - stores an executed batch in one go. This can be done for the sequencer because it is guaranteed
 // that all dependencies are in place for the execution to be successful.
-func (s *sequencer) StoreExecutedBatch(ctx context.Context, batch *core.Batch, receipts types.Receipts, newContracts map[gethcommon.Hash][]*gethcommon.Address) error {
+func (s *sequencer) StoreExecutedBatch(ctx context.Context, batch *core.Batch, txResults []*core.TxExecResult) error {
 	defer core.LogMethodDuration(s.logger, measure.NewStopwatch(), "Registry StoreBatch() exit", log.BatchHashKey, batch.Hash())
 
 	// Check if this batch is already stored.
@@ -337,11 +337,11 @@ func (s *sequencer) StoreExecutedBatch(ctx context.Context, batch *core.Batch, r
 		return fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
 
-	if err := s.storage.StoreExecutedBatch(ctx, batch.Header, receipts, newContracts); err != nil {
+	if err := s.storage.StoreExecutedBatch(ctx, batch.Header, txResults); err != nil {
 		return fmt.Errorf("failed to store batch. Cause: %w", err)
 	}
 
-	s.batchRegistry.OnBatchExecuted(batch.Header, receipts)
+	s.batchRegistry.OnBatchExecuted(batch.Header, txResults)
 
 	return nil
 }

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -132,11 +132,11 @@ func (val *obsValidator) ExecuteStoredBatches(ctx context.Context) error {
 				Transactions: txs,
 			}
 
-			receipts, contracts, err := val.batchExecutor.ExecuteBatch(ctx, batch)
+			txResults, err := val.batchExecutor.ExecuteBatch(ctx, batch)
 			if err != nil {
 				return fmt.Errorf("could not execute batchHeader %s. Cause: %w", batchHeader.Hash(), err)
 			}
-			err = val.storage.StoreExecutedBatch(ctx, batchHeader, receipts, contracts)
+			err = val.storage.StoreExecutedBatch(ctx, batchHeader, txResults)
 			if err != nil {
 				return fmt.Errorf("could not store executed batchHeader %s. Cause: %w", batchHeader.Hash(), err)
 			}
@@ -144,7 +144,7 @@ func (val *obsValidator) ExecuteStoredBatches(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to feed batchHeader into the virtual eth chain- %w", err)
 			}
-			val.batchRegistry.OnBatchExecuted(batchHeader, receipts)
+			val.batchRegistry.OnBatchExecuted(batchHeader, txResults)
 		}
 	}
 	return nil
@@ -179,7 +179,7 @@ func (val *obsValidator) handleGenesis(ctx context.Context, batch *common.BatchH
 		return fmt.Errorf("received invalid genesis batch")
 	}
 
-	err = val.storage.StoreExecutedBatch(ctx, genBatch.Header, nil, nil)
+	err = val.storage.StoreExecutedBatch(ctx, genBatch.Header, nil)
 	if err != nil {
 		return err
 	}

--- a/go/enclave/rpc/GetBalance.go
+++ b/go/enclave/rpc/GetBalance.go
@@ -3,8 +3,6 @@ package rpc
 import (
 	"fmt"
 
-	"github.com/status-im/keycard-go/hexutils"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
@@ -43,18 +41,8 @@ func GetBalanceValidate(reqParams []any, builder *CallBuilder[BalanceReq, hexuti
 }
 
 func GetBalanceExecute(builder *CallBuilder[BalanceReq, hexutil.Big], rpc *EncryptionManager) error {
-	acctOwner, err := rpc.chain.AccountOwner(builder.ctx, *builder.Param.Addr)
-	if err != nil {
-		return fmt.Errorf("cannot determine account owner. Cause: %w", err)
-	}
-
-	// authorise the call
-	if acctOwner.Hex() != builder.VK.AccountAddress.Hex() {
-		rpc.logger.Debug("Unauthorised call", "address", acctOwner, "vk", builder.VK.AccountAddress, "userId", hexutils.BytesToHex(builder.VK.UserID))
-		builder.Status = NotAuthorised
-		return nil
-	}
-
+	// anybody can query for the native balance of any address.
+	// even if we added a check, it could be bypassed easily
 	balance, err := rpc.chain.GetBalanceAtBlock(builder.ctx, *builder.Param.Addr, builder.Param.Block.BlockNumber)
 	if err != nil {
 		return fmt.Errorf("unable to get balance - %w", err)

--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ten-protocol/go-ten/go/enclave/storage/enclavedb"
+
 	"github.com/eko/gocache/lib/v4/store"
 
 	"github.com/ten-protocol/go-ten/go/enclave/core"
@@ -48,10 +50,10 @@ type CacheService struct {
 
 	// from address ( either eoa or contract) to the id of the db entry
 	eoaCache             *cache.Cache[*uint64]
-	contractAddressCache *cache.Cache[*uint64]
+	contractAddressCache *cache.Cache[*enclavedb.Contract]
 
 	// from contract_address||event_sig to the event_type (id, isLifecycle) object
-	eventTypeCache *cache.Cache[*EventType]
+	eventTypeCache *cache.Cache[*enclavedb.EventType]
 
 	// store the converted ethereum header which is passed to the evm
 	convertedGethHeaderCache *cache.Cache[*types.Header]
@@ -77,8 +79,8 @@ func NewCacheService(logger gethlog.Logger) *CacheService {
 		seqCacheByHeight:         cache.New[*big.Int](ristrettoStore),
 		convertedHashCache:       cache.New[*gethcommon.Hash](ristrettoStore),
 		eoaCache:                 cache.New[*uint64](ristrettoStore),
-		contractAddressCache:     cache.New[*uint64](ristrettoStore),
-		eventTypeCache:           cache.New[*EventType](ristrettoStore),
+		contractAddressCache:     cache.New[*enclavedb.Contract](ristrettoStore),
+		eventTypeCache:           cache.New[*enclavedb.EventType](ristrettoStore),
 		convertedGethHeaderCache: cache.New[*types.Header](ristrettoStore),
 		logger:                   logger,
 	}
@@ -121,11 +123,11 @@ func (cs *CacheService) ReadEOA(ctx context.Context, addr gethcommon.Address, on
 	return getCachedValue(ctx, cs.eoaCache, cs.logger, addr, idCost, onCacheMiss)
 }
 
-func (cs *CacheService) ReadContractAddr(ctx context.Context, addr gethcommon.Address, onCacheMiss func(any) (*uint64, error)) (*uint64, error) {
+func (cs *CacheService) ReadContractAddr(ctx context.Context, addr gethcommon.Address, onCacheMiss func(any) (*enclavedb.Contract, error)) (*enclavedb.Contract, error) {
 	return getCachedValue(ctx, cs.contractAddressCache, cs.logger, addr, idCost, onCacheMiss)
 }
 
-func (cs *CacheService) ReadEventType(ctx context.Context, contractAddress gethcommon.Address, eventSignature gethcommon.Hash, onCacheMiss func(any) (*EventType, error)) (*EventType, error) {
+func (cs *CacheService) ReadEventType(ctx context.Context, contractAddress gethcommon.Address, eventSignature gethcommon.Hash, onCacheMiss func(any) (*enclavedb.EventType, error)) (*enclavedb.EventType, error) {
 	key := make([]byte, 0)
 	key = append(key, contractAddress.Bytes()...)
 	key = append(key, eventSignature.Bytes()...)

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -347,46 +347,6 @@ func ReadContractCreator(ctx context.Context, db *sql.DB, address gethcommon.Add
 	return &eoaAddress, nil
 }
 
-//func ReadContractCfg(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address) (*core.ContractVisibilityConfig, error) {
-//	stmt := `SELECT c.auto_visibility, c.transparent, et.auto_visibility, et.public, et.topic1_can_view, et.topic2_can_view, et.topic3_can_view,et.sender_can_view
-//			FROM contract c join event_type et on et.contract=c.id WHERE c.address = ?`
-//
-//	rows, err := dbTX.QueryContext(ctx, stmt, contractAddress.Bytes())
-//	if err != nil {
-//		return nil, err
-//	}
-//	defer rows.Close()
-//
-//	config := core.ContractVisibilityConfig{
-//		EventConfigs: make(map[gethcommon.Hash]*core.EventVisibilityConfig),
-//	}
-//
-//	for rows.Next() {
-//		l := core.EventVisibilityConfig{}
-//		var t0, t1, t2, t3 []byte
-//		err = rows.Scan(&t0, &t1, &t2, &t3, &l.Data, &l.BlockHash, &l.BlockNumber, &l.TxHash, &l.TxIndex, &l.Index, &l.Address)
-//		if err != nil {
-//			return nil, fmt.Errorf("could not load log entry from db: %w", err)
-//		}
-//
-//		for _, topic := range [][]byte{t0, t1, t2, t3} {
-//			if len(topic) > 0 {
-//				l.Topics = append(l.Topics, byteArrayToHash(topic))
-//			}
-//		}
-//
-//		result = append(result, &l)
-//	}
-//
-//	if rows.Err() != nil {
-//		return nil, rows.Err()
-//	}
-//
-//	return result, nil
-//
-//	return config, nil
-//}
-
 func stringToHash(ns sql.NullString) gethcommon.Hash {
 	value, err := ns.Value()
 	if err != nil {

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"strconv"
 
+	"github.com/ten-protocol/go-ten/go/enclave/core"
+
 	"github.com/ten-protocol/go-ten/go/common/errutil"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -32,8 +34,9 @@ const (
 		"where b.is_canonical=true "
 )
 
-func WriteEventType(ctx context.Context, dbTX *sql.Tx, contractID *uint64, eventSignature gethcommon.Hash, isLifecycle bool) (uint64, error) {
-	res, err := dbTX.ExecContext(ctx, "insert into event_type (contract, event_sig, lifecycle_event) values (?, ?, ?)", contractID, eventSignature.Bytes(), isLifecycle)
+func WriteEventType(ctx context.Context, dbTX *sql.Tx, et *EventType) (uint64, error) {
+	res, err := dbTX.ExecContext(ctx, "insert into event_type (contract, event_sig, auto_visibility, public, topic1_can_view, topic2_can_view, topic3_can_view, sender_can_view) values (?, ?, ?, ?, ?, ?, ?, ?)",
+		et.ContractId, et.EventSignature.Bytes(), et.AutoVisibility, et.Public, et.Topic1CanView, et.Topic2CanView, et.Topic3CanView, et.SenderCanView)
 	if err != nil {
 		return 0, err
 	}
@@ -44,15 +47,15 @@ func WriteEventType(ctx context.Context, dbTX *sql.Tx, contractID *uint64, event
 	return uint64(id), nil
 }
 
-func ReadEventType(ctx context.Context, dbTX *sql.Tx, contractId uint64, eventSignature gethcommon.Hash) (uint64, bool, error) {
-	var id uint64
-	var isLifecycle bool
-	err := dbTX.QueryRowContext(ctx, "select id, lifecycle_event from event_type where contract=? and event_sig=?", contractId, eventSignature.Bytes()).Scan(&id, &isLifecycle)
+func ReadEventType(ctx context.Context, dbTX *sql.Tx, contractId uint64, eventSignature gethcommon.Hash) (*EventType, error) {
+	var et EventType
+	err := dbTX.QueryRowContext(ctx, "select id, contract, event_sig, auto_visibility, public, topic1_can_view, topic2_can_view, topic3_can_view, sender_can_view from event_type where contract=? and event_sig=?",
+		contractId, eventSignature.Bytes()).Scan(&et.Id, &et.ContractId, &et.EventSignature, &et.AutoVisibility, &et.Public, &et.Topic1CanView, &et.Topic2CanView, &et.Topic3CanView, &et.SenderCanView)
 	if errors.Is(err, sql.ErrNoRows) {
 		// make sure the error is converted to obscuro-wide not found error
-		return 0, false, errutil.ErrNotFound
+		return nil, errutil.ErrNotFound
 	}
-	return id, isLifecycle, err
+	return &et, err
 }
 
 func WriteEventTopic(ctx context.Context, dbTX *sql.Tx, topic *gethcommon.Hash, addressId *uint64) (uint64, error) {
@@ -68,7 +71,7 @@ func WriteEventTopic(ctx context.Context, dbTX *sql.Tx, topic *gethcommon.Hash, 
 }
 
 func UpdateEventTypeLifecycle(ctx context.Context, dbTx *sql.Tx, etId uint64, isLifecycle bool) error {
-	_, err := dbTx.ExecContext(ctx, "update event_type set lifecycle_event=? where id=?", isLifecycle, etId)
+	_, err := dbTx.ExecContext(ctx, "update event_type set public=? where id=?", isLifecycle, etId)
 	return err
 }
 
@@ -145,7 +148,7 @@ func FilterLogs(
 func DebugGetLogs(ctx context.Context, db *sql.DB, txHash common.TxHash) ([]*tracers.DebugLogs, error) {
 	var queryParams []any
 
-	query := "select eoa1.address, eoa2.address, eoa3.address, et.lifecycle_event, et.event_sig, t1.topic, t2.topic, t3.topic, datablob, b.hash, b.height, tx.hash, tx.idx, log_idx, c.address " +
+	query := "select eoa1.address, eoa2.address, eoa3.address, et.public, et.event_sig, t1.topic, t2.topic, t3.topic, datablob, b.hash, b.height, tx.hash, tx.idx, log_idx, c.address " +
 		baseEventsJoin +
 		" AND tx.hash = ? "
 
@@ -229,7 +232,7 @@ func loadLogs(ctx context.Context, db *sql.DB, requestingAccount *gethcommon.Add
 	// Add relevancy rules
 	//  An event is considered relevant to all account owners whose addresses are used as topics in the event.
 	//	In case there are no account addresses in an event's topics, then the event is considered relevant to everyone (known as a "lifecycle event").
-	query += " AND (et.lifecycle_event=true OR eoa1.address=? OR eoa2.address=? OR eoa3.address=?) "
+	query += " AND (et.public=true OR eoa1.address=? OR eoa2.address=? OR eoa3.address=?) "
 	queryParams = append(queryParams, requestingAccount.Bytes())
 	queryParams = append(queryParams, requestingAccount.Bytes())
 	queryParams = append(queryParams, requestingAccount.Bytes())
@@ -298,9 +301,9 @@ func ReadEoa(ctx context.Context, dbTx *sql.Tx, addr gethcommon.Address) (uint64
 	return id, nil
 }
 
-func WriteContractAddress(ctx context.Context, dbTX *sql.Tx, contractAddress *gethcommon.Address, eoaId uint64) (*uint64, error) {
-	insert := "insert into contract (address, owner) values (?,?)"
-	res, err := dbTX.ExecContext(ctx, insert, contractAddress.Bytes(), eoaId)
+func WriteContractConfig(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address, eoaId uint64, cfg *core.ContractVisibilityConfig) (*uint64, error) {
+	insert := "insert into contract (address, creator, auto_visibility, transparent) values (?,?,?,?)"
+	res, err := dbTX.ExecContext(ctx, insert, contractAddress.Bytes(), eoaId, cfg.AutoConfig, cfg.Transparent)
 	if err != nil {
 		return nil, err
 	}
@@ -312,11 +315,11 @@ func WriteContractAddress(ctx context.Context, dbTX *sql.Tx, contractAddress *ge
 	return &v, nil
 }
 
-func ReadContractAddress(ctx context.Context, dbTx *sql.Tx, addr gethcommon.Address) (*uint64, error) {
-	row := dbTx.QueryRowContext(ctx, "select id from contract where address = ?", addr.Bytes())
+func ReadContractByAddress(ctx context.Context, dbTx *sql.Tx, addr gethcommon.Address) (*Contract, error) {
+	row := dbTx.QueryRowContext(ctx, "select id, address, auto_visibility, transparent from contract where address = ?", addr.Bytes())
 
-	var id uint64
-	err := row.Scan(&id)
+	var c Contract
+	err := row.Scan(&c.Id, &c.Address, &c.AutoVisibility, &c.Transparent)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// make sure the error is converted to obscuro-wide not found error
@@ -325,11 +328,11 @@ func ReadContractAddress(ctx context.Context, dbTx *sql.Tx, addr gethcommon.Addr
 		return nil, err
 	}
 
-	return &id, nil
+	return &c, nil
 }
 
-func ReadContractOwner(ctx context.Context, db *sql.DB, address gethcommon.Address) (*gethcommon.Address, error) {
-	row := db.QueryRowContext(ctx, "select eoa.address from contract c join externally_owned_account eoa on c.owner=eoa.id  where c.address = ?", address.Bytes())
+func ReadContractCreator(ctx context.Context, db *sql.DB, address gethcommon.Address) (*gethcommon.Address, error) {
+	row := db.QueryRowContext(ctx, "select eoa.address from contract c join externally_owned_account eoa on c.creator=eoa.id  where c.address = ?", address.Bytes())
 
 	var eoaAddress gethcommon.Address
 	err := row.Scan(&eoaAddress)
@@ -343,6 +346,46 @@ func ReadContractOwner(ctx context.Context, db *sql.DB, address gethcommon.Addre
 
 	return &eoaAddress, nil
 }
+
+//func ReadContractCfg(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address) (*core.ContractVisibilityConfig, error) {
+//	stmt := `SELECT c.auto_visibility, c.transparent, et.auto_visibility, et.public, et.topic1_can_view, et.topic2_can_view, et.topic3_can_view,et.sender_can_view
+//			FROM contract c join event_type et on et.contract=c.id WHERE c.address = ?`
+//
+//	rows, err := dbTX.QueryContext(ctx, stmt, contractAddress.Bytes())
+//	if err != nil {
+//		return nil, err
+//	}
+//	defer rows.Close()
+//
+//	config := core.ContractVisibilityConfig{
+//		EventConfigs: make(map[gethcommon.Hash]*core.EventVisibilityConfig),
+//	}
+//
+//	for rows.Next() {
+//		l := core.EventVisibilityConfig{}
+//		var t0, t1, t2, t3 []byte
+//		err = rows.Scan(&t0, &t1, &t2, &t3, &l.Data, &l.BlockHash, &l.BlockNumber, &l.TxHash, &l.TxIndex, &l.Index, &l.Address)
+//		if err != nil {
+//			return nil, fmt.Errorf("could not load log entry from db: %w", err)
+//		}
+//
+//		for _, topic := range [][]byte{t0, t1, t2, t3} {
+//			if len(topic) > 0 {
+//				l.Topics = append(l.Topics, byteArrayToHash(topic))
+//			}
+//		}
+//
+//		result = append(result, &l)
+//	}
+//
+//	if rows.Err() != nil {
+//		return nil, rows.Err()
+//	}
+//
+//	return result, nil
+//
+//	return config, nil
+//}
 
 func stringToHash(ns sql.NullString) gethcommon.Hash {
 	value, err := ns.Value()

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
@@ -15,4 +17,23 @@ type EnclaveDB interface {
 	ethdb.Database
 	GetSQLDB() *sql.DB
 	NewDBTransaction(ctx context.Context) (*sql.Tx, error)
+}
+
+// Contract - maps to the “contract“ table
+type Contract struct {
+	Id             uint64
+	Address        gethcommon.Address
+	AutoVisibility bool
+	Transparent    *bool
+}
+
+// EventType - maps to the “event_type“ table
+type EventType struct {
+	Id                                          uint64
+	ContractId                                  uint64
+	EventSignature                              gethcommon.Hash
+	AutoVisibility                              bool
+	Public                                      bool
+	Topic1CanView, Topic2CanView, Topic3CanView *bool
+	SenderCanView                               *bool
 }

--- a/go/enclave/storage/enclavedb/utils.go
+++ b/go/enclave/storage/enclavedb/utils.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// utility for sql query building
 func repeat(token string, sep string, count int) string {
 	elems := make([]string, count)
 	for i := 0; i < count; i++ {

--- a/go/enclave/storage/events_storage.go
+++ b/go/enclave/storage/events_storage.go
@@ -27,51 +27,101 @@ func newEventsStorage(cachingService *CacheService, logger gethlog.Logger) *even
 	return &eventsStorage{cachingService: cachingService, logger: logger}
 }
 
-func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql.Tx, batch *common.BatchHeader, receipt *types.Receipt, createdContracts []*gethcommon.Address) error {
-	txId, senderId, err := enclavedb.ReadTransactionIdAndSender(ctx, dbTX, receipt.TxHash)
+func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql.Tx, batch *common.BatchHeader, txExecResult *core.TxExecResult) error {
+	txId, senderId, err := enclavedb.ReadTransactionIdAndSender(ctx, dbTX, txExecResult.Receipt.TxHash)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("could not get transaction id. Cause: %w", err)
 	}
 
-	for _, createdContract := range createdContracts {
-		_, err = enclavedb.WriteContractAddress(ctx, dbTX, createdContract, *senderId)
+	// store the contracts created by this tx
+	for createdContract, cfg := range txExecResult.CreatedContracts {
+		ctrId, err := es.storeNewContract(ctx, dbTX, createdContract, senderId, cfg)
 		if err != nil {
-			return fmt.Errorf("could not write contract address. cause %w", err)
+			return err
+		}
+
+		// create the event types for the events that were configured
+		for eventSig, eventCfg := range cfg.EventConfigs {
+			_, err = enclavedb.WriteEventType(ctx, dbTX, &enclavedb.EventType{
+				ContractId:     *ctrId,
+				EventSignature: eventSig,
+				AutoVisibility: eventCfg.AutoConfig,
+				Public:         eventCfg.Public,
+				Topic1CanView:  eventCfg.Topic1CanView,
+				Topic2CanView:  eventCfg.Topic2CanView,
+				Topic3CanView:  eventCfg.Topic3CanView,
+				SenderCanView:  eventCfg.SenderCanView,
+			})
+			if err != nil {
+				return fmt.Errorf("could not write event type. cause %w", err)
+			}
 		}
 	}
 
-	// Convert the receipt into its storage form and serialize
-	// this removes information that can be recreated
-	// todo - in a future iteration, this can be slimmed down further because we already store the logs separately
-	storageReceipt := (*types.ReceiptForStorage)(receipt)
-	receiptBytes, err := rlp.EncodeToBytes(storageReceipt)
+	receiptId, err := es.storeReceipt(ctx, dbTX, batch, txExecResult, txId)
 	if err != nil {
-		return fmt.Errorf("failed to encode block receipts. Cause: %w", err)
+		return err
 	}
 
-	execTxId, err := enclavedb.WriteReceipt(ctx, dbTX, batch.SequencerOrderNo.Uint64(), txId, receiptBytes)
-	if err != nil {
-		return fmt.Errorf("could not write receipt. Cause: %w", err)
-	}
-
-	for _, l := range receipt.Logs {
-		err := es.storeEventLog(ctx, dbTX, execTxId, l)
+	for _, l := range txExecResult.Receipt.Logs {
+		err := es.storeEventLog(ctx, dbTX, receiptId, l)
 		if err != nil {
 			return fmt.Errorf("could not store log entry %v. Cause: %w", l, err)
 		}
 	}
+
 	return nil
 }
 
-func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTxId uint64, l *types.Log) error {
-	topicIds, isLifecycle, err := es.handleUserTopics(ctx, dbTX, l)
+// Convert the receipt into its storage form and serialize
+// this removes information that can be recreated
+// todo - in a future iteration, this can be slimmed down further because we already store the logs separately
+func (es *eventsStorage) storeReceipt(ctx context.Context, dbTX *sql.Tx, batch *common.BatchHeader, txExecResult *core.TxExecResult, txId *uint64) (uint64, error) {
+	storageReceipt := (*types.ReceiptForStorage)(txExecResult.Receipt)
+	receiptBytes, err := rlp.EncodeToBytes(storageReceipt)
 	if err != nil {
-		return err
+		return 0, fmt.Errorf("failed to encode block receipts. Cause: %w", err)
 	}
 
-	eventTypeId, err := es.handleEventType(ctx, dbTX, l, isLifecycle)
+	execTxId, err := enclavedb.WriteReceipt(ctx, dbTX, batch.SequencerOrderNo.Uint64(), txId, receiptBytes)
 	if err != nil {
-		return err
+		return 0, fmt.Errorf("could not write receipt. Cause: %w", err)
+	}
+	return execTxId, nil
+}
+
+func (es *eventsStorage) storeNewContract(ctx context.Context, dbTX *sql.Tx, createdContract gethcommon.Address, senderId *uint64, cfg *core.ContractVisibilityConfig) (*uint64, error) {
+	ctrId, err := enclavedb.WriteContractConfig(ctx, dbTX, createdContract, *senderId, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("could not write contract address. cause %w", err)
+	}
+	return ctrId, nil
+}
+
+func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTxId uint64, l *types.Log) error {
+	eventSig := l.Topics[0]
+
+	contract, err := es.readContract(ctx, dbTX, l.Address)
+	if err != nil {
+		// the contract should already have been stored when it was created
+		return fmt.Errorf("could not read contract address. %s. Cause: %w", l.Address, err)
+	}
+
+	eventType, err := es.readEventType(ctx, dbTX, l.Address, eventSig)
+	if errors.Is(err, errutil.ErrNotFound) {
+		// this is the first type an event of this type is emitted, so we must store it
+		eventType, err = es.storeEventType(ctx, dbTX, contract, l)
+		if err != nil {
+			return fmt.Errorf("could not write event type. cause %w", err)
+		}
+	} else if err != nil {
+		// unexpected event type
+		return fmt.Errorf("could not read event type. Cause: %w", err)
+	}
+
+	topicIds, err := es.storeTopics(ctx, dbTX, l)
+	if err != nil {
+		return fmt.Errorf("could not store topics. cause: %w", err)
 	}
 
 	// normalize data
@@ -79,7 +129,7 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 	if len(data) == 0 {
 		data = nil
 	}
-	err = enclavedb.WriteEventLog(ctx, dbTX, eventTypeId, topicIds, data, l.Index, execTxId)
+	err = enclavedb.WriteEventLog(ctx, dbTX, eventType.Id, topicIds, data, l.Index, execTxId)
 	if err != nil {
 		return fmt.Errorf("could not write event log. Cause: %w", err)
 	}
@@ -87,62 +137,87 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 	return nil
 }
 
-func (es *eventsStorage) handleEventType(ctx context.Context, dbTX *sql.Tx, l *types.Log, isLifecycle bool) (uint64, error) {
-	et, err := es.readEventType(ctx, dbTX, l.Address, l.Topics[0])
-	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-		return 0, fmt.Errorf("could not read event type. Cause: %w", err)
-	}
-	if err == nil {
-		// in case we determined the current emitted event is not lifecycle, we must update the EventType
-		if !isLifecycle && et.isLifecycle {
-			err := enclavedb.UpdateEventTypeLifecycle(ctx, dbTX, et.id, isLifecycle)
-			if err != nil {
-				return 0, fmt.Errorf("could not update the event type. cause: %w", err)
-			}
-		}
-		return et.id, nil
-	}
+// handles the visibility config detection
+func (es *eventsStorage) storeEventType(ctx context.Context, dbTX *sql.Tx, contract *enclavedb.Contract, l *types.Log) (*enclavedb.EventType, error) {
+	eventType := enclavedb.EventType{ContractId: contract.Id, EventSignature: l.Topics[0], AutoVisibility: contract.AutoVisibility}
 
-	// the first time an event of this type is emitted we must store it
-	contractAddId, err := es.readContractAddress(ctx, dbTX, l.Address)
-	if err != nil {
-		// the contract was already stored when it was created
-		return 0, fmt.Errorf("could not read contract address. %s. Cause: %w", l.Address, err)
+	// when the contract is transparent, all events are public
+	switch {
+	case contract.Transparent != nil && *contract.Transparent:
+		eventType.Public = true
+	case contract.AutoVisibility:
+		// autodetect based on the topics
+		isPublic, t1, t2, t3, err := es.autodetectVisibility(ctx, dbTX, l)
+		if err != nil {
+			return nil, fmt.Errorf("could not auto detect visibility for event type. cause: %w", err)
+		}
+		eventType.Public = *isPublic
+		eventType.Topic1CanView = t1
+		eventType.Topic2CanView = t2
+		eventType.Topic3CanView = t3
+	default:
+		// todo
+		return nil, fmt.Errorf("not implemented")
 	}
-	return enclavedb.WriteEventType(ctx, dbTX, contractAddId, l.Topics[0], isLifecycle)
+	id, err := enclavedb.WriteEventType(ctx, dbTX, &eventType)
+	if err != nil {
+		return nil, fmt.Errorf("could not write event type. cause: %w", err)
+	}
+	eventType.Id = id
+	return &eventType, nil
 }
 
-func (es *eventsStorage) handleUserTopics(ctx context.Context, dbTX *sql.Tx, l *types.Log) ([]*uint64, bool, error) {
-	topicIds := make([]*uint64, 3)
-	// iterate the topics containing user values
-	// reuse them if already inserted
-	// if not, discover if there is a relevant externally owned address
-	isLifecycle := true
+func (es *eventsStorage) autodetectVisibility(ctx context.Context, dbTX *sql.Tx, l *types.Log) (*bool, *bool, *bool, *bool, error) {
+	isPublic := true
+	topicsCanView := make([]bool, 3)
 	for i := 1; i < len(l.Topics); i++ {
 		topic := l.Topics[i]
 		// first check if there is an entry already for this topic
-		eventTopicId, relAddressId, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
+		_, relAddressId, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
 		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-			return nil, false, fmt.Errorf("could not read the event topic. Cause: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
 		}
 		if errors.Is(err, errutil.ErrNotFound) {
 			// check whether the topic is an EOA
 			relAddressId, err = es.findRelevantAddress(ctx, dbTX, topic)
 			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-				return nil, false, fmt.Errorf("could not read relevant address. Cause %w", err)
+				return nil, nil, nil, nil, fmt.Errorf("could not read relevant address. Cause %w", err)
+			}
+		}
+		if relAddressId != nil {
+			isPublic = false
+			topicsCanView[i-1] = true
+		}
+	}
+	return &isPublic, &topicsCanView[0], &topicsCanView[1], &topicsCanView[2], nil
+}
+
+func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, l *types.Log) ([]*uint64, error) {
+	topicIds := make([]*uint64, 3)
+	// iterate the topics containing user values
+	// reuse them if already inserted
+	// if not, discover if there is a relevant externally owned address
+	for i := 1; i < len(l.Topics); i++ {
+		topic := l.Topics[i]
+		// first check if there is an entry already for this topic
+		eventTopicId, relAddressId, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
+		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
+			return nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
+		}
+		if errors.Is(err, errutil.ErrNotFound) {
+			// check whether the topic is an EOA
+			relAddressId, err = es.findRelevantAddress(ctx, dbTX, topic)
+			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
+				return nil, fmt.Errorf("could not read relevant address. Cause %w", err)
 			}
 			eventTopicId, err = enclavedb.WriteEventTopic(ctx, dbTX, &topic, relAddressId)
 			if err != nil {
-				return nil, false, fmt.Errorf("could not write event topic. Cause: %w", err)
+				return nil, fmt.Errorf("could not write event topic. Cause: %w", err)
 			}
-		}
-
-		if relAddressId != nil {
-			isLifecycle = false
 		}
 		topicIds[i-1] = &eventTopicId
 	}
-	return topicIds, isLifecycle, nil
+	return topicIds, nil
 }
 
 // Of the log's topics, returns those that are (potentially) user addresses. A topic is considered a user address if:
@@ -164,7 +239,7 @@ func (es *eventsStorage) findRelevantAddress(ctx context.Context, dbTX *sql.Tx, 
 	}
 
 	// if the address is a contract then it's clearly not an EOA
-	_, err = es.readContractAddress(ctx, dbTX, *potentialAddr)
+	_, err = es.readContract(ctx, dbTX, *potentialAddr)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return nil, err
 	}
@@ -183,29 +258,22 @@ func (es *eventsStorage) findRelevantAddress(ctx context.Context, dbTX *sql.Tx, 
 	return &id, nil
 }
 
-func (es *eventsStorage) readEventType(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address, eventSignature gethcommon.Hash) (*EventType, error) {
+func (es *eventsStorage) readEventType(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address, eventSignature gethcommon.Hash) (*enclavedb.EventType, error) {
 	defer es.logDuration("ReadEventType", measure.NewStopwatch())
 
-	return es.cachingService.ReadEventType(ctx, contractAddress, eventSignature, func(v any) (*EventType, error) {
-		contractAddrId, err := enclavedb.ReadContractAddress(ctx, dbTX, contractAddress)
+	return es.cachingService.ReadEventType(ctx, contractAddress, eventSignature, func(v any) (*enclavedb.EventType, error) {
+		contract, err := es.readContract(ctx, dbTX, contractAddress)
 		if err != nil {
 			return nil, err
 		}
-		id, isLifecycle, err := enclavedb.ReadEventType(ctx, dbTX, *contractAddrId, eventSignature)
-		if err != nil {
-			return nil, err
-		}
-		return &EventType{
-			id:          id,
-			isLifecycle: isLifecycle,
-		}, nil
+		return enclavedb.ReadEventType(ctx, dbTX, contract.Id, eventSignature)
 	})
 }
 
-func (es *eventsStorage) readContractAddress(ctx context.Context, dbTX *sql.Tx, addr gethcommon.Address) (*uint64, error) {
-	defer es.logDuration("readContractAddress", measure.NewStopwatch())
-	return es.cachingService.ReadContractAddr(ctx, addr, func(v any) (*uint64, error) {
-		return enclavedb.ReadContractAddress(ctx, dbTX, addr)
+func (es *eventsStorage) readContract(ctx context.Context, dbTX *sql.Tx, addr gethcommon.Address) (*enclavedb.Contract, error) {
+	defer es.logDuration("readContract", measure.NewStopwatch())
+	return es.cachingService.ReadContractAddr(ctx, addr, func(v any) (*enclavedb.Contract, error) {
+		return enclavedb.ReadContractByAddress(ctx, dbTX, addr)
 	})
 }
 

--- a/go/enclave/storage/events_storage.go
+++ b/go/enclave/storage/events_storage.go
@@ -200,13 +200,13 @@ func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, l *types
 	for i := 1; i < len(l.Topics); i++ {
 		topic := l.Topics[i]
 		// first check if there is an entry already for this topic
-		eventTopicId, relAddressId, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
+		eventTopicId, _, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
 		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 			return nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
 		}
 		if errors.Is(err, errutil.ErrNotFound) {
 			// check whether the topic is an EOA
-			relAddressId, err = es.findRelevantAddress(ctx, dbTX, topic)
+			relAddressId, err := es.findRelevantAddress(ctx, dbTX, topic)
 			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 				return nil, fmt.Errorf("could not read relevant address. Cause %w", err)
 			}

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -129,7 +129,7 @@ create table if not exists tendb.event_type
     id              INTEGER AUTO_INCREMENT,
     contract        int        NOT NULL,
     event_sig       binary(32) NOT NULL,
-    lifecycle_event boolean    NOT NULL,
+    public boolean    NOT NULL,
     primary key (id),
     INDEX USING HASH (contract, event_sig)
 );

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -109,9 +109,11 @@ create table if not exists tendb.receipt
 
 create table if not exists tendb.contract
 (
-    id      INTEGER AUTO_INCREMENT,
-    address binary(20) NOT NULL,
-    owner   int        NOT NULL,
+    id              INTEGER AUTO_INCREMENT,
+    address         binary(20) NOT NULL,
+    creator         int        NOT NULL,
+    auto_visibility boolean    NOT NULL,
+    transparent     boolean,
     primary key (id),
     INDEX USING HASH (address)
 );
@@ -129,7 +131,12 @@ create table if not exists tendb.event_type
     id              INTEGER AUTO_INCREMENT,
     contract        int        NOT NULL,
     event_sig       binary(32) NOT NULL,
-    public boolean    NOT NULL,
+    auto_visibility boolean    NOT NULL,
+    public          boolean    NOT NULL,
+    topic1_can_view boolean,
+    topic2_can_view boolean,
+    topic3_can_view boolean,
+    sender_can_view boolean,
     primary key (id),
     INDEX USING HASH (contract, event_sig)
 );

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -92,23 +92,25 @@ create index IDX_TX_BATCH_HEIGHT on tx (batch_height, idx);
 
 create table if not exists receipt
 (
-    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
-    content                  mediumblob,
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    content mediumblob,
     --     commenting out the fk until synthetic transactions are also stored
-    tx                       INTEGER,
-    batch                    INTEGER NOT NULL REFERENCES batch
+    tx      INTEGER,
+    batch   INTEGER NOT NULL REFERENCES batch
 );
 create index IDX_EX_TX_BATCH on receipt (batch);
 create index IDX_EX_TX_CCA on receipt (tx);
 
 create table if not exists contract
 (
-    id      INTEGER PRIMARY KEY AUTOINCREMENT,
-    address binary(20) NOT NULL,
---     denormalised for ease of access during balance checks
-    owner   int        NOT NULL REFERENCES externally_owned_account
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    address         binary(20) NOT NULL,
+    --     the tx signer that created the contract
+    creator         int        NOT NULL REFERENCES externally_owned_account,
+    auto_visibility boolean    NOT NULL,
+    transparent     boolean
 );
-create index IDX_CONTRACT_AD on contract (address, owner);
+create index IDX_CONTRACT_AD on contract (address, creator);
 
 create table if not exists externally_owned_account
 (
@@ -123,7 +125,12 @@ create table if not exists event_type
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     contract        INTEGER    NOT NULL references contract,
     event_sig       binary(32) NOT NULL, -- no need to index because there are only a few events for an address
-    lifecycle_event boolean    NOT NULL  -- set based on the first event, and then updated to false if it turns out it is true
+    auto_visibility boolean    NOT NULL, -- the visibility of this event type was not configured by the contract dev.
+    public          boolean    NOT NULL, -- set based on the first event, and then updated to false if it turns out it is true
+    topic1_can_view boolean,
+    topic2_can_view boolean,
+    topic3_can_view boolean,
+    sender_can_view boolean
 );
 create index IDX_EV_CONTRACT on event_type (contract, event_sig);
 
@@ -135,7 +142,6 @@ create table if not exists event_topic
     rel_address INTEGER references externally_owned_account
 --    pos         INTEGER    NOT NULL -- todo
 );
--- create index IDX_TOP on event_topic (topic, pos);
 create index IDX_TOP on event_topic (topic);
 
 create table if not exists event_log
@@ -149,35 +155,5 @@ create table if not exists event_log
     log_idx    INTEGER NOT NULL,
     receipt    INTEGER NOT NULL references receipt
 );
--- create index IDX_BATCH_TX on event_log (receipt);
 create index IDX_EV on event_log (receipt, event_type, topic1, topic2, topic3);
 
--- requester - address
--- receipt - range of batch heights or a single batch
--- address []list of contract addresses
--- topic0 - event sig   []list
--- topic1    []list
--- topic2    []list
--- topic3    []list
-
-
--- select * from event_log
---          join receipt on receipt
---              join batch on receipt.batch -- to get the batch height range
---          join event_type ec on event_type
---              join contract c  on
---          left join event_topic t1 on topic1
---              left join externally_owned_account eoa1 on t1.rel_address
---          left join event_topic t2 on topic2
---              left join externally_owned_account eoa2 on t2.rel_address
---          left join event_topic t3 on topic3
---              left join externally_owned_account eoa3 on t3.rel_address
--- where
---  receipt.
---  c.address in [address..] AND
---  ec.event_sig in [topic0..] AND
---  t1.topic in [topic1..] AND
---  t2.topic in [topic2..] AND
---  t3.topic in [topic3..] AND
---  b.height in [] and b.is_canonical=true
---  (ec.lifecycle_event OR eoa1.address=requester OR eoa2.address=requester OR eoa3.address=requester)

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -110,7 +110,7 @@ create table if not exists contract
     auto_visibility boolean    NOT NULL,
     transparent     boolean
 );
-create index IDX_CONTRACT_AD on contract (address, creator);
+create index IDX_CONTRACT_AD on contract (address);
 
 create table if not exists externally_owned_account
 (

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -71,7 +71,7 @@ type BatchResolver interface {
 	// StoreBatch stores an un-executed batch.
 	StoreBatch(ctx context.Context, batch *core.Batch, convertedHash gethcommon.Hash) error
 	// StoreExecutedBatch - store the batch after it was executed
-	StoreExecutedBatch(ctx context.Context, batch *common.BatchHeader, receipts []*types.Receipt, contracts map[gethcommon.Hash][]*gethcommon.Address) error
+	StoreExecutedBatch(ctx context.Context, batch *common.BatchHeader, results []*core.TxExecResult) error
 
 	// StoreRollup
 	StoreRollup(ctx context.Context, rollup *common.ExtRollup, header *common.CalldataRollupHeader) error
@@ -150,7 +150,7 @@ type Storage interface {
 	// StateDB - return the underlying state database
 	StateDB() state.Database
 
-	ReadContractOwner(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error)
+	ReadContractCreator(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error)
 }
 
 type ScanStorage interface {

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -46,11 +46,6 @@ const (
 	masterSeedCfg = "MASTER_SEED"
 )
 
-type EventType struct {
-	id          uint64
-	isLifecycle bool
-}
-
 // todo - this file needs splitting up based on concerns
 type storageImpl struct {
 	db                 enclavedb.EnclaveDB
@@ -582,7 +577,7 @@ func (s *storageImpl) handleTxSenders(ctx context.Context, batch *core.Batch, db
 	return senders, nil
 }
 
-func (s *storageImpl) StoreExecutedBatch(ctx context.Context, batch *common.BatchHeader, receipts []*types.Receipt, newContracts map[gethcommon.Hash][]*gethcommon.Address) error {
+func (s *storageImpl) StoreExecutedBatch(ctx context.Context, batch *common.BatchHeader, results []*core.TxExecResult) error {
 	defer s.logDuration("StoreExecutedBatch", measure.NewStopwatch())
 	executed, err := enclavedb.BatchWasExecuted(ctx, s.db.GetSQLDB(), batch.Hash())
 	if err != nil {
@@ -593,7 +588,7 @@ func (s *storageImpl) StoreExecutedBatch(ctx context.Context, batch *common.Batc
 		return nil
 	}
 
-	s.logger.Trace("storing executed batch", log.BatchHashKey, batch.Hash(), log.BatchSeqNoKey, batch.SequencerOrderNo, "receipts", len(receipts))
+	s.logger.Trace("storing executed batch", log.BatchHashKey, batch.Hash(), log.BatchSeqNoKey, batch.SequencerOrderNo, "receipts", len(results))
 
 	dbTx, err := s.db.NewDBTransaction(ctx)
 	if err != nil {
@@ -605,8 +600,8 @@ func (s *storageImpl) StoreExecutedBatch(ctx context.Context, batch *common.Batc
 		return fmt.Errorf("could not set the executed flag. Cause: %w", err)
 	}
 
-	for _, receipt := range receipts {
-		err = s.eventsStorage.storeReceiptAndEventLogs(ctx, dbTx, batch, receipt, newContracts[receipt.TxHash])
+	for _, txExecResult := range results {
+		err = s.eventsStorage.storeReceiptAndEventLogs(ctx, dbTx, batch, txExecResult)
 		if err != nil {
 			return fmt.Errorf("could not store receipt. Cause: %w", err)
 		}
@@ -808,8 +803,8 @@ func (s *storageImpl) readOrWriteEOA(ctx context.Context, dbTX *sql.Tx, addr get
 	})
 }
 
-func (s *storageImpl) ReadContractOwner(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error) {
-	return enclavedb.ReadContractOwner(ctx, s.db.GetSQLDB(), address)
+func (s *storageImpl) ReadContractCreator(ctx context.Context, address gethcommon.Address) (*gethcommon.Address, error) {
+	return enclavedb.ReadContractCreator(ctx, s.db.GetSQLDB(), address)
 }
 
 func (s *storageImpl) logDuration(method string, stopWatch *measure.Stopwatch) {

--- a/go/host/storage/hostdb/block.go
+++ b/go/host/storage/hostdb/block.go
@@ -2,6 +2,7 @@ package hostdb
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -23,7 +24,7 @@ func AddBlock(dbtx *dbTransaction, statements *SQLStatements, b *types.Header) e
 		b.Hash().Bytes(), // hash
 		header,           // l1 block header
 	)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), " UNIQUE constraint failed") {
 		return fmt.Errorf("could not insert block. Cause: %w", err)
 	}
 

--- a/go/host/storage/hostdb/block.go
+++ b/go/host/storage/hostdb/block.go
@@ -2,7 +2,6 @@ package hostdb
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -24,7 +23,7 @@ func AddBlock(dbtx *dbTransaction, statements *SQLStatements, b *types.Header) e
 		b.Hash().Bytes(), // hash
 		header,           // l1 block header
 	)
-	if err != nil && !strings.Contains(err.Error(), " UNIQUE constraint failed") {
+	if err != nil {
 		return fmt.Errorf("could not insert block. Cause: %w", err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

We need to restructure the responsibilities to prepare for the configurable contract visibility.

### What changes were made as part of this PR

- update database
- create placeholder for calling the evm config method
- refactor to use better data structures
- clarify responsibilities around event visibility
- remove account owner check when calling "getBalance", because it's not doing much

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


