### PR TITLE
fix debug log endpoint

### DIFF
--- a/tools/walletextension/rpcapi/debug_api.go
+++ b/tools/walletextension/rpcapi/debug_api.go
@@ -64,7 +64,7 @@ func (api *DebugAPI) EventLogRelevancy(ctx context.Context, crit common.FilterCr
 			tryUntilAuthorised: true,
 		},
 		"debug_eventLogRelevancy",
-		crit,
+		common.SerializableFilterCriteria(crit),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Why this change is needed

the debug endpoint didn't work properly with "from"  blocks, because we were serialising the wrong type

### What changes were made as part of this PR

serialise the correct type

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


