### PR TITLE
wire sender in the events sql

### DIFF
--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -317,6 +317,7 @@ func visibilityQuery(requestingAccount *gethcommon.Address) (string, []any) {
 	visibParams = append(visibParams, acc)
 	visibParams = append(visibParams, acc)
 	visibParams = append(visibParams, acc)
+	visibParams = append(visibParams, acc)
 
 	visibQuery += ") "
 	return visibQuery, visibParams

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -22,6 +22,7 @@ const (
 	baseEventsJoin = "from event_log e " +
 		"join receipt rec on e.receipt=rec.id" +
 		"	join tx on rec.tx=tx.id " +
+		"      left join externally_owned_account eoatx on tx.sender_address=eoatx.id " +
 		"	join batch b on rec.batch=b.sequence " +
 		"join event_type et on e.event_type=et.id " +
 		"	join contract c on et.contract=c.id " +
@@ -310,6 +311,7 @@ func visibilityQuery(requestingAccount *gethcommon.Address) (string, []any) {
 		"       (et.topic1_can_view AND eoa1.address=?) " +
 		"    OR (et.topic2_can_view AND eoa2.address=?) " +
 		"    OR (et.topic3_can_view AND eoa3.address=?)" +
+		"    OR (et.sender_can_view AND eoatx.address=?)" +
 		"  )" +
 		")"
 	visibParams = append(visibParams, acc)


### PR DESCRIPTION
### Why this change is needed

- to implement the event.sender_can_view functionality 

### What changes were made as part of this PR

- update the event logs SQL 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


