### PR TITLE
Set beacon env vars for dev/uat/sep

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -216,16 +216,6 @@ jobs:
         shell: bash
         run: sleep 60
 
-      # Set the beacon URL for the L1 chain based on the environment
-      - name: Set L1 Beacon URL
-        id: set_beacon_url
-        run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" ]]; then
-            echo "L1_BEACON_URL=${{ vars.L1_BEACON_URL }}" >> $GITHUB_OUTPUT
-          else
-            echo "L1_BEACON_URL=dev-testnet-eth2network.uksouth.cloudapp.azure.com:12600" >> $GITHUB_OUTPUT
-          fi
-
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
@@ -304,7 +294,7 @@ jobs:
                -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
                -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
-               -l1_beacon_url=${{ steps.set_beacon_url.outputs.L1_BEACON_URL }} \
+               -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
                -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \
                -postgres_db_host=postgres://tenuser:${{ secrets.TEN_POSTGRES_USER_PWD }}@postgres-ten-${{  github.event.inputs.testnet_type }}.postgres.database.azure.com:5432/ \
                start'

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -147,16 +147,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      # Set the beacon URL for the L1 chain based on the environment
-      - name: Set L1 Beacon URL
-        id: set_beacon_url
-        run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" ]]; then
-            echo "L1_BEACON_URL=${{ vars.L1_BEACON_URL }}" >> $GITHUB_OUTPUT
-          else
-            echo "L1_BEACON_URL=dev-testnet-eth2network.uksouth.cloudapp.azure.com:12600" >> $GITHUB_OUTPUT
-          fi
-
       - name: 'Update Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
@@ -187,7 +177,8 @@ jobs:
               -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
               -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
               -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
-              -l1_beacon_url=${{ steps.set_beacon_url.outputs.L1_BEACON_URL }} \
+              -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
+              -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \
               -postgres_db_host=postgres://tenuser:${{ secrets.TEN_POSTGRES_USER_PWD }}@postgres-ten-${{  github.event.inputs.testnet_type }}.postgres.database.azure.com:5432/ \
               upgrade'
 


### PR DESCRIPTION
### Why this change is needed

UAT deploy is broken

### What changes were made as part of this PR

* use env vars the _correct_ way

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


