### PR TITLE
event visibility config part 2

### DIFF
--- a/go/common/tracers/debug_logs.go
+++ b/go/common/tracers/debug_logs.go
@@ -14,7 +14,6 @@ type DebugLogs struct {
 	RelAddress1    *gethcommon.Address `json:"relAddress1"`
 	RelAddress2    *gethcommon.Address `json:"relAddress2"`
 	RelAddress3    *gethcommon.Address `json:"relAddress3"`
-	RelAddress4    *gethcommon.Address `json:"relAddress4"`
 	LifecycleEvent bool                `json:"lifecycleEvent"`
 
 	gethtypes.Log
@@ -37,7 +36,6 @@ func (l DebugLogs) MarshalJSON() ([]byte, error) {
 		RelAddress1    *gethcommon.Address `json:"relAddress1"`
 		RelAddress2    *gethcommon.Address `json:"relAddress2"`
 		RelAddress3    *gethcommon.Address `json:"relAddress3"`
-		RelAddress4    *gethcommon.Address `json:"relAddress4"`
 	}{
 		l.Address.Hex(),
 		l.Topics,
@@ -52,6 +50,5 @@ func (l DebugLogs) MarshalJSON() ([]byte, error) {
 		l.RelAddress1,
 		l.RelAddress2,
 		l.RelAddress3,
-		l.RelAddress4,
 	})
 }

