### PR TITLE
Use log file when starting Ten Gateway from launcher

### DIFF
--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -32,7 +32,7 @@ func (n *DockerGateway) Start() error {
 		"--nodePortWS", fmt.Sprintf("%d", n.cfg.tenNodeWSPort),
 		"--nodeHost", n.cfg.tenNodeHost,
 		"--dbType", "sqlite",
-		"--logPath", "sys_out",
+		"--logPath", "gateway_logs.log",
 		"--rateLimitUserComputeTime", fmt.Sprintf("%d", n.cfg.rateLimitUserComputeTime),
 	}
 


### PR DESCRIPTION
### Why this change is needed

For hosted gateway we use grafana and we have agents running which use `std_out` to get logs. 
When stating the gateway from `go run testnet/launcher/cmd` we then have no way of getting logs for the gateway.

### What changes were made as part of this PR

Changed log output from `std_out` to logfile.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


