### PR TITLE
HA: include enclaveID in guardian logs, fix HA netw test

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -117,6 +117,8 @@ func (g *Guardian) Start() error {
 		g.enclaveID = &enclID
 		// include the enclave ID in guardian log messages (for multi-enclave nodes)
 		g.logger = g.logger.New(log.EnclaveIDKey, g.enclaveID)
+		// recreate status with new logger
+		g.state = NewStateTracker(g.logger)
 		g.logger.Info("Starting guardian process.")
 	}
 

--- a/integration/networktest/env/dev_network.go
+++ b/integration/networktest/env/dev_network.go
@@ -28,7 +28,7 @@ func (d *devNetworkEnv) Prepare() (networktest.NetworkConnector, func(), error) 
 }
 
 func awaitNodesAvailable(nc networktest.NetworkConnector) error {
-	err := awaitHealthStatus(nc.GetSequencerNode().HostRPCWSAddress(), 60*time.Second)
+	err := awaitHealthStatus(nc.GetSequencerNode().HostRPCWSAddress(), 90*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Why this change is needed

Multi-enclave sequencer network test was failing because secret exchange takes a bit longer now and timeout was too low.

Also guardian wasn't including the enclave ID in its status logs which was very unhelpful.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


