### PR TITLE
remove github run number from DNS name for sequencer and validators

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -199,7 +199,7 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ vars.AZURE_RESOURCE_PREFIX }}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}" \
+            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}" \
             --tags deploygroup=ObscuroNode-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_L2 }}=true \
             --vnet-name ${{ github.event.inputs.testnet_type }}-virtual-network --subnet ${{ github.event.inputs.testnet_type }}-sub-network \
             --size Standard_DC8_v2 --storage-sku StandardSSD_LRS --image ObscuroConfUbuntu \
@@ -283,8 +283,8 @@ jobs:
                -message_bus_contract_addr=${{needs.build.outputs.MSG_BUS_CONTRACT_ADDR}} \
                -l1_start=${{needs.build.outputs.L1_START_HASH}} \
                -private_key=${{ secrets[matrix.node_pk_lookup] }} \
-               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
-               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
+               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
                -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
@@ -310,9 +310,9 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
 
   deploy-l2-contracts:
     needs:
@@ -329,7 +329,7 @@ jobs:
         shell: bash
         run: |
           go run ./testnet/launcher/l2contractdeployer/cmd \
-          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com \
+          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com \
           -l1_http_url=${{ secrets.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.ACCOUNT_PK_WORKER }} \

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -122,7 +122,7 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ vars.AZURE_RESOURCE_PREFIX }}-${{ github.event.inputs.node_id }}-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}" \
+            --public-ip-address-dns-name "obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}" \
             --tags deploygroup=ObscuroNode-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_L2 }}=true \
             --vnet-name ${{ github.event.inputs.testnet_type }}-virtual-network --subnet ${{ github.event.inputs.testnet_type }}-sub-network \
             --size Standard_DC8_v2 --storage-sku StandardSSD_LRS --image ObscuroConfUbuntu \
@@ -203,8 +203,8 @@ jobs:
                -message_bus_contract_addr=${{ github.event.inputs.MSG_BUS_CONTRACT_ADDR }} \
                -l1_start=${{ github.event.inputs.L1_START_HASH }} \
                -private_key=${{  secrets.ADD_NEW_NODE_PRIVATE_KEY }} \
-               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
-               -host_public_p2p_addr=obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
+               -host_public_p2p_addr=obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
                -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
@@ -261,4 +261,4 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-${{ github.event.inputs.node_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -166,8 +166,8 @@ jobs:
               -host_id=${{ vars[matrix.node_addr_lookup] }} \
               -l1_ws_url=${{ secrets[matrix.node_l1_ws_lookup] }} \
               -private_key=${{ secrets[matrix.node_pk_lookup] }} \
-              -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ needs.build.outputs.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
-              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ needs.build.outputs.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+              -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
+              -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
               -host_p2p_port=10000 \
               -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
               -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
@@ -193,8 +193,8 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ needs.build.outputs.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}-${{ needs.build.outputs.VM_BUILD_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
 
   deploy-faucet-on-dispatch:
     uses: ./.github/workflows/manual-deploy-testnet-faucet.yml


### PR DESCRIPTION
### Why this change is needed

At the moment we have github run number in DNS name for our Ten nodes. This makes DNS names different after every redeploy.
Having constant DNS names for our validators is necessary for load balancing with Azure gateway (if we want to remove manual work after every redeploy) and it also allows us to get rid of load balancer that points to the second validator for dexynth node.

### What changes were made as part of this PR

Removed github run number from dns name and changed that DNS name in all the places where it was used.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


