### PR TITLE
tagged release images

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -9,7 +9,6 @@ on:
         description: 'Tag to build and push (leave empty for latest)'
         required: false
         default: ''
-  pull_request:
 
 jobs:
   build-and-push:
@@ -45,7 +44,7 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
-          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuro/enclave:${VERSION} --build-arg TESTMODE=true -f dockerfiles/enclave.Dockerfile .
-          docker push testnetobscuronet.azurecr.io/obscuro/enclave:${VERSION}
-          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuro/host:${VERSION} -f dockerfiles/host.Dockerfile .
-          docker push testnetobscuronet.azurecr.io/obscuro/host:${VERSION}
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/enclave:${VERSION} --build-arg TESTMODE=true -f dockerfiles/enclave.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/enclave:${VERSION}
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuronet/host:${VERSION} -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuronet/host:${VERSION}

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -1,0 +1,50 @@
+name: 'Build and Push Release Images'
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and push (leave empty for latest)'
+        required: false
+        default: ''
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.8
+
+      - name: 'Login to Azure docker registry'
+        uses: azure/docker-login@v1
+        with:
+          login-server: testnetobscuronet.azurecr.io
+          username: testnetobscuronet
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 'Get version'
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: 'Build and push obscuro node images'
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuro/enclave:${VERSION} --build-arg TESTMODE=true -f dockerfiles/enclave.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuro/enclave:${VERSION}
+          DOCKER_BUILDKIT=1 docker build -t testnetobscuronet.azurecr.io/obscuro/host:${VERSION} -f dockerfiles/host.Dockerfile .
+          docker push testnetobscuronet.azurecr.io/obscuro/host:${VERSION}

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       tag:
         description: 'Tag to build and push (leave empty for latest)'
-        required: false
+        required: true
         default: ''
 
 jobs:
@@ -37,7 +37,9 @@ jobs:
           elif [ -n "${{ github.event.inputs.tag }}" ]; then
             echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION=latest" >> $GITHUB_OUTPUT
+            # Fetch the latest tag from the repository
+            LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+            echo "VERSION=${LATEST_TAG}" >> $GITHUB_OUTPUT
           fi
 
       - name: 'Build and push obscuro node images'

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -9,6 +9,7 @@ on:
         description: 'Tag to build and push (leave empty for latest)'
         required: false
         default: ''
+  pull_request:
 
 jobs:
   build-and-push:


### PR DESCRIPTION
### Why this change is needed

currently images built every CI run and overwriting latest, this will set checkpoint images which can be reused and easier to manage.

### What changes were made as part of this PR

new workflow to build and push images based on release tags.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


