### PR TITLE
remove "submitTx" from nodeType and improve mempool

### DIFF
--- a/go/enclave/components/eth_chainadapter.go
+++ b/go/enclave/components/eth_chainadapter.go
@@ -1,8 +1,10 @@
-package ethchainadapter
+package components
 
 import (
 	"context"
 	"math/big"
+
+	"github.com/ten-protocol/go-ten/go/enclave/evm/ethchainadapter"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -11,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ten-protocol/go-ten/go/common/gethencoding"
 	"github.com/ten-protocol/go-ten/go/common/log"
-	"github.com/ten-protocol/go-ten/go/enclave/components"
 	enclaveconfig "github.com/ten-protocol/go-ten/go/enclave/config"
 	"github.com/ten-protocol/go-ten/go/enclave/core"
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
@@ -24,7 +25,7 @@ import (
 // EthChainAdapter is an obscuro wrapper around the ethereum core.Blockchain object
 type EthChainAdapter struct {
 	newHeadChan   chan gethcore.ChainHeadEvent
-	batchRegistry components.BatchRegistry
+	batchRegistry BatchRegistry
 	gethEncoding  gethencoding.EncodingService
 	storage       storage.Storage
 	config        enclaveconfig.EnclaveConfig
@@ -33,7 +34,7 @@ type EthChainAdapter struct {
 }
 
 // NewEthChainAdapter returns a new instance
-func NewEthChainAdapter(chainID *big.Int, batchRegistry components.BatchRegistry, storage storage.Storage, gethEncoding gethencoding.EncodingService, config enclaveconfig.EnclaveConfig, logger gethlog.Logger) *EthChainAdapter {
+func NewEthChainAdapter(chainID *big.Int, batchRegistry BatchRegistry, storage storage.Storage, gethEncoding gethencoding.EncodingService, config enclaveconfig.EnclaveConfig, logger gethlog.Logger) *EthChainAdapter {
 	return &EthChainAdapter{
 		newHeadChan:   make(chan gethcore.ChainHeadEvent),
 		batchRegistry: batchRegistry,
@@ -47,7 +48,7 @@ func NewEthChainAdapter(chainID *big.Int, batchRegistry components.BatchRegistry
 
 // Config retrieves the chain's fork configuration.
 func (e *EthChainAdapter) Config() *params.ChainConfig {
-	return ChainParams(e.chainID)
+	return ethchainadapter.ChainParams(e.chainID)
 }
 
 // CurrentBlock returns the current head of the chain.

--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -103,7 +103,7 @@ type BatchRegistry interface {
 	SubscribeForExecutedBatches(func(*core.Batch, types.Receipts))
 	UnsubscribeFromBatches()
 
-	OnBatchExecuted(batch *common.BatchHeader, txExecResults []*core.TxExecResult)
+	OnBatchExecuted(batch *common.BatchHeader, txExecResults []*core.TxExecResult) error
 	OnL1Reorg(*BlockIngestionType)
 
 	// HasGenesisBatch - returns if genesis batch is available yet or not, or error in case
@@ -111,6 +111,8 @@ type BatchRegistry interface {
 	HasGenesisBatch() (bool, error)
 
 	HeadBatchSeq() *big.Int
+
+	EthChain() *EthChainAdapter
 
 	HealthCheck() (bool, error)
 }

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -474,7 +474,11 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 			if err != nil {
 				return err
 			}
-			rc.batchRegistry.OnBatchExecuted(genBatch.Header, nil)
+
+			err = rc.batchRegistry.OnBatchExecuted(genBatch.Header, nil)
+			if err != nil {
+				return err
+			}
 
 			rc.logger.Info("Stored genesis", log.BatchHashKey, genBatch.Hash())
 			parentHash = genBatch.Hash()
@@ -518,7 +522,10 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 			if err != nil {
 				return err
 			}
-			rc.batchRegistry.OnBatchExecuted(computedBatch.Batch.Header, nil)
+			err = rc.batchRegistry.OnBatchExecuted(computedBatch.Batch.Header, nil)
+			if err != nil {
+				return err
+			}
 
 			parentHash = computedBatch.Batch.Hash()
 		}

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -117,7 +117,7 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 
 	var service nodetype.NodeType
 	if config.NodeType == common.ActiveSequencer {
-		mempool.ChangeMode(false)
+		mempool.SetValidateMode(false)
 		// Todo - this is temporary - until the host calls `AddSequencer`
 		err := storage.StoreNewEnclave(context.Background(), enclaveKeyService.EnclaveID(), enclaveKeyService.PublicKey())
 		if err != nil {

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -180,10 +180,6 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 	// todo - security
 	obscuroKey := crypto.GetObscuroKey(logger)
 
-	// submit tx becomes part of the mempool impl - with a toggle based on the node type : either validate or store
-	// which is set when the node loads - or can be commuted
-	// otherwise, the service is validator, and is commuted to sequencer when the node is made active
-
 	rpcEncryptionManager := rpc.NewEncryptionManager(ecies.ImportECDSA(obscuroKey), storage, cachingService, registry, mempool, crossChainProcessors, config, gasOracle, storage, blockProcessor, chain, logger)
 	subscriptionManager := events.NewSubscriptionManager(storage, registry, config.ObscuroChainID, logger)
 

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -99,7 +99,7 @@ func (e *enclaveAdminService) AddSequencer(id common.EnclaveID, proof types.Rece
 	// compare the id with the current enclaveId and if they match - do something so that the current enclave behaves as a "backup sequencer"
 	// the host will specifically mark the active enclave
 	if e.enclaveKeyService.EnclaveID() == id {
-		e.mempool.ChangeMode(false)
+		e.mempool.SetValidateMode(false)
 	}
 
 	// todo - use the proof

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -13,11 +13,6 @@ import (
 // NodeType - the interface for any service type running in Obscuro nodes.
 // Should only contain the shared functionality that every service type needs to have.
 type NodeType interface {
-	// SubmitTransaction - L2 obscuro transactions need to be passed here. Sequencers
-	// will put them in the mempool while validators might put them in a queue and monitor
-	// for censorship.
-	// SubmitTransaction(*common.L2Tx) error
-
 	// OnL1Fork - logic to be performed when there is an L1 Fork
 	OnL1Fork(ctx context.Context, fork *common.ChainFork) error
 

--- a/go/enclave/nodetype/interfaces.go
+++ b/go/enclave/nodetype/interfaces.go
@@ -16,7 +16,7 @@ type NodeType interface {
 	// SubmitTransaction - L2 obscuro transactions need to be passed here. Sequencers
 	// will put them in the mempool while validators might put them in a queue and monitor
 	// for censorship.
-	SubmitTransaction(*common.L2Tx) error
+	// SubmitTransaction(*common.L2Tx) error
 
 	// OnL1Fork - logic to be performed when there is an L1 Fork
 	OnL1Fork(ctx context.Context, fork *common.ChainFork) error

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -113,15 +113,6 @@ func (s *sequencer) CreateBatch(ctx context.Context, skipBatchIfEmpty bool) erro
 		return s.createGenesisBatch(ctx, l1HeadBlock)
 	}
 
-	if running := s.mempool.Running(); !running {
-		// the mempool can only be started after at least 1 block (the genesis) is in the blockchain object
-		// if the node restarted the mempool must be started again
-		err = s.mempool.Start()
-		if err != nil {
-			return err
-		}
-	}
-
 	return s.createNewHeadBatch(ctx, l1HeadBlock, skipBatchIfEmpty)
 }
 
@@ -154,12 +145,6 @@ func (s *sequencer) createGenesisBatch(ctx context.Context, block *types.Header)
 	err = s.blockchain.IngestNewBlock(batch)
 	if err != nil {
 		return fmt.Errorf("failed to feed batch into the virtual eth chain - %w", err)
-	}
-
-	// the mempool can only be started after at least 1 block is in the blockchain object
-	err = s.mempool.Start()
-	if err != nil {
-		return err
 	}
 
 	// errors in unit test seem to suggest that batch 2 was received before batch 1
@@ -464,10 +449,6 @@ func (s *sequencer) duplicateBatches(ctx context.Context, l1Head *types.Header, 
 	//}
 
 	return nil
-}
-
-func (s *sequencer) SubmitTransaction(transaction *common.L2Tx) error {
-	return s.mempool.Add(transaction)
 }
 
 func (s *sequencer) OnL1Fork(ctx context.Context, fork *common.ChainFork) error {

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -101,7 +101,6 @@ func (val *validator) ExecuteStoredBatches(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("could not get txs for batch %s. Cause: %w", batchHeader.Hash(), err)
 			}
-			val.logger.Info("2")
 
 			batch := &core.Batch{
 				Header:       batchHeader,

--- a/go/enclave/rpc/SubmitTx.go
+++ b/go/enclave/rpc/SubmitTx.go
@@ -29,7 +29,7 @@ func SubmitTxExecute(builder *CallBuilder[common.L2Tx, gethcommon.Hash], rpc *En
 		return nil
 	}
 
-	if err := rpc.service.SubmitTransaction(builder.Param); err != nil {
+	if err := rpc.mempool.SubmitTx(builder.Param); err != nil {
 		rpc.logger.Debug("Could not submit transaction", log.TxKey, builder.Param.Hash(), log.ErrKey, err)
 		builder.Err = err
 		return nil

--- a/go/enclave/rpc/TenStorageRead.go
+++ b/go/enclave/rpc/TenStorageRead.go
@@ -45,7 +45,7 @@ func TenStorageReadValidate(reqParams []any, builder *CallBuilder[storageReadWit
 	}
 
 	// block the call for un-transparent contracts and non-whitelisted slots
-	if !rpc.whitelist.AllowedStorageSlots[slot] && !contract.IsTransparent() {
+	if !rpc.storageSlotWhitelist.AllowedStorageSlots[slot] && !contract.IsTransparent() {
 		builder.Err = fmt.Errorf("eth_getStorageAt is not supported for this contract")
 		return nil
 	}

--- a/go/enclave/rpc/rpc_encryption_manager.go
+++ b/go/enclave/rpc/rpc_encryption_manager.go
@@ -3,6 +3,8 @@ package rpc
 import (
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/go/enclave/txpool"
+
 	"github.com/ten-protocol/go-ten/go/common/privacy"
 	enclaveconfig "github.com/ten-protocol/go-ten/go/enclave/config"
 	"github.com/ten-protocol/go-ten/go/enclave/gas"
@@ -11,7 +13,6 @@ import (
 	"github.com/ten-protocol/go-ten/go/enclave/components"
 	"github.com/ten-protocol/go-ten/go/enclave/crosschain"
 	"github.com/ten-protocol/go-ten/go/enclave/l2chain"
-	"github.com/ten-protocol/go-ten/go/enclave/nodetype"
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
 
 	"github.com/ethereum/go-ethereum/crypto/ecies"
@@ -25,22 +26,21 @@ type EncryptionManager struct {
 	cacheService           *storage.CacheService
 	registry               components.BatchRegistry
 	processors             *crosschain.Processors
-	service                nodetype.NodeType
+	mempool                *txpool.TxPool
 	gasOracle              gas.Oracle
 	blockResolver          storage.BlockResolver
 	l1BlockProcessor       components.L1BlockProcessor
 	config                 *enclaveconfig.EnclaveConfig
 	logger                 gethlog.Logger
-	whitelist              *privacy.Whitelist
+	storageSlotWhitelist   *privacy.Whitelist
 }
 
-func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey, storage storage.Storage, cacheService *storage.CacheService, registry components.BatchRegistry, processors *crosschain.Processors, service nodetype.NodeType, config *enclaveconfig.EnclaveConfig, oracle gas.Oracle, blockResolver storage.BlockResolver, l1BlockProcessor components.L1BlockProcessor, chain l2chain.ObscuroChain, logger gethlog.Logger) *EncryptionManager {
+func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey, storage storage.Storage, cacheService *storage.CacheService, registry components.BatchRegistry, mempool *txpool.TxPool, processors *crosschain.Processors, config *enclaveconfig.EnclaveConfig, oracle gas.Oracle, blockResolver storage.BlockResolver, l1BlockProcessor components.L1BlockProcessor, chain l2chain.ObscuroChain, logger gethlog.Logger) *EncryptionManager {
 	return &EncryptionManager{
 		storage:                storage,
 		cacheService:           cacheService,
 		registry:               registry,
 		processors:             processors,
-		service:                service,
 		chain:                  chain,
 		config:                 config,
 		blockResolver:          blockResolver,
@@ -48,7 +48,8 @@ func NewEncryptionManager(enclavePrivateKeyECIES *ecies.PrivateKey, storage stor
 		gasOracle:              oracle,
 		logger:                 logger,
 		enclavePrivateKeyECIES: enclavePrivateKeyECIES,
-		whitelist:              privacy.NewWhitelist(),
+		storageSlotWhitelist:   privacy.NewWhitelist(),
+		mempool:                mempool,
 	}
 }
 

--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -26,7 +26,7 @@ import (
 )
 
 // this is how long the node waits to receive the second batch
-var startMempoolTimeout = 120 * time.Second
+var startMempoolTimeout = 5 * time.Minute
 
 // TxPool is an obscuro wrapper around geths transaction pool
 type TxPool struct {

--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -81,7 +81,7 @@ func (t *TxPool) start() {
 	)
 	defer newHeadSub.Unsubscribe()
 	defer close(newHeadCh)
-	for {
+	for { //nolint:gosimple
 		select {
 		case event := <-newHeadCh:
 			newHead := event.Block.Header()

--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -26,7 +26,7 @@ import (
 )
 
 // this is how long the node waits to receive the second batch
-var startMempoolTimeout = 20 * time.Second
+var startMempoolTimeout = 120 * time.Second
 
 // TxPool is an obscuro wrapper around geths transaction pool
 type TxPool struct {

--- a/go/enclave/txpool/txpool.go
+++ b/go/enclave/txpool/txpool.go
@@ -85,8 +85,8 @@ func (t *TxPool) start() {
 		newHeadCh  = make(chan core.ChainHeadEvent)
 		newHeadSub = t.Chain.SubscribeChainHeadEvent(newHeadCh)
 	)
-	defer newHeadSub.Unsubscribe()
 	defer close(newHeadCh)
+	defer newHeadSub.Unsubscribe()
 	for {
 		select {
 		case event := <-newHeadCh:

--- a/integration/eth2network/pos_eth2_network.go
+++ b/integration/eth2network/pos_eth2_network.go
@@ -177,6 +177,7 @@ func (n *PosImpl) Start() error {
 }
 
 func (n *PosImpl) Stop() error {
+	println("Stopping geth Network")
 	kill(n.gethProcessID)
 	kill(n.validatorProcessID)
 	kill(n.beaconProcessID)
@@ -399,6 +400,7 @@ func fundWallets(walletsToFund []string, buildDir string, chainID int) (string, 
 }
 
 func kill(pid int) {
+	fmt.Printf("Killing %d\n", pid)
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		fmt.Printf("Error finding process with PID %d: %v\n", pid, err)


### PR DESCRIPTION
### Why this change is needed

- In preparation for HA, we need more flexibility on how the mempool behaves.
- The logic to start the mempool was unnecessarily complex

### What changes were made as part of this PR

- remove "submitTransaction" from node type
- add additional logic to the mempool
- simplify the mempool start logic

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


