### PR TITLE
Single pass gas estimation.

### DIFF
--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -53,7 +53,7 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	MessageBusAddressFlag:         flag.NewStringFlag(MessageBusAddressFlag, "", "The address of the L1 message bus contract owned by the management contract."),
 	MaxBatchSizeFlag:              flag.NewUint64Flag(MaxBatchSizeFlag, 1024*55, "The maximum size a batch is allowed to reach uncompressed"),
 	MaxRollupSizeFlag:             flag.NewUint64Flag(MaxRollupSizeFlag, 1024*128, "The maximum size a rollup is allowed to reach"),
-	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, params.InitialBaseFee/10, ""),
+	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, params.InitialBaseFee, ""),
 	L2CoinbaseFlag:                flag.NewStringFlag(L2CoinbaseFlag, "0xd6C9230053f45F873Cb66D8A02439380a37A4fbF", ""),
 	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 3_000_000_000, "Max gas that can be executed in a single batch"),
 	TenGenesisFlag:                flag.NewStringFlag(TenGenesisFlag, "", "The json string with the obscuro genesis"),

--- a/go/config/enclave_cli_flags.go
+++ b/go/config/enclave_cli_flags.go
@@ -53,7 +53,7 @@ var EnclaveFlags = map[string]*flag.TenFlag{
 	MessageBusAddressFlag:         flag.NewStringFlag(MessageBusAddressFlag, "", "The address of the L1 message bus contract owned by the management contract."),
 	MaxBatchSizeFlag:              flag.NewUint64Flag(MaxBatchSizeFlag, 1024*55, "The maximum size a batch is allowed to reach uncompressed"),
 	MaxRollupSizeFlag:             flag.NewUint64Flag(MaxRollupSizeFlag, 1024*128, "The maximum size a rollup is allowed to reach"),
-	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, params.InitialBaseFee, ""),
+	L2BaseFeeFlag:                 flag.NewUint64Flag(L2BaseFeeFlag, params.InitialBaseFee/10, ""),
 	L2CoinbaseFlag:                flag.NewStringFlag(L2CoinbaseFlag, "0xd6C9230053f45F873Cb66D8A02439380a37A4fbF", ""),
 	GasBatchExecutionLimit:        flag.NewUint64Flag(GasBatchExecutionLimit, 3_000_000_000, "Max gas that can be executed in a single batch"),
 	TenGenesisFlag:                flag.NewStringFlag(TenGenesisFlag, "", "The json string with the obscuro genesis"),

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -374,8 +374,7 @@ func ExecuteObsCall(
 	gp := gethcore.GasPool(gasEstimationCap)
 	gp.SetGas(gasEstimationCap)
 
-	cleanState := s.Copy()
-	cleanState.Prepare(chainConfig.Rules(header.Number, true, 0), msg.From, ethHeader.Coinbase, msg.To, nil, msg.AccessList)
+	cleanState := createCleanState(s, msg, ethHeader, chainConfig)
 
 	chain, vmCfg := initParams(storage, gethEncodingService, config, noBaseFee, nil)
 	blockContext := gethcore.NewEVMBlockContext(ethHeader, chain, nil)
@@ -405,6 +404,12 @@ func ExecuteObsCall(
 	}
 
 	return result, nil
+}
+
+func createCleanState(s *state.StateDB, msg *gethcore.Message, ethHeader *types.Header, chainConfig *params.ChainConfig) *state.StateDB {
+	cleanState := s.Copy()
+	cleanState.Prepare(chainConfig.Rules(ethHeader.Number, true, 0), msg.From, ethHeader.Coinbase, msg.To, nil, msg.AccessList)
+	return cleanState
 }
 
 func initParams(storage storage.Storage, gethEncodingService gethencoding.EncodingService, config config.EnclaveConfig, noBaseFee bool, l gethlog.Logger) (*ObscuroChainContext, vm.Config) {

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -53,7 +53,7 @@ func EstimateGasValidate(reqParams []any, builder *CallBuilder[CallParamsWithBlo
 }
 
 // EstimateGasExecute - performs the gas estimation based on the provided parameters and the local environment configuration.
-// Will accomodate l1 gas cost and stretch the final gas estimation.
+// Will accommodate l1 gas cost and stretch the final gas estimation.
 func EstimateGasExecute(builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64], rpc *EncryptionManager) error {
 	err := authenticateFrom(builder.VK, builder.From)
 	if err != nil {
@@ -229,7 +229,7 @@ func (rpc *EncryptionManager) estimateGasSinglePass(ctx context.Context, args *g
 	// There can be further discrepancies in the execution due to storage and other factors.
 	gasUsedBig := big.NewInt(0).SetUint64(result.UsedGas)
 	gasUsedBig.Add(gasUsedBig, big.NewInt(0).SetUint64(calculateProxyOverhead(args)))
-	// Add 20% overhead to gas used - this is a rough accomodation for
+	// Add 20% overhead to gas used - this is a rough accommodation for
 	// warm storage slots.
 	gasUsedBig.Mul(gasUsedBig, big.NewInt(120))
 	gasUsedBig.Div(gasUsedBig, big.NewInt(100))

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -183,6 +183,12 @@ func calculateProxyOverhead(txArgs *gethapi.TransactionArgs) uint64 {
 // estimateGasSinglePass - deduces the simulation params from the call parameters and the local environment configuration.
 // will override the gas limit with one provided in transaction if lower. Furthermore figures out the gas cap and the allowance
 // for the from address.
+// In the binary search approach geth uses, the high of the range for gas limit is where our single pass runs.
+// For example, if you estimate gas for a swap, the simulation EVM will be configured to run at the highest possible gas cap.
+// This allows the maximum gas for running the call. Then we look at the gas used and return this with a couple modifications.
+// The modifications are an overhead buffer and a 20% increase to account for warm storage slots. This is because the stateDB
+// for the head batch might not be fully clean in terms of the running call. Cold storage slots cost far more than warm ones to
+// read and write.
 func (rpc *EncryptionManager) estimateGasSinglePass(ctx context.Context, args *gethapi.TransactionArgs, blkNumber *gethrpc.BlockNumber, gasCap uint64) (hexutil.Uint64, *big.Int, common.SystemError) {
 	maxGasCap := rpc.calculateMaxGasCap(ctx, gasCap, args.Gas)
 	// allowance will either be the maxGasCap or the balance allowance.


### PR DESCRIPTION
### Why this change is needed

Gas estimation currently is doing a binary search for the most optimal gas. This maxes it out and makes it run at maximum returning the gas used. Inefficient for complex contracts that have non deterministic logic based on provided gas, but those should potentially be handled through a separate rpc. 

### What changes were made as part of this PR

Removed the binary search doEstimateGas in favour of estimateGasSinglePass

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


