### PR TITLE
cache receipts

### DIFF
--- a/go/enclave/core/event_types.go
+++ b/go/enclave/core/event_types.go
@@ -33,6 +33,7 @@ type TxExecResult struct {
 	Receipt          *types.Receipt
 	CreatedContracts map[gethcommon.Address]*ContractVisibilityConfig
 	Tx               *types.Transaction
+	From             *gethcommon.Address
 	Err              error
 }
 
@@ -43,7 +44,6 @@ type InternalReceipt struct {
 	CumulativeGasUsed uint64
 	EffectiveGasPrice *uint64
 	CreatedContract   *gethcommon.Address
-	TxContent         []byte
 	TxHash            gethcommon.Hash
 	BlockHash         gethcommon.Hash
 	BlockNumber       *big.Int

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -242,7 +242,7 @@ func NewEnclave(
 		registry,
 		config.GasLocalExecutionCapFlag,
 	)
-	rpcEncryptionManager := rpc.NewEncryptionManager(ecies.ImportECDSA(obscuroKey), storage, registry, crossChainProcessors, service, config, gasOracle, storage, blockProcessor, chain, logger)
+	rpcEncryptionManager := rpc.NewEncryptionManager(ecies.ImportECDSA(obscuroKey), storage, cachingService, registry, crossChainProcessors, service, config, gasOracle, storage, blockProcessor, chain, logger)
 	subscriptionManager := events.NewSubscriptionManager(storage, registry, config.ObscuroChainID, logger)
 
 	// ensure cached chain state data is up-to-date using the persisted batch data

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -248,7 +248,7 @@ func executeTransaction(
 	header.MixDigest = before
 	if err != nil {
 		s.RevertToSnapshot(snap)
-		return &core.TxExecResult{Receipt: receipt, Tx: t.Tx, Err: err}
+		return &core.TxExecResult{Receipt: receipt, Tx: t.Tx, From: &from, Err: err}
 	}
 
 	contractsWithVisibility := make(map[gethcommon.Address]*core.ContractVisibilityConfig)
@@ -256,7 +256,7 @@ func executeTransaction(
 		contractsWithVisibility[*contractAddress] = readVisibilityConfig(vmenv, contractAddress)
 	}
 
-	return &core.TxExecResult{Receipt: receipt, Tx: t.Tx, CreatedContracts: contractsWithVisibility}
+	return &core.TxExecResult{Receipt: receipt, Tx: t.Tx, From: &from, CreatedContracts: contractsWithVisibility}
 }
 
 const (

--- a/go/enclave/rpc/GetTransactionReceipt.go
+++ b/go/enclave/rpc/GetTransactionReceipt.go
@@ -1,8 +1,15 @@
 package rpc
 
 import (
+	"context"
 	"errors"
 	"fmt"
+
+	"github.com/ten-protocol/go-ten/go/enclave/storage"
+	"github.com/ten-protocol/go-ten/go/enclave/storage/enclavedb"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ten-protocol/go-ten/go/common/errutil"
@@ -31,6 +38,30 @@ func GetTransactionReceiptExecute(builder *CallBuilder[gethcommon.Hash, map[stri
 	requester := builder.VK.AccountAddress
 	rpc.logger.Trace("Get receipt for ", log.TxKey, txHash, "requester", requester.Hex())
 
+	rec, _ := rpc.cacheService.ReadReceipt(builder.ctx, txHash)
+	if rec != nil {
+		// receipt found in cache
+		// we need to check whether the requester is the sender
+		if rec.From == requester {
+			logs := rec.Receipt.Logs
+			if rec.To != nil && *rec.To != (gethcommon.Address{}) {
+				// we need to filter the logs.
+				ctr, err := rpc.storage.ReadContract(builder.ctx, *rec.To)
+				if err != nil {
+					return fmt.Errorf("could not read contract in eth_getTransactionReceipt request. Cause: %w", err)
+				}
+				logs, err = filterLogs(builder.ctx, rpc.storage, rec.Receipt.Logs, ctr, requester)
+				if err != nil {
+					return fmt.Errorf("could not filter cached logs in eth_getTransactionReceipt request. Cause: %w", err)
+				}
+			}
+			r := marshalReceipt(rec.Receipt, logs, rec.From, rec.To)
+			builder.ReturnValue = &r
+			rpc.logger.Trace("Successfully retrieved receipt from cache for ", log.TxKey, txHash, "rec", rec)
+			return nil
+		}
+	}
+
 	exists, err := rpc.storage.ExistsTransactionReceipt(builder.ctx, txHash)
 	if err != nil {
 		return fmt.Errorf("could not retrieve transaction receipt in eth_getTransactionReceipt request. Cause: %w", err)
@@ -41,7 +72,7 @@ func GetTransactionReceiptExecute(builder *CallBuilder[gethcommon.Hash, map[stri
 	}
 
 	// We retrieve the transaction receipt.
-	receipt, err := rpc.storage.GetTransactionReceipt(builder.ctx, txHash, requester, false)
+	receipt, err := rpc.storage.GetFilteredInternalReceipt(builder.ctx, txHash, requester, false)
 	if err != nil {
 		rpc.logger.Trace("error getting tx receipt", log.TxKey, txHash, log.ErrKey, err)
 		if errors.Is(err, errutil.ErrNotFound) {
@@ -56,4 +87,75 @@ func GetTransactionReceiptExecute(builder *CallBuilder[gethcommon.Hash, map[stri
 	r := receipt.MarshalToJson()
 	builder.ReturnValue = &r
 	return nil
+}
+
+// at this point the requester is the tx sender
+func filterLogs(ctx context.Context, storage storage.Storage, logs []*types.Log, ctr *enclavedb.Contract, requester *gethcommon.Address) ([]*types.Log, error) {
+	filtered := make([]*types.Log, 0)
+	for _, l := range logs {
+
+		eventSig := l.Topics[0]
+		eventType, err := storage.ReadEventType(ctx, ctr.Address, eventSig)
+		if err != nil {
+			return nil, fmt.Errorf("could not read event type in eth_getTransactionReceipt request. Cause: %w", err)
+		}
+		// event visibility logic
+		canView := eventType.ConfigPublic ||
+			eventType.IsPublic() ||
+			(eventType.AutoPublic != nil && *eventType.AutoPublic) ||
+			(eventType.SenderCanView != nil && *eventType.SenderCanView) ||
+			(eventType.Topic1CanView != nil && *eventType.Topic1CanView && isAddress(l.Topics, 1, requester)) ||
+			(eventType.Topic2CanView != nil && *eventType.Topic2CanView && isAddress(l.Topics, 2, requester)) ||
+			(eventType.Topic3CanView != nil && *eventType.Topic3CanView && isAddress(l.Topics, 3, requester)) ||
+			(eventType.AutoVisibility && (isAddress(l.Topics, 1, requester) || isAddress(l.Topics, 2, requester) || isAddress(l.Topics, 3, requester)))
+
+		if canView {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered, nil
+}
+
+func isAddress(topics []gethcommon.Hash, nr int, requester *gethcommon.Address) bool {
+	if len(topics) < nr+1 {
+		return false
+	}
+	topic := gethcommon.Address(topics[nr].Bytes())
+	return topic == *requester
+}
+
+// marshalReceipt marshals a transaction receipt into a JSON object.
+// taken from geth
+func marshalReceipt(receipt *types.Receipt, logs []*types.Log, from, to *gethcommon.Address) map[string]interface{} {
+	fields := map[string]interface{}{
+		"blockHash":         receipt.BlockHash.Hex(),
+		"blockNumber":       hexutil.Uint64(receipt.BlockNumber.Uint64()),
+		"transactionHash":   receipt.TxHash.Hex(),
+		"transactionIndex":  hexutil.Uint64(receipt.TransactionIndex),
+		"from":              from,
+		"to":                to,
+		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
+		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
+		"contractAddress":   nil,
+		"logs":              logs,
+		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(receipt.Type),
+		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
+	}
+
+	// Assign receipt status or post state.
+	if len(receipt.PostState) > 0 {
+		fields["root"] = hexutil.Bytes(receipt.PostState)
+	} else {
+		fields["status"] = hexutil.Uint(receipt.Status)
+	}
+	if receipt.Logs == nil {
+		fields["logs"] = []*types.Log{}
+	}
+
+	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
+	if receipt.ContractAddress != (gethcommon.Address{}) {
+		fields["contractAddress"] = receipt.ContractAddress
+	}
+	return fields
 }

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -22,6 +22,7 @@ type EncryptionManager struct {
 	chain                  l2chain.ObscuroChain
 	enclavePrivateKeyECIES *ecies.PrivateKey
 	storage                storage.Storage
+	cacheService           *storage.CacheService
 	registry               components.BatchRegistry
 	processors             *crosschain.Processors
 	service                nodetype.NodeType
@@ -33,9 +34,10 @@ type EncryptionManager struct {
 	whitelist              *privacy.Whitelist
 }
 
-func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey, storage storage.Storage, registry components.BatchRegistry, processors *crosschain.Processors, service nodetype.NodeType, config *config.EnclaveConfig, oracle gas.Oracle, blockResolver storage.BlockResolver, l1BlockProcessor components.L1BlockProcessor, chain l2chain.ObscuroChain, logger gethlog.Logger) *EncryptionManager {
+func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey, storage storage.Storage, cacheService *storage.CacheService, registry components.BatchRegistry, processors *crosschain.Processors, service nodetype.NodeType, config *config.EnclaveConfig, oracle gas.Oracle, blockResolver storage.BlockResolver, l1BlockProcessor components.L1BlockProcessor, chain l2chain.ObscuroChain, logger gethlog.Logger) *EncryptionManager {
 	return &EncryptionManager{
 		storage:                storage,
+		cacheService:           cacheService,
 		registry:               registry,
 		processors:             processors,
 		service:                service,

--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -187,7 +187,7 @@ func (cs *CacheService) ReadEventType(ctx context.Context, contractAddress gethc
 }
 
 func (cs *CacheService) ReadConvertedHeader(ctx context.Context, batchHash common.L2BatchHash, onCacheMiss func(any) (*types.Header, error)) (*types.Header, error) {
-	return getCachedValue(ctx, cs.convertedGethHeaderCache, cs.logger, batchHash, blockHeaderCost, onCacheMiss, false)
+	return getCachedValue(ctx, cs.convertedGethHeaderCache, cs.logger, batchHash, blockHeaderCost, onCacheMiss, true)
 }
 
 // getCachedValue - returns the cached value for the provided key. If the key is not found, then invoke the 'onCacheMiss' function

--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -82,6 +82,9 @@ func NewCacheService(logger gethlog.Logger) *CacheService {
 	nrBatches := int64(50)
 	ristrettoStoreForBatches := newCache(logger, nrBatches, nrBatches*batchCost)
 
+	nrReceiptsToCache := int64(10_000)
+	ristrettoStoreForReceipts := newCache(logger, nrReceiptsToCache, nrReceiptsToCache*receiptCost)
+
 	return &CacheService{
 		blockCache:               cache.New[*types.Header](ristrettoStore),
 		batchCacheBySeqNo:        cache.New[*common.BatchHeader](ristrettoStore),
@@ -93,8 +96,7 @@ func NewCacheService(logger gethlog.Logger) *CacheService {
 		eventTypeCache:           cache.New[*enclavedb.EventType](ristrettoStore),
 		convertedGethHeaderCache: cache.New[*types.Header](ristrettoStore),
 
-		// todo separate store
-		receiptCache:     cache.New[*CachedReceipt](ristrettoStore),
+		receiptCache:     cache.New[*CachedReceipt](ristrettoStoreForReceipts),
 		lastBatchesCache: cache.New[*core.Batch](ristrettoStoreForBatches),
 		logger:           logger,
 	}

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -238,7 +238,7 @@ func loadReceiptList(ctx context.Context, db *sql.DB, requestingAccount *gethcom
 	}
 	var queryParams []any
 
-	query := "select b.hash, b.height, curr_tx.hash, curr_tx.idx, rec.post_state, rec.status, rec.cumulative_gas_used, rec.effective_gas_price, rec.created_contract_address, curr_tx.content, tx_sender.address, tx_contr.address, curr_tx.type "
+	query := "select b.hash, b.height, curr_tx.hash, curr_tx.idx, rec.post_state, rec.status, rec.cumulative_gas_used, rec.effective_gas_price, rec.created_contract_address, tx_sender.address, tx_contr.address, curr_tx.type "
 	query += baseReceiptJoin
 
 	// visibility
@@ -286,7 +286,7 @@ func onRowWithReceipt(rows *sql.Rows) (*core.InternalReceipt, error) {
 	var txIndex *uint
 	var blockHash, transactionHash *gethcommon.Hash
 	var blockNumber *uint64
-	res := []any{&blockHash, &blockNumber, &transactionHash, &txIndex, &r.PostState, &r.Status, &r.CumulativeGasUsed, &r.EffectiveGasPrice, &r.CreatedContract, &r.TxContent, &r.From, &r.To, &r.TxType}
+	res := []any{&blockHash, &blockNumber, &transactionHash, &txIndex, &r.PostState, &r.Status, &r.CumulativeGasUsed, &r.EffectiveGasPrice, &r.CreatedContract, &r.From, &r.To, &r.TxType}
 
 	err := rows.Scan(res...)
 	if err != nil {
@@ -306,7 +306,7 @@ func onRowWithReceipt(rows *sql.Rows) (*core.InternalReceipt, error) {
 // todo always pass in the actual batch hashes because of reorgs, or make sure to clean up log entries from discarded batches
 func loadReceiptsAndEventLogs(ctx context.Context, db *sql.DB, requestingAccount *gethcommon.Address, whereCondition string, whereParams []any, withReceipts bool) ([]*core.InternalReceipt, []*types.Log, error) {
 	logsQuery := " et.event_sig, t1.topic, t2.topic, t3.topic, datablob, log_idx, b.hash, b.height, curr_tx.hash, curr_tx.idx, c.address "
-	receiptQuery := " rec.post_state, rec.status, rec.cumulative_gas_used, rec.effective_gas_price, rec.created_contract_address, curr_tx.content, tx_sender.address, tx_contr.address, curr_tx.type "
+	receiptQuery := " rec.post_state, rec.status, rec.cumulative_gas_used, rec.effective_gas_price, rec.created_contract_address, tx_sender.address, tx_contr.address, curr_tx.type "
 
 	query := "select " + logsQuery
 	if withReceipts {
@@ -417,7 +417,7 @@ func onRowWithEventLogAndReceipt(rows *sql.Rows, withReceipts bool) (*core.Inter
 
 	if withReceipts {
 		// when loading receipts, add the extra fields
-		res = append(res, &r.PostState, &r.Status, &r.CumulativeGasUsed, &r.EffectiveGasPrice, &r.CreatedContract, &r.TxContent, &r.From, &r.To, &r.TxType)
+		res = append(res, &r.PostState, &r.Status, &r.CumulativeGasUsed, &r.EffectiveGasPrice, &r.CreatedContract, &r.From, &r.To, &r.TxType)
 	}
 
 	err := rows.Scan(res...)

--- a/go/enclave/storage/events_storage.go
+++ b/go/enclave/storage/events_storage.go
@@ -18,12 +18,13 @@ import (
 
 // responsible for saving event logs
 type eventsStorage struct {
+	db             enclavedb.EnclaveDB
 	cachingService *CacheService
 	logger         gethlog.Logger
 }
 
-func newEventsStorage(cachingService *CacheService, logger gethlog.Logger) *eventsStorage {
-	return &eventsStorage{cachingService: cachingService, logger: logger}
+func newEventsStorage(cachingService *CacheService, db enclavedb.EnclaveDB, logger gethlog.Logger) *eventsStorage {
+	return &eventsStorage{cachingService: cachingService, db: db, logger: logger}
 }
 
 func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql.Tx, batch *common.BatchHeader, txExecResult *core.TxExecResult) error {
@@ -52,6 +53,11 @@ func (es *eventsStorage) storeReceiptAndEventLogs(ctx context.Context, dbTX *sql
 		}
 	}
 
+	es.cachingService.CacheReceipt(ctx, &CachedReceipt{
+		Receipt: txExecResult.Receipt,
+		From:    txExecResult.From,
+		To:      txExecResult.Tx.To(),
+	})
 	return nil
 }
 

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -97,8 +97,8 @@ type SharedSecretStorage interface {
 type TransactionStorage interface {
 	// GetTransaction - returns the positional metadata of the tx by hash
 	GetTransaction(ctx context.Context, txHash common.L2TxHash) (*types.Transaction, common.L2BatchHash, uint64, uint64, error)
-	// GetTransactionReceipt - returns the receipt of a tx by tx hash
-	GetTransactionReceipt(ctx context.Context, txHash common.L2TxHash, requester *gethcommon.Address, syntheticTx bool) (*core.InternalReceipt, error)
+	// GetFilteredReceipt - returns the receipt of a tx with event logs visible to the requester
+	GetFilteredInternalReceipt(ctx context.Context, txHash common.L2TxHash, requester *gethcommon.Address, syntheticTx bool) (*core.InternalReceipt, error)
 	ExistsTransactionReceipt(ctx context.Context, txHash common.L2TxHash) (bool, error)
 }
 
@@ -153,6 +153,7 @@ type Storage interface {
 	StateDB() state.Database
 
 	ReadContract(ctx context.Context, address gethcommon.Address) (*enclavedb.Contract, error)
+	ReadEventType(ctx context.Context, contractAddress gethcommon.Address, eventSignature gethcommon.Hash) (*enclavedb.EventType, error)
 }
 
 type ScanStorage interface {

--- a/go/enclave/system/hooks.go
+++ b/go/enclave/system/hooks.go
@@ -79,7 +79,7 @@ func (s *systemContractCallbacks) Load() error {
 		return fmt.Errorf("genesis batch does not have enough transactions")
 	}
 
-	receipt, err := s.storage.GetTransactionReceipt(context.Background(), batch.Transactions[1].Hash(), nil, true)
+	receipt, err := s.storage.GetFilteredInternalReceipt(context.Background(), batch.Transactions[1].Hash(), nil, true)
 	if err != nil {
 		s.logger.Error("Load: Failed fetching receipt", "transactionHash", batch.Transactions[1].Hash().Hex(), "error", err)
 		return fmt.Errorf("failed fetching receipt %w", err)


### PR DESCRIPTION
### Why this change is needed

Retrieving tx receipts is expensive because the SQL query is complex.
The most common use case is that users will request receipts for recent transactions.

### What changes were made as part of this PR

- introduce a cache of the most recent transactions
- implement the event visibility logic in-memory to filter out the logs from the cached receipts
- unrelated - there was an issue in the caching service where the 'cost' of some cache entries was wrong
- unrelated - remove unnecessary `tx.content` column from the receipt SQL query

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


