### PR TITLE
Disable rate limiting for local testnet and fix verbosity flag

### DIFF
--- a/testnet/launcher/gateway/docker.go
+++ b/testnet/launcher/gateway/docker.go
@@ -33,8 +33,8 @@ func (n *DockerGateway) Start() error {
 		"--nodeHost", n.cfg.tenNodeHost,
 		"--dbType", "sqlite",
 		"--logPath", "gateway_logs.log",
-		"--verbose", "true",
 		"--rateLimitUserComputeTime", fmt.Sprintf("%d", n.cfg.rateLimitUserComputeTime),
+		"--verbose",
 	}
 
 	_, err := docker.StartNewContainer("gateway", n.cfg.dockerImage, cmds, []int{n.cfg.gatewayHTTPPort, n.cfg.gatewayWSPort}, nil, nil, nil, true)


### PR DESCRIPTION
### Why this change is needed

Verbosity flag is a boolean flag and it should not have (true/false) set. 
This caused it to ignore all the other flags.

### What changes were made as part of this PR

Fixed parameter passing in the local testnet gateway.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


