### PR TITLE
Fix for gas payment overmint

### DIFF
--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -216,9 +216,12 @@ func executeTransaction(
 			return receipt, err
 		}
 
+		// Synthetic transactions and ten zen are free. Do not increase the balancec of the coinbase.
+		isPaidProcessing := !cfg.NoBaseFee
+
 		// Do not increase the balance of zero address as it is the contract deployment address.
 		// Doing so might cause weird interactions.
-		if header.Coinbase.Big().Cmp(gethcommon.Big0) != 0 {
+		if header.Coinbase.Big().Cmp(gethcommon.Big0) != 0 && isPaidProcessing {
 			gasUsed := big.NewInt(0).SetUint64(receipt.GasUsed)
 			executionGasCost := big.NewInt(0).Mul(gasUsed, header.BaseFee)
 			// As the baseFee is burned, we add it back to the coinbase.


### PR DESCRIPTION
### Why this change is needed

gen_ten_40 has revealed an issue with baseFee being payed twice for transactions. This is due to the zen token issuing.

### What changes were made as part of this PR

Made it so execution gas payment only happens for evm runs that are configured to burn the baseFee from the sender, which is not the case for synthetic transactions.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


