### PR TITLE
Log Gateway logs to a file

### DIFF
--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -32,7 +32,8 @@ func (n *DockerGateway) Start() error {
 		"--nodePortWS", fmt.Sprintf("%d", n.cfg.tenNodeWSPort),
 		"--nodeHost", n.cfg.tenNodeHost,
 		"--dbType", "sqlite",
-		"--logPath", "sys_out",
+		"--logPath", "gateway_logs.log",
+		"--verbose", "true",
 		"--rateLimitUserComputeTime", fmt.Sprintf("%d", n.cfg.rateLimitUserComputeTime),
 	}
 

--- a/tools/walletextension/Dockerfile
+++ b/tools/walletextension/Dockerfile
@@ -37,6 +37,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Lightweight final build stage. Includes bare minimum to start wallet extension
 FROM alpine:3.18
 
+
+# Set a writable working directory
+WORKDIR /home/obscuro
+RUN mkdir -p /home/obscuro && chmod -R 777 /home/obscuro
+
 # copy over the gateway executable
 COPY --from=build-wallet /home/obscuro/go-obscuro/tools/walletextension/bin /home/obscuro/go-obscuro/tools/walletextension/bin
 


### PR DESCRIPTION
### Why this change is needed

Use the same Dockerfile as in deployed version (but in simulation mode) for local testnet and log to file and not to `std_out`

### What changes were made as part of this PR

At the moment we are sticking to non SGX version of the gateway for local testnets, due to a problem with creating files inside SGX mode in simulation mode. Priority is to implement other tasks more crucial for mainnet release.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


