### PR TITLE
github actions fix for dexynth gateway

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -10,7 +10,7 @@
 #  - GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER
 
 # If we are deploying to a non primary instance all those variables should be prefixed with the instance name
-# example: dexynth-DOCKER_BUILD_TAG_GATEWAY
+# example: DEXYNTH_DOCKER_BUILD_TAG_GATEWAY
 
 
 name: '[M] Deploy Ten Gateway Backend'
@@ -34,7 +34,7 @@ on:
         type: choice
         options:
           - "primary"
-          - "dexynth"
+          - "DEXYNTH"
 
 jobs:
   validate-inputs:
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: "Check if deployment is allowed"
         run: |
-          if [[ "${{ github.event.inputs.instance_type }}" == "Dexynth" && "${{ github.event.inputs.testnet_type }}" != "sepolia-testnet" ]]; then
+          if [[ "${{ github.event.inputs.instance_type }}" == "DEXYNTH" && "${{ github.event.inputs.testnet_type }}" != "sepolia-testnet" ]]; then
             echo "Error: Dexynth can only be deployed to sepolia-testnet."
             exit 1
           fi
@@ -60,6 +60,7 @@ jobs:
 
           if [[ "${{ github.event.inputs.instance_type }}" != "primary" ]]; then
             INSTANCE_SUFFIX="_${{ github.event.inputs.instance_type }}"
+            INSTANCE_SUFFIX2="-${{ github.event.inputs.instance_type }}"
             INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}_"
           fi
 
@@ -67,8 +68,8 @@ jobs:
           echo "INSTANCE_PREFIX=$INSTANCE_PREFIX" >> $GITHUB_ENV
 
           # Set infrastructure variables
-          PUBLIC_IP="${{ github.event.inputs.testnet_type }}-OG-static${INSTANCE_SUFFIX}"
-          DNS_NAME="obscurogateway-${{ github.event.inputs.testnet_type }}${INSTANCE_SUFFIX}"
+          PUBLIC_IP="${{ github.event.inputs.testnet_type }}-OG-static${INSTANCE_SUFFIX2,,}"
+          DNS_NAME="obscurogateway-${{ github.event.inputs.testnet_type }}${INSTANCE_SUFFIX2,,}"
           VM_NAME="${{ github.event.inputs.testnet_type }}-OG-${{ github.run_number }}${INSTANCE_SUFFIX}"
           DEPLOY_GROUP="ObscuroGateway-${{ github.event.inputs.testnet_type }}-${{ github.run_number }}${INSTANCE_SUFFIX}"
           VNET_NAME="ObscuroGateway-${{ github.event.inputs.testnet_type }}-01VNET${INSTANCE_SUFFIX}"

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -7,7 +7,7 @@
 # - TENSCAN_URL
 
 # If we are deploying to a non primary instance all those variables should be prefixed with the instance name
-# example: dexynth-GATEWAY_URL
+# example: DEXYNTH_GATEWAY_URL
 
 name: '[M] Deploy Ten Gateway Frontend'
 run-name: '[M] Deploy Ten Gateway Frontend ( ${{ github.event.inputs.testnet_type }} )'
@@ -30,14 +30,14 @@ on:
         type: choice
         options:
           - "primary"
-          - "dexynth"
+          - "DEXYNTH"
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check if deployment is allowed"
         run: |
-          if [[ "${{ github.event.inputs.instance_type }}" == "dexynth" && "${{ github.event.inputs.testnet_type }}" != "sepolia-testnet" ]]; then
+          if [[ "${{ github.event.inputs.instance_type }}" == "DEXYNTH" && "${{ github.event.inputs.testnet_type }}" != "sepolia-testnet" ]]; then
             echo "Error: Dexynth can only be deployed to sepolia-testnet."
             exit 1
           fi
@@ -53,16 +53,17 @@ jobs:
           INSTANCE_PREFIX=""
 
           if [[ "${{ github.event.inputs.instance_type }}" != "primary" ]]; then
-            INSTANCE_SUFFIX="-${{ github.event.inputs.instance_type }}"
-            INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}-"
+            INSTANCE_SUFFIX="_${{ github.event.inputs.instance_type }}"
+            INSTANCE_SUFFIX2="-${{ github.event.inputs.instance_type }}"
+            INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}_"
           fi
 
           echo "INSTANCE_SUFFIX=$INSTANCE_SUFFIX" >> $GITHUB_ENV
           echo "INSTANCE_PREFIX=$INSTANCE_PREFIX" >> $GITHUB_ENV
 
 
-          DNS_NAME_LABEL_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-ten-gateway${INSTANCE_SUFFIX}"
-          IMAGE_NAME_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-fe-ten-gateway${INSTANCE_SUFFIX}"
+          DNS_NAME_LABEL_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-ten-gateway${INSTANCE_SUFFIX2,,}"
+          IMAGE_NAME_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-fe-ten-gateway${INSTANCE_SUFFIX2,,}"
 
           echo "DNS_NAME_LABEL_GATEWAY_FE=$DNS_NAME_LABEL_GATEWAY_FE" >> $GITHUB_ENV
           echo "IMAGE_NAME_GATEWAY_FE=$IMAGE_NAME_GATEWAY_FE" >> $GITHUB_ENV
@@ -122,12 +123,12 @@ jobs:
       - name: 'Build and Push Docker Image'
         run: |
           DOCKER_BUILDKIT=1 docker build \
-            --build-arg NEXT_PUBLIC_NETWORK_NAME=${{ env.NETWORK_NAME }} \
-            --build-arg NEXT_PUBLIC_TENSCAN_URL=${{ env.TENSCAN_URL }} \
-            --build-arg NEXT_PUBLIC_GATEWAY_URL=${{ env.GATEWAY_URL }} \
-            -t ${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }} \
+            --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ env.NETWORK_NAME }}" \
+            --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ env.TENSCAN_URL }}" \
+            --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ env.GATEWAY_URL }}" \
+            -t "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
-          docker push ${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}
+          docker push "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}"
 
       - name: 'Deploy Gateway FE to Azure Container Instances'
         uses: "azure/aci-deploy@v1"


### PR DESCRIPTION
### Why this change is needed

There were some problems with dexynth gateway deployment because some variable names containing `-` or `_`. It is fixed and deployed from that branch now.

### What changes were made as part of this PR

Minor fixes in github actions scripts for the gateway.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


