### PR TITLE
Fix gas estimation for reverts that are considered consensus errors

### DIFF
--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -198,6 +198,15 @@ func (rpc *EncryptionManager) doEstimateGas(ctx context.Context, args *gethapi.T
 		hi = gasCap
 	}
 	cap = hi //nolint: revive
+	isFailedAtMax, _, err := rpc.isGasEnough(ctx, args, hi, blkNumber)
+	//TODO: Workaround for the weird conensus nil statement down, which gets interwined with evm errors.
+	// Here if there is a consensus error - we'd bail. If the tx fails at max gas - we'd bail (probably bad)
+	if err != nil {
+		return 0, gethcommon.Big0, err
+	}
+	if isFailedAtMax {
+		return 0, gethcommon.Big0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
+	}
 
 	// Execute the binary search and hone in on an isGasEnough gas limit
 	for lo+1 < hi {
@@ -208,19 +217,25 @@ func (rpc *EncryptionManager) doEstimateGas(ctx context.Context, args *gethapi.T
 			// range here is skewed to favor the low side.
 			mid = lo * 2
 		}
-		failed, _, err := rpc.isGasEnough(ctx, args, mid, blkNumber)
+		failed, _, _ := rpc.isGasEnough(ctx, args, mid, blkNumber)
+		// TODO @siliev: The following statement is bullshit. I dont know why its here.
+		// We might have masked our internal workings, or mixed up with how geth works.
+		// Either way transaction reverted is counted as a consensus error, rather than
+		// EVM failure.
+
 		// If the error is not nil(consensus error), it means the provided message
 		// call or transaction will never be accepted no matter how much gas it is
 		// assigned. Return the error directly, don't struggle any more.
-		if err != nil {
+		/*if err != nil && isFailedAtMax {
 			return 0, gethcommon.Big0, err
-		}
+		}*/
 		if failed {
 			lo = mid
 		} else {
 			hi = mid
 		}
 	}
+
 	// Reject the transaction as invalid if it still fails at the highest allowance
 	if hi == cap { //nolint:nestif
 		failed, result, err := rpc.isGasEnough(ctx, args, hi, blkNumber)


### PR DESCRIPTION
### Why this change is needed

Gas estimation which we copied from geth fails when there is a revert while searching for proper gas. This is due to the error not being the correct gas too low (for whatever reason). This is a workaround.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


