### PR TITLE
clear responsibilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,6 @@ require (
 	github.com/go-playground/validator/v10 v10.22.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,14 +12,12 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xP
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/FantasyJony/openzeppelin-merkle-tree-go v1.1.3 h1:KzMvCFet0baw6uJnxTE/His8YeRgaxlASd4/ISuTvzI=
 github.com/FantasyJony/openzeppelin-merkle-tree-go v1.1.3/go.mod h1:OiwyYqbtMkQH+VzA4b8lI+qHnExJy0fIdz+59/8nFes=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
-github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
-github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
@@ -175,9 +173,6 @@ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOW
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
-github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -20,4 +21,65 @@ type Cache interface {
 
 func NewCache(logger log.Logger) (Cache, error) {
 	return NewRistrettoCacheWithEviction(logger)
+}
+
+type Strategy uint8
+
+const (
+	NoCache     Strategy = iota
+	LatestBatch Strategy = iota
+	LongLiving  Strategy = iota
+
+	longCacheTTL  = 5 * time.Hour
+	shortCacheTTL = 1 * time.Minute
+)
+
+type Cfg struct {
+	Type        Strategy
+	DynamicType func() Strategy
+}
+
+func WithCache[R any](cache Cache, cfg *Cfg, cacheKey []byte, onCacheMiss func() (*R, error)) (*R, error) {
+	if cfg == nil {
+		return onCacheMiss()
+	}
+
+	cacheType := cfg.Type
+	if cfg.DynamicType != nil {
+		cacheType = cfg.DynamicType()
+	}
+
+	if cacheType == NoCache {
+		return onCacheMiss()
+	}
+
+	// we implement a custom cache eviction logic for the cache strategy of type LatestBatch.
+	// when a new batch is created, all entries with "LatestBatch" are considered evicted.
+	// elements not cached for a specific batch are not evicted
+	isEvicted := false
+	ttl := longCacheTTL
+	if cacheType == LatestBatch {
+		ttl = shortCacheTTL
+		isEvicted = cache.IsEvicted(cacheKey, ttl)
+	}
+
+	if !isEvicted {
+		cachedValue, foundInCache := cache.Get(cacheKey)
+		if foundInCache {
+			returnValue, ok := cachedValue.(*R)
+			if !ok {
+				return nil, fmt.Errorf("unexpected error. Invalid format cached. %v", cachedValue)
+			}
+			return returnValue, nil
+		}
+	}
+
+	result, err := onCacheMiss()
+
+	// cache only non-nil values
+	if err == nil && result != nil {
+		cache.Set(cacheKey, result, ttl)
+	}
+
+	return result, err
 }

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	"github.com/status-im/keycard-go/hexutils"
 
+	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"github.com/ten-protocol/go-ten/lib/gethfork/node"
-	"github.com/ten-protocol/go-ten/tools/walletextension/rpcapi"
-
-	"github.com/ten-protocol/go-ten/go/common/log"
 
 	"github.com/ten-protocol/go-ten/go/common/httputil"
 	"github.com/ten-protocol/go-ten/tools/walletextension/common"
@@ -20,7 +20,7 @@ import (
 
 // NewHTTPRoutes returns the http specific routes
 // todo - move these to the rpc framework.
-func NewHTTPRoutes(walletExt *rpcapi.Services) []node.Route {
+func NewHTTPRoutes(walletExt *services.Services) []node.Route {
 	return []node.Route{
 		{
 			Name: common.APIVersion1 + common.PathReady,
@@ -66,8 +66,8 @@ func NewHTTPRoutes(walletExt *rpcapi.Services) []node.Route {
 }
 
 func httpHandler(
-	walletExt *rpcapi.Services,
-	fun func(walletExt *rpcapi.Services, conn UserConn),
+	walletExt *services.Services,
+	fun func(walletExt *services.Services, conn UserConn),
 ) func(resp http.ResponseWriter, req *http.Request) {
 	return func(resp http.ResponseWriter, req *http.Request) {
 		httpRequestHandler(walletExt, resp, req, fun)
@@ -75,7 +75,7 @@ func httpHandler(
 }
 
 // Overall request handler for http requests
-func httpRequestHandler(walletExt *rpcapi.Services, resp http.ResponseWriter, req *http.Request, fun func(walletExt *rpcapi.Services, conn UserConn)) {
+func httpRequestHandler(walletExt *services.Services, resp http.ResponseWriter, req *http.Request, fun func(walletExt *services.Services, conn UserConn)) {
 	if walletExt.IsStopping() {
 		return
 	}
@@ -87,10 +87,10 @@ func httpRequestHandler(walletExt *rpcapi.Services, resp http.ResponseWriter, re
 }
 
 // readyRequestHandler is used to check whether the server is ready
-func readyRequestHandler(_ *rpcapi.Services, _ UserConn) {}
+func readyRequestHandler(_ *services.Services, _ UserConn) {}
 
 // This function handles request to /join endpoint. It is responsible to create new user (new key-pair) and store it to the db
-func joinRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func joinRequestHandler(walletExt *services.Services, conn UserConn) {
 	// audit()
 	// todo (@ziga) add protection against DDOS attacks
 	_, err := conn.ReadRequest()
@@ -116,7 +116,7 @@ func joinRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 // This function handles request to /authenticate endpoint.
 // In the request we receive message, signature and address in JSON as request body and userID and address as query parameters
 // We then check if message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
-func authenticateRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func authenticateRequestHandler(walletExt *services.Services, conn UserConn) {
 	// read the request
 	body, err := conn.ReadRequest()
 	if err != nil {
@@ -181,7 +181,7 @@ func authenticateRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 // This function handles request to /query endpoint.
 // In the query parameters address and userID are required. We check if provided address is registered for given userID
 // and return true/false in json response
-func queryRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func queryRequestHandler(walletExt *services.Services, conn UserConn) {
 	// read the request
 	_, err := conn.ReadRequest()
 	if err != nil {
@@ -233,7 +233,7 @@ func queryRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 
 // This function handles request to /revoke endpoint.
 // It requires userID as query parameter and deletes given user and all associated viewing keys
-func revokeRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func revokeRequestHandler(walletExt *services.Services, conn UserConn) {
 	// read the request
 	_, err := conn.ReadRequest()
 	if err != nil {
@@ -263,7 +263,7 @@ func revokeRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 }
 
 // Handles request to /health endpoint.
-func healthRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func healthRequestHandler(walletExt *services.Services, conn UserConn) {
 	// read the request
 	_, err := conn.ReadRequest()
 	if err != nil {
@@ -279,7 +279,7 @@ func healthRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
 }
 
 // Handles request to /network-health endpoint.
-func networkHealthRequestHandler(walletExt *rpcapi.Services, userConn UserConn) {
+func networkHealthRequestHandler(walletExt *services.Services, userConn UserConn) {
 	// read the request
 	_, err := userConn.ReadRequest()
 	if err != nil {
@@ -321,7 +321,7 @@ func networkHealthRequestHandler(walletExt *rpcapi.Services, userConn UserConn) 
 	}
 }
 
-func networkConfigRequestHandler(walletExt *rpcapi.Services, userConn UserConn) {
+func networkConfigRequestHandler(walletExt *services.Services, userConn UserConn) {
 	// read the request
 	_, err := userConn.ReadRequest()
 	if err != nil {
@@ -373,7 +373,7 @@ func networkConfigRequestHandler(walletExt *rpcapi.Services, userConn UserConn) 
 }
 
 // Handles request to /version endpoint.
-func versionRequestHandler(walletExt *rpcapi.Services, userConn UserConn) {
+func versionRequestHandler(walletExt *services.Services, userConn UserConn) {
 	// read the request
 	_, err := userConn.ReadRequest()
 	if err != nil {
@@ -388,7 +388,7 @@ func versionRequestHandler(walletExt *rpcapi.Services, userConn UserConn) {
 }
 
 // getMessageRequestHandler handles request to /getmessage endpoint.
-func getMessageRequestHandler(walletExt *rpcapi.Services, conn UserConn) {
+func getMessageRequestHandler(walletExt *services.Services, conn UserConn) {
 	// read the request
 	body, err := conn.ReadRequest()
 	if err != nil {

--- a/tools/walletextension/rpcapi/blockchain_api.go
+++ b/tools/walletextension/rpcapi/blockchain_api.go
@@ -6,6 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,11 +21,11 @@ import (
 )
 
 type BlockChainAPI struct {
-	we               *Services
+	we               *services.Services
 	storageWhitelist *privacy.Whitelist
 }
 
-func NewBlockChainAPI(we *Services) *BlockChainAPI {
+func NewBlockChainAPI(we *services.Services) *BlockChainAPI {
 	whitelist := privacy.NewWhitelist()
 	return &BlockChainAPI{
 		we:               we,
@@ -30,12 +34,12 @@ func NewBlockChainAPI(we *Services) *BlockChainAPI {
 }
 
 func (api *BlockChainAPI) ChainId() *hexutil.Big { //nolint:stylecheck
-	chainID, _ := UnauthenticatedTenRPCCall[hexutil.Big](context.Background(), api.we, &CacheCfg{CacheType: LongLiving}, "eth_chainId")
+	chainID, _ := UnauthenticatedTenRPCCall[hexutil.Big](context.Background(), api.we, &cache.Cfg{Type: cache.LongLiving}, "eth_chainId")
 	return chainID
 }
 
 func (api *BlockChainAPI) BlockNumber() hexutil.Uint64 {
-	nr, err := UnauthenticatedTenRPCCall[hexutil.Uint64](context.Background(), api.we, &CacheCfg{CacheType: LatestBatch}, "eth_blockNumber")
+	nr, err := UnauthenticatedTenRPCCall[hexutil.Uint64](context.Background(), api.we, &cache.Cfg{Type: cache.LatestBatch}, "eth_blockNumber")
 	if err != nil {
 		return hexutil.Uint64(0)
 	}
@@ -47,8 +51,8 @@ func (api *BlockChainAPI) GetBalance(ctx context.Context, address gethcommon.Add
 		ctx,
 		api.we,
 		&ExecCfg{
-			cacheCfg: &CacheCfg{
-				CacheTypeDynamic: func() CacheStrategy {
+			cacheCfg: &cache.Cfg{
+				DynamicType: func() cache.Strategy {
 					return cacheBlockNumberOrHash(blockNrOrHash)
 				},
 			},
@@ -83,7 +87,7 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address gethcommon.Address
 }
 
 func (api *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error) {
-	resp, err := UnauthenticatedTenRPCCall[map[string]interface{}](ctx, api.we, &CacheCfg{CacheTypeDynamic: func() CacheStrategy {
+	resp, err := UnauthenticatedTenRPCCall[map[string]interface{}](ctx, api.we, &cache.Cfg{DynamicType: func() cache.Strategy {
 		return cacheBlockNumber(number)
 	}}, "eth_getHeaderByNumber", number)
 	if resp == nil {
@@ -93,7 +97,7 @@ func (api *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.Bloc
 }
 
 func (api *BlockChainAPI) GetHeaderByHash(ctx context.Context, hash gethcommon.Hash) map[string]interface{} {
-	resp, _ := UnauthenticatedTenRPCCall[map[string]interface{}](ctx, api.we, &CacheCfg{CacheType: LongLiving}, "eth_getHeaderByHash", hash)
+	resp, _ := UnauthenticatedTenRPCCall[map[string]interface{}](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "eth_getHeaderByHash", hash)
 	if resp == nil {
 		return nil
 	}
@@ -104,8 +108,8 @@ func (api *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.Block
 	resp, err := UnauthenticatedTenRPCCall[common.BatchHeader](
 		ctx,
 		api.we,
-		&CacheCfg{
-			CacheTypeDynamic: func() CacheStrategy {
+		&cache.Cfg{
+			DynamicType: func() cache.Strategy {
 				return cacheBlockNumber(number)
 			},
 		}, "eth_getBlockByNumber", number, fullTx)
@@ -126,7 +130,7 @@ func (api *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.Block
 }
 
 func (api *BlockChainAPI) GetBlockByHash(ctx context.Context, hash gethcommon.Hash, fullTx bool) (map[string]interface{}, error) {
-	resp, err := UnauthenticatedTenRPCCall[common.BatchHeader](ctx, api.we, &CacheCfg{CacheType: LongLiving}, "eth_getBlockByHash", hash, fullTx)
+	resp, err := UnauthenticatedTenRPCCall[common.BatchHeader](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "eth_getBlockByHash", hash, fullTx)
 	if resp == nil {
 		return nil, err
 	}
@@ -148,8 +152,8 @@ func (api *BlockChainAPI) GetCode(ctx context.Context, address gethcommon.Addres
 	resp, err := UnauthenticatedTenRPCCall[hexutil.Bytes](
 		ctx,
 		api.we,
-		&CacheCfg{
-			CacheTypeDynamic: func() CacheStrategy {
+		&cache.Cfg{
+			DynamicType: func() cache.Strategy {
 				return cacheBlockNumberOrHash(blockNrOrHash)
 			},
 		},
@@ -181,7 +185,7 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address gethcommon.A
 			return nil, err
 		}
 
-		_, err = getUser(userID, api.we)
+		_, err = api.we.GetUser(userID)
 		if err != nil {
 			return nil, err
 		}
@@ -246,15 +250,15 @@ type (
 
 func (api *BlockChainAPI) Call(ctx context.Context, args gethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
 	resp, err := ExecAuthRPC[hexutil.Bytes](ctx, api.we, &ExecCfg{
-		cacheCfg: &CacheCfg{
-			CacheTypeDynamic: func() CacheStrategy {
+		cacheCfg: &cache.Cfg{
+			DynamicType: func() cache.Strategy {
 				return cacheBlockNumberOrHash(blockNrOrHash)
 			},
 		},
-		computeFromCallback: func(user *GWUser) *gethcommon.Address {
+		computeFromCallback: func(user *services.GWUser) *gethcommon.Address {
 			return searchFromAndData(user.GetAllAddresses(), args)
 		},
-		adjustArgs: func(acct *GWAccount) []any {
+		adjustArgs: func(acct *services.GWAccount) []any {
 			argsClone := populateFrom(acct, args)
 			return []any{argsClone, blockNrOrHash, overrides, blockOverrides}
 		},
@@ -268,18 +272,18 @@ func (api *BlockChainAPI) Call(ctx context.Context, args gethapi.TransactionArgs
 
 func (api *BlockChainAPI) EstimateGas(ctx context.Context, args gethapi.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Uint64, error) {
 	resp, err := ExecAuthRPC[hexutil.Uint64](ctx, api.we, &ExecCfg{
-		cacheCfg: &CacheCfg{
-			CacheTypeDynamic: func() CacheStrategy {
+		cacheCfg: &cache.Cfg{
+			DynamicType: func() cache.Strategy {
 				if blockNrOrHash != nil {
 					return cacheBlockNumberOrHash(*blockNrOrHash)
 				}
-				return LatestBatch
+				return cache.LatestBatch
 			},
 		},
-		computeFromCallback: func(user *GWUser) *gethcommon.Address {
+		computeFromCallback: func(user *services.GWUser) *gethcommon.Address {
 			return searchFromAndData(user.GetAllAddresses(), args)
 		},
-		adjustArgs: func(acct *GWAccount) []any {
+		adjustArgs: func(acct *services.GWAccount) []any {
 			argsClone := populateFrom(acct, args)
 			return []any{argsClone, blockNrOrHash, overrides}
 		},
@@ -292,12 +296,12 @@ func (api *BlockChainAPI) EstimateGas(ctx context.Context, args gethapi.Transact
 	return *resp, err
 }
 
-func populateFrom(acct *GWAccount, args gethapi.TransactionArgs) gethapi.TransactionArgs {
+func populateFrom(acct *services.GWAccount, args gethapi.TransactionArgs) gethapi.TransactionArgs {
 	// clone the args
 	argsClone := cloneArgs(args)
 	// set the from
 	if args.From == nil || args.From.Hex() == (gethcommon.Address{}).Hex() {
-		argsClone.From = acct.address
+		argsClone.From = acct.Address
 	}
 	return argsClone
 }

--- a/tools/walletextension/rpcapi/debug_api.go
+++ b/tools/walletextension/rpcapi/debug_api.go
@@ -3,6 +3,10 @@ package rpcapi
 import (
 	"context"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ten-protocol/go-ten/go/common"
@@ -10,10 +14,10 @@ import (
 )
 
 type DebugAPI struct {
-	we *Services
+	we *services.Services
 }
 
-func NewDebugAPI(we *Services) *DebugAPI {
+func NewDebugAPI(we *services.Services) *DebugAPI {
 	return &DebugAPI{we}
 }
 
@@ -58,8 +62,8 @@ func (api *DebugAPI) EventLogRelevancy(ctx context.Context, crit common.FilterCr
 		ctx,
 		api.we,
 		&ExecCfg{
-			cacheCfg: &CacheCfg{
-				CacheType: NoCache,
+			cacheCfg: &cache.Cfg{
+				Type: cache.NoCache,
 			},
 			tryUntilAuthorised: true,
 		},

--- a/tools/walletextension/rpcapi/ethereum_api.go
+++ b/tools/walletextension/rpcapi/ethereum_api.go
@@ -3,26 +3,30 @@ package rpcapi
 import (
 	"context"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 )
 
 type EthereumAPI struct {
-	we *Services
+	we *services.Services
 }
 
-func NewEthereumAPI(we *Services,
+func NewEthereumAPI(we *services.Services,
 ) *EthereumAPI {
 	return &EthereumAPI{we}
 }
 
 func (api *EthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
-	return UnauthenticatedTenRPCCall[hexutil.Big](ctx, api.we, &CacheCfg{CacheType: LatestBatch}, "eth_gasPrice")
+	return UnauthenticatedTenRPCCall[hexutil.Big](ctx, api.we, &cache.Cfg{Type: cache.LatestBatch}, "eth_gasPrice")
 }
 
 func (api *EthereumAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
-	return UnauthenticatedTenRPCCall[hexutil.Big](ctx, api.we, &CacheCfg{CacheType: LatestBatch}, "eth_maxPriorityFeePerGas")
+	return UnauthenticatedTenRPCCall[hexutil.Big](ctx, api.we, &cache.Cfg{Type: cache.LatestBatch}, "eth_maxPriorityFeePerGas")
 }
 
 type FeeHistoryResult struct {
@@ -36,7 +40,7 @@ func (api *EthereumAPI) FeeHistory(ctx context.Context, blockCount math.HexOrDec
 	return UnauthenticatedTenRPCCall[FeeHistoryResult](
 		ctx,
 		api.we,
-		&CacheCfg{CacheTypeDynamic: func() CacheStrategy {
+		&cache.Cfg{DynamicType: func() cache.Strategy {
 			return cacheBlockNumber(lastBlock)
 		}},
 		"eth_feeHistory",

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -7,6 +7,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -25,14 +29,14 @@ import (
 )
 
 type FilterAPI struct {
-	we     *Services
+	we     *services.Services
 	logger log.Logger
 }
 
-func NewFilterAPI(we *Services) *FilterAPI {
+func NewFilterAPI(we *services.Services) *FilterAPI {
 	return &FilterAPI{
 		we:     we,
-		logger: we.logger,
+		logger: we.Logger(),
 	}
 }
 
@@ -81,7 +85,7 @@ func (api *FilterAPI) Logs(ctx context.Context, crit common.FilterCriteria) (*rp
 	errorChannels := make([]<-chan error, 0)
 	backendSubscriptions := make([]*rpc.ClientSubscription, 0)
 	for _, address := range candidateAddresses {
-		rpcWSClient, err := connectWS(ctx, user.accounts[*address], api.we.Logger())
+		rpcWSClient, err := services.ConnectWS(ctx, user.Accounts[*address], api.we.Logger())
 		if err != nil {
 			return nil, err
 		}
@@ -148,11 +152,11 @@ func (api *FilterAPI) closeConnections(backendSubscriptions []*rpc.ClientSubscri
 		backendSub.Unsubscribe()
 	}
 	for _, connection := range backendWSConnections {
-		_ = returnConn(api.we.rpcWSConnPool, connection.BackingClient(), api.logger)
+		_ = services.ReturnConn(api.we.RpcWSConnPool, connection.BackingClient(), api.logger)
 	}
 }
 
-func getUserAndNotifier(ctx context.Context, api *FilterAPI) (*rpc.Notifier, *GWUser, error) {
+func getUserAndNotifier(ctx context.Context, api *FilterAPI) (*rpc.Notifier, *services.GWUser, error) {
 	subNotifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, nil, fmt.Errorf("creation of subscriptions is not supported")
@@ -163,7 +167,7 @@ func getUserAndNotifier(ctx context.Context, api *FilterAPI) (*rpc.Notifier, *GW
 		return nil, nil, fmt.Errorf("illegal access")
 	}
 
-	user, err := getUser(subNotifier.UserID, api.we)
+	user, err := api.we.GetUser(subNotifier.UserID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("illegal access: %s, %w", subNotifier.UserID, err)
 	}
@@ -203,23 +207,23 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 		return nil, fmt.Errorf("rate limit exceeded")
 	}
 
-	res, err := withCache(
+	res, err := cache.WithCache(
 		api.we.Cache,
-		&CacheCfg{
-			CacheTypeDynamic: func() CacheStrategy {
+		&cache.Cfg{
+			DynamicType: func() cache.Strategy {
 				if crit.ToBlock != nil && crit.ToBlock.Int64() > 0 {
-					return LongLiving
+					return cache.LongLiving
 				}
 				if crit.BlockHash != nil {
-					return LongLiving
+					return cache.LongLiving
 				}
 				// when the toBlock or the block Hash are not specified, the request is open-ended
-				return LatestBatch
+				return cache.LatestBatch
 			},
 		},
 		generateCacheKey([]any{userID, method, common.SerializableFilterCriteria(crit)}),
 		func() (*[]*types.Log, error) { // called when there is no entry in the cache
-			user, err := getUser(userID, api.we)
+			user, err := api.we.GetUser(userID)
 			if err != nil {
 				return nil, err
 			}
@@ -228,8 +232,8 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 			// for each account registered for the current user
 			// execute the get_Logs function
 			// dedupe and concatenate the results
-			for _, acct := range user.accounts {
-				eventLogs, err := withEncRPCConnection(ctx, api.we, acct, func(rpcClient *tenrpc.EncRPCClient) (*[]*types.Log, error) {
+			for _, acct := range user.Accounts {
+				eventLogs, err := services.WithEncRPCConnection(ctx, api.we, acct, func(rpcClient *tenrpc.EncRPCClient) (*[]*types.Log, error) {
 					var result []*types.Log
 
 					// wrap the context with a timeout to prevent long executions

--- a/tools/walletextension/rpcapi/net_api.go
+++ b/tools/walletextension/rpcapi/net_api.go
@@ -2,18 +2,22 @@ package rpcapi
 
 import (
 	"context"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
 )
 
 type NetAPI struct {
-	we *Services
+	we *services.Services
 }
 
-func NewNetAPI(we *Services) *NetAPI {
+func NewNetAPI(we *services.Services) *NetAPI {
 	return &NetAPI{we}
 }
 
 func (api *NetAPI) Version(ctx context.Context) (*string, error) {
-	return UnauthenticatedTenRPCCall[string](ctx, api.we, &CacheCfg{CacheType: LongLiving}, "net_version")
+	return UnauthenticatedTenRPCCall[string](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "net_version")
 }
 
 type ConfigResponseJson struct {
@@ -24,5 +28,5 @@ type ConfigResponseJson struct {
 }
 
 func (api *NetAPI) Config(ctx context.Context) (*ConfigResponseJson, error) {
-	return UnauthenticatedTenRPCCall[ConfigResponseJson](ctx, api.we, &CacheCfg{CacheType: LongLiving}, "obscuro_config")
+	return UnauthenticatedTenRPCCall[ConfigResponseJson](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "obscuro_config")
 }

--- a/tools/walletextension/rpcapi/transaction_api.go
+++ b/tools/walletextension/rpcapi/transaction_api.go
@@ -3,6 +3,10 @@ package rpcapi
 import (
 	"context"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -12,15 +16,15 @@ import (
 )
 
 type TransactionAPI struct {
-	we *Services
+	we *services.Services
 }
 
-func NewTransactionAPI(we *Services) *TransactionAPI {
+func NewTransactionAPI(we *services.Services) *TransactionAPI {
 	return &TransactionAPI{we}
 }
 
 func (s *TransactionAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr gethrpc.BlockNumber) *hexutil.Uint {
-	count, err := UnauthenticatedTenRPCCall[hexutil.Uint](ctx, s.we, &CacheCfg{CacheTypeDynamic: func() CacheStrategy {
+	count, err := UnauthenticatedTenRPCCall[hexutil.Uint](ctx, s.we, &cache.Cfg{DynamicType: func() cache.Strategy {
 		return cacheBlockNumber(blockNr)
 	}}, "eth_getBlockTransactionCountByNumber", blockNr)
 	if err != nil {
@@ -30,7 +34,7 @@ func (s *TransactionAPI) GetBlockTransactionCountByNumber(ctx context.Context, b
 }
 
 func (s *TransactionAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	count, err := UnauthenticatedTenRPCCall[hexutil.Uint](ctx, s.we, &CacheCfg{CacheType: LongLiving}, "eth_getBlockTransactionCountByHash", blockHash)
+	count, err := UnauthenticatedTenRPCCall[hexutil.Uint](ctx, s.we, &cache.Cfg{Type: cache.LongLiving}, "eth_getBlockTransactionCountByHash", blockHash)
 	if err != nil {
 		return nil
 	}
@@ -63,8 +67,8 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 		s.we,
 		&ExecCfg{
 			account: &address,
-			cacheCfg: &CacheCfg{
-				CacheTypeDynamic: func() CacheStrategy {
+			cacheCfg: &cache.Cfg{
+				DynamicType: func() cache.Strategy {
 					return cacheBlockNumberOrHash(blockNrOrHash)
 				},
 			},
@@ -76,11 +80,11 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 }
 
 func (s *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (*rpc.RpcTransaction, error) {
-	return ExecAuthRPC[rpc.RpcTransaction](ctx, s.we, &ExecCfg{tryAll: true, cacheCfg: &CacheCfg{CacheType: LongLiving}}, "eth_getTransactionByHash", hash)
+	return ExecAuthRPC[rpc.RpcTransaction](ctx, s.we, &ExecCfg{tryAll: true, cacheCfg: &cache.Cfg{Type: cache.LongLiving}}, "eth_getTransactionByHash", hash)
 }
 
 func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutil.Bytes, error) {
-	tx, err := ExecAuthRPC[hexutil.Bytes](ctx, s.we, &ExecCfg{tryAll: true, cacheCfg: &CacheCfg{CacheType: LongLiving}}, "eth_getRawTransactionByHash", hash)
+	tx, err := ExecAuthRPC[hexutil.Bytes](ctx, s.we, &ExecCfg{tryAll: true, cacheCfg: &cache.Cfg{Type: cache.LongLiving}}, "eth_getRawTransactionByHash", hash)
 	if tx != nil {
 		return *tx, err
 	}
@@ -88,7 +92,7 @@ func (s *TransactionAPI) GetRawTransactionByHash(ctx context.Context, hash commo
 }
 
 func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	txRec, err := ExecAuthRPC[map[string]interface{}](ctx, s.we, &ExecCfg{tryUntilAuthorised: true, cacheCfg: &CacheCfg{CacheType: LongLiving}}, "eth_getTransactionReceipt", hash)
+	txRec, err := ExecAuthRPC[map[string]interface{}](ctx, s.we, &ExecCfg{tryUntilAuthorised: true, cacheCfg: &cache.Cfg{Type: cache.LongLiving}}, "eth_getTransactionReceipt", hash)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/walletextension/rpcapi/txpool_api.go
+++ b/tools/walletextension/rpcapi/txpool_api.go
@@ -4,13 +4,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	rpc2 "github.com/ten-protocol/go-ten/go/enclave/rpc"
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
 )
 
 type TxPoolAPI struct {
-	we *Services
+	we *services.Services
 }
 
-func NewTxPoolAPI(we *Services) *TxPoolAPI {
+func NewTxPoolAPI(we *services.Services) *TxPoolAPI {
 	return &TxPoolAPI{we}
 }
 

--- a/tools/walletextension/rpcapi/web3_api.go
+++ b/tools/walletextension/rpcapi/web3_api.go
@@ -2,15 +2,17 @@ package rpcapi
 
 import (
 	"context"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
 )
 
 var _hardcodedClientVersion = "Geth/v10.0.0/ten"
 
 type Web3API struct {
-	we *Services
+	we *services.Services
 }
 
-func NewWeb3API(we *Services) *Web3API {
+func NewWeb3API(we *services.Services) *Web3API {
 	return &Web3API{we}
 }
 

--- a/tools/walletextension/services/conn_utils.go
+++ b/tools/walletextension/services/conn_utils.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
+	pool "github.com/jolestar/go-commons-pool/v2"
+	"github.com/ten-protocol/go-ten/go/common/log"
+	"github.com/ten-protocol/go-ten/go/common/measure"
+	"github.com/ten-protocol/go-ten/go/enclave/core"
+	tenrpc "github.com/ten-protocol/go-ten/go/rpc"
+	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
+	wecommon "github.com/ten-protocol/go-ten/tools/walletextension/common"
+)
+
+func ConnectWS(ctx context.Context, account *GWAccount, logger gethlog.Logger) (*tenrpc.EncRPCClient, error) {
+	return connect(ctx, account.user.services.RpcWSConnPool, account, logger)
+}
+
+func connect(ctx context.Context, p *pool.ObjectPool, account *GWAccount, logger gethlog.Logger) (*tenrpc.EncRPCClient, error) {
+	defer core.LogMethodDuration(logger, measure.NewStopwatch(), "get rpc connection")
+	connectionObj, err := p.BorrowObject(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch rpc connection to backend node %w", err)
+	}
+	conn := connectionObj.(*rpc.Client)
+	encClient, err := wecommon.CreateEncClient(conn, account.Address.Bytes(), account.user.userKey, account.signature, account.signatureType, logger)
+	if err != nil {
+		_ = ReturnConn(p, conn, logger)
+		return nil, fmt.Errorf("error creating new client, %w", err)
+	}
+	return encClient, nil
+}
+
+func ReturnConn(p *pool.ObjectPool, conn tenrpc.Client, logger gethlog.Logger) error {
+	err := p.ReturnObject(context.Background(), conn)
+	if err != nil {
+		logger.Error("Error returning connection to pool", log.ErrKey, err)
+	}
+	return err
+}
+
+func WithEncRPCConnection[R any](ctx context.Context, w *Services, acct *GWAccount, execute func(*tenrpc.EncRPCClient) (*R, error)) (*R, error) {
+	rpcClient, err := connect(ctx, acct.user.services.RpcHTTPConnPool, acct, w.logger)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to backed. Cause: %w", err)
+	}
+	defer ReturnConn(w.RpcHTTPConnPool, rpcClient.BackingClient(), w.logger)
+	return execute(rpcClient)
+}
+
+func WithPlainRPCConnection[R any](ctx context.Context, w *Services, execute func(client *rpc.Client) (*R, error)) (*R, error) {
+	connectionObj, err := w.RpcHTTPConnPool.BorrowObject(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch rpc connection to backend node %w", err)
+	}
+	rpcClient := connectionObj.(*rpc.Client)
+	defer ReturnConn(w.RpcHTTPConnPool, rpcClient, w.logger)
+	return execute(rpcClient)
+}

--- a/tools/walletextension/services/utils.go
+++ b/tools/walletextension/services/utils.go
@@ -1,0 +1,11 @@
+package services
+
+import (
+	"fmt"
+)
+
+func audit(services *Services, msg string, params ...any) {
+	if services.Config.VerboseFlag {
+		services.logger.Info(fmt.Sprintf(msg, params...))
+	}
+}

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+
 	"github.com/ten-protocol/go-ten/go/common/subscription"
 
 	"github.com/ten-protocol/go-ten/tools/walletextension/httpapi"
@@ -24,7 +26,7 @@ type Container struct {
 	stopControl     *stopcontrol.StopControl
 	logger          gethlog.Logger
 	rpcServer       node.Server
-	services        *rpcapi.Services
+	services        *services.Services
 	newHeadsService *subscription.NewHeadsService
 }
 
@@ -58,7 +60,7 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 	}
 
 	stopControl := stopcontrol.New()
-	walletExt := rpcapi.NewServices(hostRPCBindAddrHTTP, hostRPCBindAddrWS, databaseStorage, stopControl, version, logger, &config)
+	walletExt := services.NewServices(hostRPCBindAddrHTTP, hostRPCBindAddrWS, databaseStorage, stopControl, version, logger, &config)
 	cfg := &node.RPCConfig{
 		EnableHTTP: true,
 		HTTPPort:   config.WalletExtensionPortHTTP,


### PR DESCRIPTION
### Why this change is needed

In preparation for adding session keys, we need to clear responsibilities, because a lot of the services will be reused

### What changes were made as part of this PR

- move the "services" to a separate package
- move all cache logic to its own package


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


