### PR TITLE
WIP gateway encrypt and decrypt stored data

### DIFF
--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 
@@ -75,4 +76,13 @@ func (r *RPCRequest) Clone() *RPCRequest {
 		Method: r.Method,
 		Params: r.Params,
 	}
+}
+
+func GenerateRandomKey(keySize int) ([]byte, error) {
+	key := make([]byte, keySize)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
 }

--- a/tools/walletextension/rpcapi/wallet_extension.go
+++ b/tools/walletextension/rpcapi/wallet_extension.go
@@ -39,7 +39,7 @@ import (
 type Services struct {
 	HostAddrHTTP string // The HTTP address on which the TEN host can be reached
 	HostAddrWS   string // The WS address on which the TEN host can be reached
-	Storage      storage.Storage
+	Storage      *storage.EncryptedStorage
 	logger       gethlog.Logger
 	stopControl  *stopcontrol.StopControl
 	version      string
@@ -56,7 +56,7 @@ type NewHeadNotifier interface {
 	onNewHead(header *tencommon.BatchHeader)
 }
 
-func NewServices(hostAddrHTTP string, hostAddrWS string, storage storage.Storage, stopControl *stopcontrol.StopControl, version string, logger gethlog.Logger, config *common.Config) *Services {
+func NewServices(hostAddrHTTP string, hostAddrWS string, storage *storage.EncryptedStorage, stopControl *stopcontrol.StopControl, version string, logger gethlog.Logger, config *common.Config) *Services {
 	newGatewayCache, err := cache.NewCache(logger)
 	if err != nil {
 		logger.Error(fmt.Errorf("could not create cache. Cause: %w", err).Error())

--- a/tools/walletextension/storage/encryption/encryption.go
+++ b/tools/walletextension/storage/encryption/encryption.go
@@ -1,0 +1,41 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"io"
+)
+
+type Encryptor struct {
+	gcm cipher.AEAD
+}
+
+func NewEncryptor(key []byte) (*Encryptor, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Encryptor{gcm: gcm}, nil
+}
+
+func (e *Encryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return e.gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func (e *Encryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < e.gcm.NonceSize() {
+		return nil, errors.New("ciphertext too short")
+	}
+	nonce, ciphertext := ciphertext[:e.gcm.NonceSize()], ciphertext[e.gcm.NonceSize():]
+	return e.gcm.Open(nil, nonce, ciphertext, nil)
+}

--- a/tools/walletextension/storage/encryption/encryption_test.go
+++ b/tools/walletextension/storage/encryption/encryption_test.go
@@ -1,0 +1,115 @@
+package encryption
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewEncryptor(t *testing.T) {
+	key := make([]byte, 32) // 256-bit key
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("NewEncryptor failed: %v", err)
+	}
+
+	if encryptor == nil {
+		t.Fatal("NewEncryptor returned nil")
+	}
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32) // 256-bit key
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("NewEncryptor failed: %v", err)
+	}
+
+	plaintext := []byte("Hello, World!")
+
+	ciphertext, err := encryptor.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encryption failed: %v", err)
+	}
+
+	decrypted, err := encryptor.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decryption failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatalf("Decrypted text does not match original plaintext")
+	}
+}
+
+func TestEncryptDecryptEmptyString(t *testing.T) {
+	key := make([]byte, 32) // 256-bit key
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("NewEncryptor failed: %v", err)
+	}
+
+	plaintext := []byte("")
+
+	ciphertext, err := encryptor.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encryption of empty string failed: %v", err)
+	}
+
+	decrypted, err := encryptor.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decryption of empty string failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatalf("Decrypted empty string does not match original")
+	}
+}
+
+func TestDecryptInvalidCiphertext(t *testing.T) {
+	key := make([]byte, 32) // 256-bit key
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("NewEncryptor failed: %v", err)
+	}
+
+	invalidCiphertext := []byte("This is not a valid ciphertext")
+
+	_, err = encryptor.Decrypt(invalidCiphertext)
+	if err == nil {
+		t.Fatal("Decryption of invalid ciphertext should have failed, but didn't")
+	}
+}
+
+func TestNewEncryptorInvalidKeySize(t *testing.T) {
+	invalidKey := make([]byte, 31) // Invalid key size (not 16, 24, or 32 bytes)
+	_, err := rand.Read(invalidKey)
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	_, err = NewEncryptor(invalidKey)
+	if err == nil {
+		t.Fatal("NewEncryptor should have failed with invalid key size, but didn't")
+	}
+}

--- a/tools/walletextension/storage/storage.go
+++ b/tools/walletextension/storage/storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ten-protocol/go-ten/tools/walletextension/storage/database/sqlite"
 
 	"github.com/ten-protocol/go-ten/tools/walletextension/common"
