### PR TITLE
Deploy scripts: load message bus address dynamically

### DIFF
--- a/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
+++ b/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
@@ -57,8 +57,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   return;
     const l2Network = hre; 
     const {deployer} = await hre.getNamedAccounts();
-    
-    var mbusBase = await hre.ethers.getContractAt("MessageBus", "0x526c84529b2b8c11f57d93d3f5537aca3aecef9b");
+
+    const networkConfig : any = await hre.network.provider.request({method: 'net_config'});
+    console.log(`Network config = ${JSON.stringify(networkConfig, null, 2)}`);
+
+    const mgmtContractAddress = networkConfig.ManagementContractAddress;
+    const messageBusAddress = networkConfig.MessageBusAddress;
+
+    var mbusBase = await hre.ethers.getContractAt("MessageBus", messageBusAddress);
     const mbus = mbusBase.connect(await hre.ethers.provider.getSigner(deployer)); 
     const tx = await mbus.getFunction("sendValueToL2").send(deployer, 1000, { value: 1000});
     const receipt = await tx.wait()
@@ -95,13 +101,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       console.error('Constructed merkle root matches block crossChainTreeHash');
       return
     }
-
-
-    const networkConfig : any = await hre.network.provider.request({method: 'net_config'});
-    console.log(`Network config = ${JSON.stringify(networkConfig, null, 2)}`);
-
-    const mgmtContractAddress = networkConfig.ManagementContractAddress;
-    const messageBusAddress = networkConfig.MessageBusAddress;
 
     const l1Accounts = await hre.companionNetworks.layer1.getNamedAccounts()
     const fundTx = await hre.companionNetworks.layer1.deployments.rawTx({

--- a/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
+++ b/contracts/deployment_scripts/testing/003_simple_withdrawal.ts
@@ -63,8 +63,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     const mgmtContractAddress = networkConfig.ManagementContractAddress;
     const messageBusAddress = networkConfig.MessageBusAddress;
+    const l2MessageBusAddress = networkConfig.L2MessageBusAddress;
 
-    var mbusBase = await hre.ethers.getContractAt("MessageBus", messageBusAddress);
+    var mbusBase = await hre.ethers.getContractAt("MessageBus", l2MessageBusAddress);
     const mbus = mbusBase.connect(await hre.ethers.provider.getSigner(deployer)); 
     const tx = await mbus.getFunction("sendValueToL2").send(deployer, 1000, { value: 1000});
     const receipt = await tx.wait()

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -29,11 +29,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     // Request the message bus address from the config endpoint
     const networkConfig: any = await hre.network.provider.request({ method: 'net_config' });
-    if (!networkConfig || !networkConfig.MessageBusAddress) {
-        throw new Error("Failed to retrieve MessageBusAddress from network config");
+    if (!networkConfig || !networkConfig.L2MessageBusAddress) {
+        throw new Error("Failed to retrieve L2MessageBusAddress from network config");
     }
-    const messageBusAddress = networkConfig.MessageBusAddress;
-    console.log(`Loaded message bus address = ${messageBusAddress}`);
+    const l2messageBusAddress = networkConfig.L2MessageBusAddress;
+    console.log(`Loaded message bus address = ${l2messageBusAddress}`);
 
     // Tell the bridge to whitelist the address of HOC token. This generates a cross chain message.
     let hocResult = await l1Network.deployments.execute("ObscuroBridge", {
@@ -103,7 +103,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Poll message submission 
     await new Promise(async (resolve, fail)=> { 
         setTimeout(fail, 30_000)
-        const messageBusContract = (await hre.ethers.getContractAt('MessageBus', messageBusAddress));
+        const messageBusContract = (await hre.ethers.getContractAt('MessageBus', l2messageBusAddress));
         const gasLimit = await messageBusContract.getFunction('verifyMessageFinalized').estimateGas(messages[1], {
             maxFeePerGas: 1000000001,
         })

--- a/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
+++ b/contracts/deployment_scripts/testnet/layer2/001_whitelist_tokens.ts
@@ -27,6 +27,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     console.log(` Using deployers for bridge interaction L1 address=${l1Accounts.deployer} L2 Address=${l2Accounts.deployer}`);
 
+    // Request the message bus address from the config endpoint
+    const networkConfig: any = await hre.network.provider.request({ method: 'net_config' });
+    if (!networkConfig || !networkConfig.MessageBusAddress) {
+        throw new Error("Failed to retrieve MessageBusAddress from network config");
+    }
+    const messageBusAddress = networkConfig.MessageBusAddress;
+    console.log(`Loaded message bus address = ${messageBusAddress}`);
+
     // Tell the bridge to whitelist the address of HOC token. This generates a cross chain message.
     let hocResult = await l1Network.deployments.execute("ObscuroBridge", {
         from: l1Accounts.deployer, 
@@ -95,7 +103,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Poll message submission 
     await new Promise(async (resolve, fail)=> { 
         setTimeout(fail, 30_000)
-        const messageBusContract = (await hre.ethers.getContractAt('MessageBus', '0x526c84529b2b8c11f57d93d3f5537aca3aecef9b'));
+        const messageBusContract = (await hre.ethers.getContractAt('MessageBus', messageBusAddress));
         const gasLimit = await messageBusContract.getFunction('verifyMessageFinalized').estimateGas(messages[1], {
             maxFeePerGas: 1000000001,
         })


### PR DESCRIPTION
### Why this change is needed

Hardcoded msg bus address was breaking local network deployments.

### What changes were made as part of this PR

Request msg bus address from cfg endpoint

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


