### PR TITLE
Default testnet launcher to info level logs

### DIFF
--- a/go/config/defaults/testnet-launcher/1-testnet-launcher.yaml
+++ b/go/config/defaults/testnet-launcher/1-testnet-launcher.yaml
@@ -11,8 +11,12 @@ host:
         enableDebugNamespace: true
    l1:
       wsURL: ws://eth2network:9000
+   log:
+      level: 4
 enclave:
    db:
       useInMemory: false
    debug:
       enableDebugNamespace: true
+   log:
+        level: 4


### PR DESCRIPTION
### Why this change is needed

Recent chance to default logs level for sims has changed the log level on testnet to error which means we don't have good visibility on issues.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