+	"github.com/ten-protocol/go-ten/tools/walletextension/storage/encryption"
 )
 
 type Storage interface {
@@ -21,12 +22,132 @@ type Storage interface {
 	StoreTransaction(rawTx string, userID []byte) error
 }
 
-func New(dbType string, dbConnectionURL, dbPath string) (Storage, error) {
+type EncryptedStorage struct {
+	Storage
+	encryptor *encryption.Encryptor
+}
+
+func New(dbType string, dbConnectionURL, dbPath string, randomNumber []byte) (Storage, error) {
+	var baseStorage Storage
+	var err error
+
 	switch dbType {
 	case "mariaDB":
-		return mariadb.NewMariaDB(dbConnectionURL)
+		baseStorage, err = mariadb.NewMariaDB(dbConnectionURL)
 	case "sqlite":
-		return sqlite.NewSqliteDatabase(dbPath)
+		baseStorage, err = sqlite.NewSqliteDatabase(dbPath)
+	default:
+		return nil, fmt.Errorf("unknown db %s", dbType)
 	}
-	return nil, fmt.Errorf("unknown db %s", dbType)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewEncryptedStorage(baseStorage, randomNumber)
+}
+
+func NewEncryptedStorage(storage Storage, key []byte) (*EncryptedStorage, error) {
+	encryptor, err := encryption.NewEncryptor(key)
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptedStorage{
+		Storage:   storage,
+		encryptor: encryptor,
+	}, nil
+}
+
+// Implement the methods of EncryptedStorage
+func (es *EncryptedStorage) AddUser(userID []byte, privateKey []byte) error {
+	encryptedPrivateKey, err := es.encryptor.Encrypt(privateKey)
+	if err != nil {
+		return err
+	}
+	return es.Storage.AddUser(userID, encryptedPrivateKey)
+}
+
+func (es *EncryptedStorage) GetUserPrivateKey(userID []byte) ([]byte, error) {
+	encryptedPrivateKey, err := es.Storage.GetUserPrivateKey(userID)
+	if err != nil {
+		return nil, err
+	}
+	return es.encryptor.Decrypt(encryptedPrivateKey)
+}
+func (es *EncryptedStorage) AddAccount(userID []byte, accountAddress []byte, signature []byte, signatureType viewingkey.SignatureType) error {
+	encryptedUserID, err := es.encryptor.Encrypt(userID)
+	if err != nil {
+		return err
+	}
+	encryptedAccountAddress, err := es.encryptor.Encrypt(accountAddress)
+	if err != nil {
+		return err
+	}
+	encryptedSignature, err := es.encryptor.Encrypt(signature)
+	if err != nil {
+		return err
+	}
+
+	return es.Storage.AddAccount(encryptedUserID, encryptedAccountAddress, encryptedSignature, signatureType)
+}
+
+func (es *EncryptedStorage) GetAccounts(userID []byte) ([]common.AccountDB, error) {
+	accounts, err := es.Storage.GetAccounts(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, account := range accounts {
+		decryptedAccountAddress, err := es.encryptor.Decrypt(account.AccountAddress)
+		if err != nil {
+			return nil, err
+		}
+		decryptedSignature, err := es.encryptor.Decrypt(account.Signature)
+		if err != nil {
+			return nil, err
+		}
+
+		accounts[i].AccountAddress = decryptedAccountAddress
+		accounts[i].Signature = decryptedSignature
+	}
+
+	return accounts, nil
+}
+
+func (es *EncryptedStorage) GetAllUsers() ([]common.UserDB, error) {
+	users, err := es.Storage.GetAllUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	decryptedUsers := make([]common.UserDB, len(users))
+	for i, user := range users {
+		decryptedUserID, err := es.encryptor.Decrypt(user.UserID)
+		if err != nil {
+			return nil, err
+		}
+		decryptedPrivateKey, err := es.encryptor.Decrypt(user.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+		decryptedUsers[i] = common.UserDB{
+			UserID:     decryptedUserID,
+			PrivateKey: decryptedPrivateKey,
+		}
+	}
+	return decryptedUsers, nil
+}
+
+func (es *EncryptedStorage) StoreTransaction(rawTx string, userID []byte) error {
+	encryptedUserID, err := es.encryptor.Encrypt(userID)
+	if err != nil {
+		return err
+	}
+
+	encryptedRawTx, err := es.encryptor.Encrypt([]byte(rawTx))
+	if err != nil {
+		return err
+	}
+
+	return es.Storage.StoreTransaction(string(encryptedRawTx), encryptedUserID)
 }

--- a/tools/walletextension/storage/storage_test.go
+++ b/tools/walletextension/storage/storage_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
+	wecommon "github.com/ten-protocol/go-ten/tools/walletextension/common"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ten-protocol/go-ten/go/common/errutil"
 )
 
-var tests = map[string]func(storage Storage, t *testing.T){
+var tests = map[string]func(*EncryptedStorage, *testing.T){
 	"testAddAndGetUser":     testAddAndGetUser,
 	"testAddAndGetAccounts": testAddAndGetAccounts,
 	"testDeleteUser":        testDeleteUser,
@@ -20,10 +21,14 @@ var tests = map[string]func(storage Storage, t *testing.T){
 }
 
 func TestSQLiteGatewayDB(t *testing.T) {
+	randomKey, err := wecommon.GenerateRandomKey(32)
+	require.NoError(t, err)
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// storage, err := New("mariaDB", "obscurouser:password@tcp(127.0.0.1:3306)/ogdb", "") allows to run tests against a local instance of MariaDB
-			storage, err := New("sqlite", "", "")
+
+			storage, err := New("sqlite", "", "", randomKey)
 			require.NoError(t, err)
 
 			test(storage, t)
@@ -31,7 +36,7 @@ func TestSQLiteGatewayDB(t *testing.T) {
 	}
 }
 
-func testAddAndGetUser(storage Storage, t *testing.T) {
+func testAddAndGetUser(storage *EncryptedStorage, t *testing.T) {
 	userID := []byte("userID")
 	privateKey := []byte("privateKey")
 
@@ -50,7 +55,7 @@ func testAddAndGetUser(storage Storage, t *testing.T) {
 	}
 }
 
-func testAddAndGetAccounts(storage Storage, t *testing.T) {
+func testAddAndGetAccounts(storage *EncryptedStorage, t *testing.T) {
 	userID := []byte("userID")
 	privateKey := []byte("privateKey")
 	accountAddress1 := []byte("accountAddress1")
@@ -104,7 +109,7 @@ func testAddAndGetAccounts(storage Storage, t *testing.T) {
 	}
 }
 
-func testDeleteUser(storage Storage, t *testing.T) {
+func testDeleteUser(storage *EncryptedStorage, t *testing.T) {
 	userID := []byte("testDeleteUserID")
 	privateKey := []byte("testDeleteUserPrivateKey")
 
@@ -124,7 +129,7 @@ func testDeleteUser(storage Storage, t *testing.T) {
 	}
 }
 
-func testGetAllUsers(storage Storage, t *testing.T) {
+func testGetAllUsers(storage *EncryptedStorage, t *testing.T) {
 	initialUsers, err := storage.GetAllUsers()
 	if err != nil {
 		t.Fatal(err)
@@ -148,7 +153,7 @@ func testGetAllUsers(storage Storage, t *testing.T) {
 	}
 }
 
-func testStoringNewTx(storage Storage, t *testing.T) {
+func testStoringNewTx(storage *EncryptedStorage, t *testing.T) {
 	userID := []byte("userID")
 	rawTransaction := "0x0123456789"
 

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -32,8 +32,15 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 	// create the account manager with a single unauthenticated connection
 	hostRPCBindAddrWS := wecommon.WSProtocol + config.NodeRPCWebsocketAddress
 	hostRPCBindAddrHTTP := wecommon.HTTPProtocol + config.NodeRPCHTTPAddress
+
 	// start the database
-	databaseStorage, err := storage.New(config.DBType, config.DBConnectionURL, config.DBPathOverride)
+	// TODO fix passing this random key to next enclave and not generating it here every time we start the wallet extension
+	randomKey, err := wecommon.GenerateRandomKey(32)
+	if err != nil {
+		logger.Crit("unable to generate random encryption key", log.ErrKey, err)
+		os.Exit(1)
+	}
+	databaseStorage, err := storage.New(config.DBType, config.DBConnectionURL, config.DBPathOverride, randomKey)
 	if err != nil {
 		logger.Crit("unable to create database to store viewing keys ", log.ErrKey, err)
 		os.Exit(1)


### PR DESCRIPTION
### Why this change is needed

We want to store encrypted data in the database with the key generated inside the gateway (which runs inside an enclave).
By encrypting data ourselves we can use "normal" database and avoid EdgelessDB.

### What changes were made as part of this PR

- Random key generator (this key is then used for symmetric encryption)
- Encryptor which handles all the encryption/decryption (It uses AES-GCM encryption with key generated above and random nonce)
- EncryptedStorage type
- Usage of EncryptedStorage to store data in the database
- We store `userID` field not only encrypted but also as a `hash`, because we need to query it in the database and querying encrypted data is impossible (different cypher text for same input text, due to nonces). 

At the moment I only implemented changes to sqlite database and after the confirmation that this is the approach we want to go with I can adapt it to MariaDB/CosmosDB. 

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


