### PR TITLE
fix session keys issue and add new dedicate rpc endpoint

### DIFF
--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -555,31 +555,22 @@ func createSKRequestHandler(walletExt *services.Services, conn UserConn) {
 
 func deleteSKRequestHandler(walletExt *services.Services, conn UserConn) {
 	withUser(walletExt, conn, func(user *common.GWUser) ([]byte, error) {
-		err := walletExt.Storage.RemoveSessionKey(user.ID)
-		if err != nil {
-			return nil, err
-		}
-		return nil, nil
+		res, err := walletExt.SKManager.DeleteSessionKey(user)
+		return []byte{boolToByte(res)}, err
 	})
 }
 
 func activateSKRequestHandler(walletExt *services.Services, conn UserConn) {
 	withUser(walletExt, conn, func(user *common.GWUser) ([]byte, error) {
-		err := walletExt.Storage.ActivateSessionKey(user.ID, true)
-		if err != nil {
-			return nil, err
-		}
-		return []byte{1}, nil
+		res, err := walletExt.SKManager.ActivateSessionKey(user)
+		return []byte{boolToByte(res)}, err
 	})
 }
 
 func deactivateSKRequestHandler(walletExt *services.Services, conn UserConn) {
 	withUser(walletExt, conn, func(user *common.GWUser) ([]byte, error) {
-		err := walletExt.Storage.ActivateSessionKey(user.ID, false)
-		if err != nil {
-			return nil, err
-		}
-		return nil, nil
+		res, err := walletExt.SKManager.DeactivateSessionKey(user)
+		return []byte{boolToByte(res)}, err
 	})
 }
 
@@ -614,4 +605,11 @@ func withUser(walletExt *services.Services, conn UserConn, withUser func(user *c
 	if err != nil {
 		walletExt.Logger().Error("error writing success response", log.ErrKey, err)
 	}
+}
+
+func boolToByte(res bool) byte {
+	if res {
+		return 1
+	}
+	return 0
 }

--- a/tools/walletextension/rpcapi/session_key_api.go
+++ b/tools/walletextension/rpcapi/session_key_api.go
@@ -1,0 +1,58 @@
+package rpcapi
+
+import (
+	"context"
+	"fmt"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/ten-protocol/go-ten/tools/walletextension/services"
+)
+
+type SessionKeyAPI struct {
+	we *services.Services
+}
+
+func NewSessionKeyAPI(we *services.Services) *SessionKeyAPI {
+	return &SessionKeyAPI{we}
+}
+
+func (api *SessionKeyAPI) Create(ctx context.Context) (gethcommon.Address, error) {
+	user, err := extractUserForRequest(ctx, api.we)
+	if err != nil {
+		return gethcommon.Address{}, err
+	}
+
+	sk, err := api.we.SKManager.CreateSessionKey(user)
+	if err != nil {
+		return gethcommon.Address{}, fmt.Errorf("unable to create session key: %w", err)
+	}
+	return *sk.Account.Address, nil
+}
+
+func (api *SessionKeyAPI) Activate(ctx context.Context) (bool, error) {
+	user, err := extractUserForRequest(ctx, api.we)
+	if err != nil {
+		return false, err
+	}
+
+	return api.we.SKManager.ActivateSessionKey(user)
+}
+
+func (api *SessionKeyAPI) Deactivate(ctx context.Context) (bool, error) {
+	user, err := extractUserForRequest(ctx, api.we)
+	if err != nil {
+		return false, err
+	}
+
+	return api.we.SKManager.ActivateSessionKey(user)
+}
+
+func (api *SessionKeyAPI) Delete(ctx context.Context) (bool, error) {
+	user, err := extractUserForRequest(ctx, api.we)
+	if err != nil {
+		return false, err
+	}
+
+	return api.we.SKManager.DeleteSessionKey(user)
+}

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -92,6 +92,9 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 			Namespace: "debug",
 			Service:   rpcapi.NewDebugAPI(walletExt),
 		}, {
+			Namespace: "sessionkeys",
+			Service:   rpcapi.NewSessionKeyAPI(walletExt),
+		}, {
 			Namespace: "eth",
 			Service:   rpcapi.NewFilterAPI(walletExt),
 		}, {


### PR DESCRIPTION
### Why this change is needed

To fix a few bugs raised after testing

### What changes were made as part of this PR

- create a dedicated rpc endpoint: "sessionkeys_create" ,"sessionkeys_activate" ,"sessionkeys_deactivate" ,"sessionkeys_delete"
-  "sessionkeys_create" - returns a checksum address
- move validation logic to the "sk_manager"



