### PR TITLE
change default log path in local testnet gateway back to sys_out

### DIFF
--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -32,7 +32,7 @@ func (n *DockerGateway) Start() error {
 		"--nodePortWS", fmt.Sprintf("%d", n.cfg.tenNodeWSPort),
 		"--nodeHost", n.cfg.tenNodeHost,
 		"--dbType", "sqlite",
-		"--logPath", "gateway_logs.log",
+		"--logPath", "sys_out",
 		"--rateLimitUserComputeTime", fmt.Sprintf("%d", n.cfg.rateLimitUserComputeTime),
 	}
 


### PR DESCRIPTION
### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