--- a/go/enclave/core/event_types.go
+++ b/go/enclave/core/event_types.go
@@ -5,7 +5,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// EventVisibilityConfig - configuration per event by the dApp developer
+// EventVisibilityConfig - configuration per event by the dApp developer(DD)
+// There are 4 cases:
+// 1. DD doesn't configure anything. - ContractVisibilityConfig.AutoConfig=true
+// 2. DD configures and  specifies the contract as transparent - ContractVisibilityConfig.Transparent=true
+// 3. DD configures and specify the contract as non-transparent, but doesn't configure the event - Contract: false/false , EventVisibilityConfig.AutoConfig=true
+// DD configures the contract as non-transparent, and also configures the topics for the event
 type EventVisibilityConfig struct {
 	AutoConfig                                  bool  // true for events that have no explicit configuration
 	Public                                      bool  // everyone can see and query for this event

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -162,7 +162,8 @@ func FilterLogs(
 func DebugGetLogs(ctx context.Context, db *sql.DB, txHash common.TxHash) ([]*tracers.DebugLogs, error) {
 	var queryParams []any
 
-	query := "select eoa1.address, eoa2.address, eoa3.address, et.public, et.event_sig, t1.topic, t2.topic, t3.topic, datablob, b.hash, b.height, tx.hash, tx.idx, log_idx, c.address " +
+	// todo - should we return the config here?
+	query := "select eoa1.address, eoa2.address, eoa3.address, et.public, et.auto_public, et.event_sig, t1.topic, t2.topic, t3.topic, datablob, b.hash, b.height, tx.hash, tx.idx, log_idx, c.address " +
 		baseEventsJoin +
 		" AND tx.hash = ? "
 
@@ -186,11 +187,13 @@ func DebugGetLogs(ctx context.Context, db *sql.DB, txHash common.TxHash) ([]*tra
 
 		var t0, t1, t2, t3 sql.NullString
 		var relAddress1, relAddress2, relAddress3 []byte
+		var public, autoPublic bool
 		err = rows.Scan(
 			&relAddress1,
 			&relAddress2,
 			&relAddress3,
-			&l.LifecycleEvent,
+			&public,
+			&autoPublic,
 			&t0, &t1, &t2, &t3,
 			&l.Data,
 			&l.BlockHash,
@@ -200,6 +203,7 @@ func DebugGetLogs(ctx context.Context, db *sql.DB, txHash common.TxHash) ([]*tra
 			&l.Index,
 			&l.Address,
 		)
+		l.LifecycleEvent = public || autoPublic
 		if err != nil {
 			return nil, fmt.Errorf("could not load log entry from db: %w", err)
 		}

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -38,6 +38,7 @@ type EventType struct {
 	Contract                                    *Contract
 	EventSignature                              gethcommon.Hash
 	AutoVisibility                              bool
+	AutoPublic                                  *bool // true -when the event is autodetected as public
 	Public                                      bool
 	Topic1CanView, Topic2CanView, Topic3CanView *bool
 	SenderCanView                               *bool

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -3,6 +3,7 @@ package enclavedb
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
@@ -27,13 +28,38 @@ type Contract struct {
 	Transparent    *bool
 }
 
+func (contract Contract) IsTransparent() bool {
+	return contract.Transparent != nil && *contract.Transparent
+}
+
 // EventType - maps to the “event_type“ table
 type EventType struct {
 	Id                                          uint64
-	ContractId                                  uint64
+	Contract                                    *Contract
 	EventSignature                              gethcommon.Hash
 	AutoVisibility                              bool
 	Public                                      bool
 	Topic1CanView, Topic2CanView, Topic3CanView *bool
 	SenderCanView                               *bool
+}
+
+func (et EventType) Auto() bool {
+	return et.Contract.AutoVisibility && et.AutoVisibility
+}
+
+func (et EventType) IsPublic() bool {
+	return (et.Contract.Transparent != nil && *et.Contract.Transparent) || et.Public
+}
+
+func (et EventType) IsTopicRelevant(topicNo int) bool {
+	switch topicNo {
+	case 1:
+		return et.Topic1CanView != nil && *et.Topic1CanView
+	case 2:
+		return et.Topic2CanView != nil && *et.Topic2CanView
+	case 3:
+		return et.Topic3CanView != nil && *et.Topic3CanView
+	}
+	// this should not happen under any circumstance
+	panic(fmt.Sprintf("unknown topic no: %d", topicNo))
 }

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -39,13 +39,13 @@ type EventType struct {
 	EventSignature                              gethcommon.Hash
 	AutoVisibility                              bool
 	AutoPublic                                  *bool // true -when the event is autodetected as public
-	Public                                      bool
+	ConfigPublic                                bool
 	Topic1CanView, Topic2CanView, Topic3CanView *bool
 	SenderCanView                               *bool
 }
 
 func (et EventType) IsPublic() bool {
-	return (et.Contract.Transparent != nil && *et.Contract.Transparent) || et.Public
+	return (et.Contract.Transparent != nil && *et.Contract.Transparent) || et.ConfigPublic
 }
 
 func (et EventType) IsTopicRelevant(topicNo int) bool {

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -43,10 +43,6 @@ type EventType struct {
 	SenderCanView                               *bool
 }
 
-func (et EventType) Auto() bool {
-	return et.Contract.AutoVisibility && et.AutoVisibility
-}
-
 func (et EventType) IsPublic() bool {
 	return (et.Contract.Transparent != nil && *et.Contract.Transparent) || et.Public
 }

--- a/go/enclave/storage/events_storage.go
+++ b/go/enclave/storage/events_storage.go
@@ -35,7 +35,12 @@ func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql
 
 	// store the contracts created by this tx
 	for createdContract, cfg := range txExecResult.CreatedContracts {
-		ctrId, err := es.storeNewContract(ctx, dbTX, createdContract, senderId, cfg)
+		_, err := es.storeNewContract(ctx, dbTX, createdContract, senderId, cfg)
+		if err != nil {
+			return err
+		}
+
+		c, err := es.readContract(ctx, dbTX, createdContract)
 		if err != nil {
 			return err
 		}
@@ -43,7 +48,7 @@ func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql
 		// create the event types for the events that were configured
 		for eventSig, eventCfg := range cfg.EventConfigs {
 			_, err = enclavedb.WriteEventType(ctx, dbTX, &enclavedb.EventType{
-				ContractId:     *ctrId,
+				Contract:       c,
 				EventSignature: eventSig,
 				AutoVisibility: eventCfg.AutoConfig,
 				Public:         eventCfg.Public,
@@ -110,7 +115,7 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 	eventType, err := es.readEventType(ctx, dbTX, l.Address, eventSig)
 	if errors.Is(err, errutil.ErrNotFound) {
 		// this is the first type an event of this type is emitted, so we must store it
-		eventType, err = es.storeEventType(ctx, dbTX, contract, l)
+		eventType, err = es.storeAutoConfigEventType(ctx, dbTX, contract, l)
 		if err != nil {
 			return fmt.Errorf("could not write event type. cause %w", err)
 		}
@@ -119,7 +124,7 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 		return fmt.Errorf("could not read event type. Cause: %w", err)
 	}
 
-	topicIds, err := es.storeTopics(ctx, dbTX, l)
+	topicIds, err := es.storeTopics(ctx, dbTX, eventType, l)
 	if err != nil {
 		return fmt.Errorf("could not store topics. cause: %w", err)
 	}
@@ -138,27 +143,18 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 }
 
 // handles the visibility config detection
-func (es *eventsStorage) storeEventType(ctx context.Context, dbTX *sql.Tx, contract *enclavedb.Contract, l *types.Log) (*enclavedb.EventType, error) {
-	eventType := enclavedb.EventType{ContractId: contract.Id, EventSignature: l.Topics[0], AutoVisibility: contract.AutoVisibility}
-
-	// when the contract is transparent, all events are public
-	switch {
-	case contract.Transparent != nil && *contract.Transparent:
-		eventType.Public = true
-	case contract.AutoVisibility:
-		// autodetect based on the topics
-		isPublic, t1, t2, t3, err := es.autodetectVisibility(ctx, dbTX, l)
-		if err != nil {
-			return nil, fmt.Errorf("could not auto detect visibility for event type. cause: %w", err)
-		}
-		eventType.Public = *isPublic
-		eventType.Topic1CanView = t1
-		eventType.Topic2CanView = t2
-		eventType.Topic3CanView = t3
-	default:
-		// todo
-		return nil, fmt.Errorf("not implemented")
+func (es *eventsStorage) storeAutoConfigEventType(ctx context.Context, dbTX *sql.Tx, contract *enclavedb.Contract, l *types.Log) (*enclavedb.EventType, error) {
+	eventType := enclavedb.EventType{
+		Contract:       contract,
+		EventSignature: l.Topics[0],
+		Public:         contract.IsTransparent(),
 	}
+
+	// event types that are not public - will have the default rules
+	if !eventType.Public {
+		eventType.AutoVisibility = true
+	}
+
 	id, err := enclavedb.WriteEventType(ctx, dbTX, &eventType)
 	if err != nil {
 		return nil, fmt.Errorf("could not write event type. cause: %w", err)
@@ -167,32 +163,7 @@ func (es *eventsStorage) storeEventType(ctx context.Context, dbTX *sql.Tx, contr
 	return &eventType, nil
 }
 
-func (es *eventsStorage) autodetectVisibility(ctx context.Context, dbTX *sql.Tx, l *types.Log) (*bool, *bool, *bool, *bool, error) {
-	isPublic := true
-	topicsCanView := make([]bool, 3)
-	for i := 1; i < len(l.Topics); i++ {
-		topic := l.Topics[i]
-		// first check if there is an entry already for this topic
-		_, relAddressId, err := es.findEventTopic(ctx, dbTX, topic.Bytes())
-		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-			return nil, nil, nil, nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
-		}
-		if errors.Is(err, errutil.ErrNotFound) {
-			// check whether the topic is an EOA
-			relAddressId, err = es.findRelevantAddress(ctx, dbTX, topic)
-			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-				return nil, nil, nil, nil, fmt.Errorf("could not read relevant address. Cause %w", err)
-			}
-		}
-		if relAddressId != nil {
-			isPublic = false
-			topicsCanView[i-1] = true
-		}
-	}
-	return &isPublic, &topicsCanView[0], &topicsCanView[1], &topicsCanView[2], nil
-}
-
-func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, l *types.Log) ([]*uint64, error) {
+func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, eventType *enclavedb.EventType, l *types.Log) ([]*uint64, error) {
 	topicIds := make([]*uint64, 3)
 	// iterate the topics containing user values
 	// reuse them if already inserted
@@ -205,14 +176,10 @@ func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, l *types
 			return nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
 		}
 		if errors.Is(err, errutil.ErrNotFound) {
-			// check whether the topic is an EOA
-			relAddressId, err := es.findRelevantAddress(ctx, dbTX, topic)
-			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
-				return nil, fmt.Errorf("could not read relevant address. Cause %w", err)
-			}
-			eventTopicId, err = enclavedb.WriteEventTopic(ctx, dbTX, &topic, relAddressId)
+			// if no entry was found
+			eventTopicId, err = es.storeEventTopic(ctx, dbTX, eventType, i, topic)
 			if err != nil {
-				return nil, fmt.Errorf("could not write event topic. Cause: %w", err)
+				return nil, fmt.Errorf("could not read the event topic. Cause: %w", err)
 			}
 		}
 		topicIds[i-1] = &eventTopicId
@@ -220,22 +187,84 @@ func (es *eventsStorage) storeTopics(ctx context.Context, dbTX *sql.Tx, l *types
 	return topicIds, nil
 }
 
+// this function contains visibility logic
+func (es *eventsStorage) storeEventTopic(ctx context.Context, dbTX *sql.Tx, eventType *enclavedb.EventType, i int, topic gethcommon.Hash) (uint64, error) {
+	relevantAddress, err := es.visibililty(ctx, dbTX, eventType, i, topic)
+	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
+		return 0, fmt.Errorf("could not determine visibility rules. cause: %w", err)
+	}
+
+	var relAddressId *uint64
+	if relevantAddress != nil {
+		var err error
+		relAddressId, err = es.readEOA(ctx, dbTX, *relevantAddress)
+		if err != nil {
+			return 0, err
+		}
+	}
+	eventTopicId, err := enclavedb.WriteEventTopic(ctx, dbTX, &topic, relAddressId)
+	if err != nil {
+		return 0, fmt.Errorf("could not write event topic. Cause: %w", err)
+	}
+	return eventTopicId, nil
+}
+
+func (es *eventsStorage) visibililty(ctx context.Context, dbTX *sql.Tx, eventType *enclavedb.EventType, i int, topic gethcommon.Hash) (*gethcommon.Address, error) {
+	var relevantAddress *gethcommon.Address
+	switch {
+	case eventType.AutoVisibility:
+		var err error
+		// if there is no configuration, we have to autodetect the address
+		relevantAddress, err = es.autoDetectRelevantAddress(ctx, dbTX, topic)
+		if err != nil {
+			return nil, err
+		}
+
+		// when autodetecting, we assume that any address that is not a contract is an EOA
+		_, err = es.readEOA(ctx, dbTX, *relevantAddress)
+		if err != nil && !errors.Is(err, errutil.ErrNotFound) {
+			return nil, err
+		}
+		if errors.Is(err, errutil.ErrNotFound) {
+			_, err := enclavedb.WriteEoa(ctx, dbTX, *relevantAddress)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+	case eventType.IsPublic():
+		// for public events, there is no relevant address
+		relevantAddress = nil
+
+	case eventType.IsTopicRelevant(i):
+		relevantAddress = common.ExtractPotentialAddress(topic)
+		if relevantAddress == nil {
+			return nil, fmt.Errorf("invalid configuration. expected address in topic %d : %s", i, topic.String())
+		}
+
+	default:
+		es.logger.Crit("impossible case. Should not get here")
+	}
+
+	return relevantAddress, nil
+}
+
 // Of the log's topics, returns those that are (potentially) user addresses. A topic is considered a user address if:
 //   - It has at least 12 leading zero bytes (since addresses are 20 bytes long, while hashes are 32) and at most 22 leading zero bytes
 //   - It is not a smart contract address
-func (es *eventsStorage) findRelevantAddress(ctx context.Context, dbTX *sql.Tx, topic gethcommon.Hash) (*uint64, error) {
+func (es *eventsStorage) autoDetectRelevantAddress(ctx context.Context, dbTX *sql.Tx, topic gethcommon.Hash) (*gethcommon.Address, error) {
 	potentialAddr := common.ExtractPotentialAddress(topic)
 	if potentialAddr == nil {
 		return nil, errutil.ErrNotFound
 	}
 
 	// first check whether there is already an entry in the EOA table
-	eoaID, err := es.readEOA(ctx, dbTX, *potentialAddr)
+	_, err := es.readEOA(ctx, dbTX, *potentialAddr)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return nil, err
 	}
 	if err == nil {
-		return eoaID, nil
+		return potentialAddr, nil
 	}
 
 	// if the address is a contract then it's clearly not an EOA
@@ -247,15 +276,7 @@ func (es *eventsStorage) findRelevantAddress(ctx context.Context, dbTX *sql.Tx, 
 		return nil, errutil.ErrNotFound
 	}
 
-	// when we reach this point, the value looks like an address, but we haven't yet seen it
-	// for the first iteration, we'll just assume it's an EOA
-	// we can make this smarter by passing in more information about the event
-	id, err := enclavedb.WriteEoa(ctx, dbTX, *potentialAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &id, nil
+	return potentialAddr, nil
 }
 
 func (es *eventsStorage) readEventType(ctx context.Context, dbTX *sql.Tx, contractAddress gethcommon.Address, eventSignature gethcommon.Hash) (*enclavedb.EventType, error) {
@@ -266,7 +287,7 @@ func (es *eventsStorage) readEventType(ctx context.Context, dbTX *sql.Tx, contra
 		if err != nil {
 			return nil, err
 		}
-		return enclavedb.ReadEventType(ctx, dbTX, contract.Id, eventSignature)
+		return enclavedb.ReadEventType(ctx, dbTX, contract, eventSignature)
 	})
 }
 

--- a/go/enclave/storage/events_storage.go
+++ b/go/enclave/storage/events_storage.go
@@ -73,7 +73,7 @@ func (es *eventsStorage) storeNewContractWithEventTypeConfigs(ctx context.Contex
 			Contract:       c,
 			EventSignature: eventSig,
 			AutoVisibility: eventCfg.AutoConfig,
-			Public:         eventCfg.Public,
+			ConfigPublic:   eventCfg.Public,
 			Topic1CanView:  eventCfg.Topic1CanView,
 			Topic2CanView:  eventCfg.Topic2CanView,
 			Topic3CanView:  eventCfg.Topic3CanView,
@@ -139,7 +139,7 @@ func (es *eventsStorage) storeEventLog(ctx context.Context, dbTX *sql.Tx, execTx
 		return fmt.Errorf("could not write event log. Cause: %w", err)
 	}
 
-	if !eventType.Public && eventType.AutoVisibility && eventType.AutoPublic == nil {
+	if !eventType.ConfigPublic && eventType.AutoVisibility && eventType.AutoPublic == nil {
 		isPublic := true
 		for _, topicId := range topicIds {
 			if topicId != nil {
@@ -169,11 +169,11 @@ func (es *eventsStorage) storeAutoConfigEventType(ctx context.Context, dbTX *sql
 	eventType := enclavedb.EventType{
 		Contract:       contract,
 		EventSignature: l.Topics[0],
-		Public:         contract.IsTransparent(),
+		ConfigPublic:   contract.IsTransparent(),
 	}
 
 	// event types that are not public - will have the default rules
-	if !eventType.Public {
+	if !eventType.ConfigPublic {
 		eventType.AutoVisibility = true
 	}
 

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -144,6 +144,7 @@ create table if not exists tendb.event_type
 create table if not exists tendb.event_topic
 (
     id          INTEGER AUTO_INCREMENT,
+    event_type  INTEGER,
     topic       binary(32) NOT NULL,
     rel_address INTEGER,
     primary key (id),

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -132,6 +132,7 @@ create table if not exists tendb.event_type
     contract        int        NOT NULL,
     event_sig       binary(32) NOT NULL,
     auto_visibility boolean    NOT NULL,
+    auto_public     boolean,
     public          boolean    NOT NULL,
     topic1_can_view boolean,
     topic2_can_view boolean,

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -133,7 +133,7 @@ create table if not exists tendb.event_type
     event_sig       binary(32) NOT NULL,
     auto_visibility boolean    NOT NULL,
     auto_public     boolean,
-    public          boolean    NOT NULL,
+    config_public   boolean    NOT NULL,
     topic1_can_view boolean,
     topic2_can_view boolean,
     topic3_can_view boolean,

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -138,11 +138,13 @@ create index IDX_EV_CONTRACT on event_type (contract, event_sig);
 create table if not exists event_topic
 (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type  INTEGER references event_type,
     topic       binary(32) NOT NULL,
     rel_address INTEGER references externally_owned_account
 --    pos         INTEGER    NOT NULL -- todo
 );
 create index IDX_TOP on event_topic (topic);
+create index IDX_REL_A on event_topic (rel_address);
 
 create table if not exists event_log
 (

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -127,7 +127,7 @@ create table if not exists event_type
     event_sig       binary(32) NOT NULL,
     auto_visibility boolean    NOT NULL,
     auto_public     boolean,
-    public          boolean    NOT NULL,
+    config_public   boolean    NOT NULL,
     topic1_can_view boolean,
     topic2_can_view boolean,
     topic3_can_view boolean,

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -124,9 +124,10 @@ create table if not exists event_type
 (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     contract        INTEGER    NOT NULL references contract,
-    event_sig       binary(32) NOT NULL, -- no need to index because there are only a few events for an address
-    auto_visibility boolean    NOT NULL, -- the visibility of this event type was not configured by the contract dev.
-    public          boolean    NOT NULL, -- set based on the first event, and then updated to false if it turns out it is true
+    event_sig       binary(32) NOT NULL,
+    auto_visibility boolean    NOT NULL,
+    auto_public     boolean,
+    public          boolean    NOT NULL,
     topic1_can_view boolean,
     topic2_can_view boolean,
     topic3_can_view boolean,


### PR DESCRIPTION
### Why this change is needed

This is part 2 for https://github.com/ten-protocol/go-ten/pull/2056

Part 3 will follow shortly.

This change should not break existing functionality.

### What changes were made as part of this PR

- change the query logic to use the new configs
- clarify and fix the event type and event topic storage logic

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


