### PR TITLE
Add cAdvisor and Node Exporter to VMs, Configure Prometheus for Central Metrics

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway-database.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway-database.yml
@@ -90,7 +90,7 @@ jobs:
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && git clone --depth 1 -b ${{ env.BRANCH_NAME }} https://github.com/ten-protocol/go-ten.git /home/obscuro/go-obscuro \
             && docker network create --driver bridge node_network || true \
-            && mkdir -p /home/obscuro/promtail \
+            && mkdir -p /home/obscuro/metrics \
             && echo "
             server:
               http_listen_port: 9080
@@ -124,16 +124,58 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/promtail/promtail-config.yaml \
+            " > /home/obscuro/metrics/promtail-config.yaml \
+            && echo "
+            global:
+              scrape_interval: 15s
+              evaluation_interval: 15s
+            remote_write:
+              - url: ${{ vars.METRICS_URI }}
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: ${{ secrets.LOKI_USER }}
+                  password: ${{ secrets.LOKI_PASSWORD }}
+            scrape_configs:
+              # Node metrics
+              - job_name:  node-${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s  # Frequent scrapes for node metrics
+                static_configs:
+                  - targets:
+                      - node_exporter:9100  # Node Exporter instance
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }}
+
+              # Container metrics
+              - job_name:  container-${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s
+                static_configs:
+                  - targets:
+                      - cadvisor:8080  # cAdvisor instance for container metrics
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }}
+
+            " > /home/obscuro/metrics/prometheus.yaml \
             && docker run -d --name promtail \
               --network node_network \
               -e HOSTNAME=${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }} \
               -v /var/log:/var/log \
-              -v /home/obscuro/promtail:/etc/promtail \
+              -v /home/obscuro/metrics:/etc/promtail \
               -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
               -v /var/run/docker.sock:/var/run/docker.sock \
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
+            && docker run -d --name prometheus \
+              --network node_network \
+              -p 9090:9090 \
+              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+              -v prometheus-data:/prometheus \
+              prom/prometheus:latest \
+              --config.file=/etc/prometheus/prometheus.yml \
             && cd /home/obscuro/go-obscuro/ \
             && docker run -d --name ${{ github.event.inputs.testnet_type }}-OG-MariaDB-${{ GITHUB.RUN_NUMBER }} \
                 -p 3306:3306 \

--- a/.github/workflows/manual-deploy-obscuro-gateway-database.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway-database.yml
@@ -100,7 +100,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -130,7 +130,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -251,7 +251,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: "${{ vars.METRICS_URI }}"
+              - url: "${{ vars.METRICS_URI }}/loki/api/v1/push"
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -292,7 +292,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: "${{ vars.METRICS_URI }}"
+              - url: "${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write"
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -239,9 +239,9 @@ jobs:
             cd /home/obscuro/go-obscuro/
 
             # Promtail Integration Start
-            mkdir -p /home/obscuro/promtail
+            mkdir -p /home/obscuro/metrics
 
-            cat <<EOF > /home/obscuro/promtail/promtail-config.yaml
+            cat <<EOF > /home/obscuro/metrics/promtail-config.yaml
             
             server:
               http_listen_port: 9080
@@ -281,11 +281,74 @@ jobs:
             --network node_network \
             -e HOSTNAME="${{ env.VM_NAME }}" \
             -v /var/log:/var/log \
-            -v /home/obscuro/promtail:/etc/promtail \
+            -v /home/obscuro/metrics:/etc/promtail \
             -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
             -v /var/run/docker.sock:/var/run/docker.sock \
             grafana/promtail:latest \
             -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true
+
+            cat <<EOF > /home/obscuro/metrics/prometheus.yaml
+            global:
+              scrape_interval: 15s
+              evaluation_interval: 15s
+            remote_write:
+              - url: "${{ vars.METRICS_URI }}"
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: "${{ secrets.LOKI_USER }}"
+                  password: "${{ secrets.LOKI_PASSWORD }}"
+            scrape_configs:
+              # Node metrics
+              - job_name:  node-${{ env.VM_NAME }}
+                scrape_interval: 5s  # Frequent scrapes for node metrics
+                static_configs:
+                  - targets:
+                      - node_exporter:9100  # Node Exporter instance
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  node-${{ env.VM_NAME }}
+
+              # Container metrics
+              - job_name:  container-${{ env.VM_NAME }}
+                scrape_interval: 5s
+                static_configs:
+                  - targets:
+                      - cadvisor:8080  # cAdvisor instance for container metrics
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  container-${{ env.VM_NAME }}
+            EOF
+
+            docker volume create prometheus-data
+            docker run -d --name prometheus \
+            --network node_network \
+            -p 9090:9090 \
+            -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+            -v prometheus-data:/prometheus \
+            prom/prometheus:latest \
+            --config.file=/etc/prometheus/prometheus.yml
+
+            docker run -d --name node_exporter \
+            --network node_network \
+            -p 9100:9100 \
+            --pid="host" \
+            -v /:/host:ro \
+            quay.io/prometheus/node-exporter:latest \
+            --path.rootfs=/host
+
+            docker run -d --name cadvisor \
+            --network node_network \
+            -p 8080:8080 \
+            --privileged \
+            -v /:/rootfs:ro \
+            -v /var/run:/var/run:ro \
+            -v /sys:/sys:ro \
+            -v /var/lib/docker/:/var/lib/docker:ro \
+            -v /dev/disk/:/dev/disk:ro \
+            gcr.io/cadvisor/cadvisor:latest
             # Promtail Integration End
             
             # Start Ten Gateway Container

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -113,7 +113,7 @@ jobs:
             && sudo snap refresh \
             && curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh \
             && docker network create --driver bridge l1_network || true \
-            && mkdir -p /home/obscuro/promtail \
+            && mkdir -p /home/obscuro/metrics \
             && echo "
             server:
               http_listen_port: 9080
@@ -147,16 +147,76 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/promtail/promtail-config.yaml \
+            " > /home/obscuro/metrics/promtail-config.yaml \
+            && echo "
+            global:
+              scrape_interval: 15s
+              evaluation_interval: 15s
+            remote_write:
+              - url: ${{ vars.METRICS_URI }}
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: ${{ secrets.LOKI_USER }}
+                  password: ${{ secrets.LOKI_PASSWORD }}
+            scrape_configs:
+              # Node metrics
+              - job_name:  node-${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s  # Frequent scrapes for node metrics
+                static_configs:
+                  - targets:
+                      - node_exporter:9100  # Node Exporter instance
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
+
+              # Container metrics
+              - job_name:  container-${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s
+                static_configs:
+                  - targets:
+                      - cadvisor:8080  # cAdvisor instance for container metrics
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
+
+            " > /home/obscuro/metrics/prometheus.yaml \
             && docker run -d --name promtail \
               --network l1_network \
               -e HOSTNAME=${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }} \
               -v /var/log:/var/log \
-              -v /home/obscuro/promtail:/etc/promtail \
+              -v /home/obscuro/metrics:/etc/promtail \
               -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
               -v /var/run/docker.sock:/var/run/docker.sock \
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
+            && docker volume create prometheus-data \
+            && docker run -d --name prometheus \
+              --network l1_network \
+              -p 9090:9090 \
+              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+              -v prometheus-data:/prometheus \
+              prom/prometheus:latest \
+              --config.file=/etc/prometheus/prometheus.yml \
+            && docker run -d --name node_exporter \
+              --network l1_network \
+              -p 9100:9100 \
+              --pid="host" \
+              -v /:/host:ro \
+              quay.io/prometheus/node-exporter:latest \
+              --path.rootfs=/host \
+            && docker run -d --name cadvisor \
+              --network l1_network \
+              -p 8080:8080 \
+              --privileged \
+              -v /:/rootfs:ro \
+              -v /var/run:/var/run:ro \
+              -v /sys:/sys:ro \
+              -v /var/lib/docker/:/var/lib/docker:ro \
+              -v /dev/disk/:/dev/disk:ro \
+              gcr.io/cadvisor/cadvisor:latest \
             && docker run -d \
             -p 8025:8025 -p 8026:8026 -p 9000:9000 -p 9001:9001 -p 12600:12600 \
             --entrypoint /home/obscuro/go-obscuro/integration/eth2network/main/main ${{ vars.DOCKER_BUILD_TAG_ETH2NETWORK }} \

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -123,7 +123,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -153,7 +153,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:
@@ -181,7 +181,6 @@ jobs:
                   - source_labels: [job]
                     target_label: 'node'
                     replacement:  ${{ github.event.inputs.testnet_type }}-eth2network-${{ GITHUB.RUN_NUMBER }}
-
             " > /home/obscuro/metrics/prometheus.yaml \
             && docker run -d --name promtail \
               --network l1_network \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -276,7 +276,7 @@ jobs:
                   password: ${{ secrets.LOKI_PASSWORD }}
             scrape_configs:
               # Node metrics
-              - job_name:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+              - job_name:  node-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
                 scrape_interval: 5s  # Frequent scrapes for node metrics
                 static_configs:
                   - targets:
@@ -287,7 +287,7 @@ jobs:
                     replacement:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
 
               # Container metrics
-              - job_name:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+              - job_name:  container-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
                 scrape_interval: 5s
                 static_configs:
                   - targets:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: 'Build and push obscuro node images'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }} --build-arg TESTMODE=true -f dockerfiles/enclave.Dockerfile  .
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }} -f dockerfiles/enclave.Dockerfile  .
           docker push ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }}
           DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_HOST }} -f dockerfiles/host.Dockerfile .
           docker push ${{ vars.DOCKER_BUILD_TAG_HOST }}
@@ -199,7 +199,7 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ vars.AZURE_RESOURCE_PREFIX }}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}" \
+            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}" \
             --tags deploygroup=ObscuroNode-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_L2 }}=true \
             --vnet-name ${{ github.event.inputs.testnet_type }}-virtual-network --subnet ${{ github.event.inputs.testnet_type }}-sub-network \
             --size Standard_DC8_v2 --storage-sku StandardSSD_LRS --image ObscuroConfUbuntu \
@@ -215,7 +215,7 @@ jobs:
       - name: 'Allow time for VM initialization'
         shell: bash
         run: sleep 60
-      
+
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
@@ -262,7 +262,7 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/metrics/promtail-config.yaml \
+            " > /home/obscuro/promtail/promtail-config.yaml \
             && echo "
             global:
               scrape_interval: 15s
@@ -308,30 +308,30 @@ jobs:
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
             && docker volume create prometheus-data \
-            docker run -d --name prometheus \
-            --network node_network \
-            -p 9090:9090 \
-            -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
-            -v prometheus-data:/prometheus \
-            prom/prometheus:latest \
-            --config.file=/etc/prometheus/prometheus.yml \
+            && docker run -d --name prometheus \
+              --network node_network \
+              -p 9090:9090 \
+              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+              -v prometheus-data:/prometheus \
+              prom/prometheus:latest \
+              --config.file=/etc/prometheus/prometheus.yml \
             && docker run -d --name node_exporter \
-            --network node_network \
-            -p 9100:9100 \
-            --pid="host" \
-            -v /:/host:ro \
-            quay.io/prometheus/node-exporter:latest \
-            --path.rootfs=/host \
+              --network node_network \
+              -p 9100:9100 \
+              --pid="host" \
+              -v /:/host:ro \
+              quay.io/prometheus/node-exporter:latest \
+              --path.rootfs=/host \
             && docker run -d --name cadvisor \
-            --network node_network \
-            -p 8080:8080 \
-            --privileged \
-            -v /:/rootfs:ro \
-            -v /var/run:/var/run:ro \
-            -v /sys:/sys:ro \
-            -v /var/lib/docker/:/var/lib/docker:ro \
-            -v /dev/disk/:/dev/disk:ro \
-            gcr.io/cadvisor/cadvisor:latest \
+              --network node_network \
+              -p 8080:8080 \
+              --privileged \
+              -v /:/rootfs:ro \
+              -v /var/run:/var/run:ro \
+              -v /sys:/sys:ro \
+              -v /var/lib/docker/:/var/lib/docker:ro \
+              -v /dev/disk/:/dev/disk:ro \
+              gcr.io/cadvisor/cadvisor:latest \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
                -is_genesis=${{ matrix.is_genesis }} \
@@ -343,8 +343,8 @@ jobs:
                -message_bus_contract_addr=${{needs.build.outputs.MSG_BUS_CONTRACT_ADDR}} \
                -l1_start=${{needs.build.outputs.L1_START_HASH}} \
                -private_key=${{ secrets[matrix.node_pk_lookup] }} \
-               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
-               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
+               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
                -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
@@ -354,6 +354,8 @@ jobs:
                -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
                -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
+               -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
+               -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \
                -postgres_db_host=postgres://tenuser:${{ secrets.TEN_POSTGRES_USER_PWD }}@postgres-ten-${{  github.event.inputs.testnet_type }}.postgres.database.azure.com:5432/ \
                start'
 
@@ -370,9 +372,9 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
 
   deploy-l2-contracts:
     needs:
@@ -389,7 +391,7 @@ jobs:
         shell: bash
         run: |
           go run ./testnet/launcher/l2contractdeployer/cmd \
-          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com \
+          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com \
           -l1_http_url=${{ secrets.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.ACCOUNT_PK_WORKER }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: 'Build and push obscuro node images'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }} -f dockerfiles/enclave.Dockerfile  .
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }} --build-arg TESTMODE=true -f dockerfiles/enclave.Dockerfile  .
           docker push ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }}
           DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_HOST }} -f dockerfiles/host.Dockerfile .
           docker push ${{ vars.DOCKER_BUILD_TAG_HOST }}
@@ -199,7 +199,7 @@ jobs:
           inlineScript: |
             az vm create -g Testnet -n "${{ vars.AZURE_RESOURCE_PREFIX }}-${{ matrix.host_id }}-${{ GITHUB.RUN_NUMBER }}" \
             --admin-username obscurouser --admin-password "${{ secrets.OBSCURO_NODE_VM_PWD }}" \
-            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}" \
+            --public-ip-address-dns-name "obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}" \
             --tags deploygroup=ObscuroNode-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}  ${{ vars.AZURE_DEPLOY_GROUP_L2 }}=true \
             --vnet-name ${{ github.event.inputs.testnet_type }}-virtual-network --subnet ${{ github.event.inputs.testnet_type }}-sub-network \
             --size Standard_DC8_v2 --storage-sku StandardSSD_LRS --image ObscuroConfUbuntu \
@@ -215,7 +215,7 @@ jobs:
       - name: 'Allow time for VM initialization'
         shell: bash
         run: sleep 60
-
+      
       - name: 'Start Obscuro node-${{ matrix.host_id }} on Azure'
         uses: azure/CLI@v1
         with:
@@ -228,7 +228,8 @@ jobs:
             && chown obscurouser:obscurouser /home/obscurouser/edb-connect.sh \
             && chmod u+x /home/obscurouser/edb-connect.sh \
             && docker network create --driver bridge node_network || true \
-            && mkdir -p /home/obscuro/promtail \
+            && mkdir -p /home/obscuro/metrics \
+            && echo "AZURE_METRICS_PROMETHEUS_ENDPOINT=http://localhost:9090/metrics" | tee -a /etc/environment \
             && echo "
             server:
               http_listen_port: 9080
@@ -262,16 +263,35 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/promtail/promtail-config.yaml \
+            " > /home/obscuro/metrics/promtail-config.yaml \
+            && echo "
+            scrape_configs:
+            - job_name: 'cadvisor'
+              static_configs:
+              - targets: ['host.docker.internal:8080']
+                      - job_name: flog_scrape
+                        docker_sd_configs:
+                          - host: unix:///var/run/docker.sock
+                            refresh_interval: 5s
+              relabel_configs:
+                - source_labels: [\"__meta_docker_container_name\"]
+                  regex: \"/(.*)\"
+                  target_label: \"container\"
+                  target_label: \"job\"
+                - replacement: ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+                  target_label: "node_name"
+            " > /home/obscuro/metrics/prometheus.yml \
             && docker run -d --name promtail \
               --network node_network \
               -e HOSTNAME=${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }} \
               -v /var/log:/var/log \
-              -v /home/obscuro/promtail:/etc/promtail \
+              -v /home/obscuro/metrics:/etc/promtail \
               -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
               -v /var/run/docker.sock:/var/run/docker.sock \
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
+            && docker run -d --name=prometheus -p 9090:9090 -v /home/obscuro/metrics/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus \
+            &&  docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --publish=8080:8080 --detach=true --name=cadvisor google/cadvisor:latest \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
                -is_genesis=${{ matrix.is_genesis }} \
@@ -283,8 +303,8 @@ jobs:
                -message_bus_contract_addr=${{needs.build.outputs.MSG_BUS_CONTRACT_ADDR}} \
                -l1_start=${{needs.build.outputs.L1_START_HASH}} \
                -private_key=${{ secrets[matrix.node_pk_lookup] }} \
-               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
-               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:10000 \
+               -sequencer_addr=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
+               -host_public_p2p_addr=obscuronode-${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com:10000 \
                -host_p2p_port=10000 \
                -enclave_docker_image=${{ vars.L2_ENCLAVE_DOCKER_BUILD_TAG }} \
                -host_docker_image=${{ vars.L2_HOST_DOCKER_BUILD_TAG }} \
@@ -294,8 +314,6 @@ jobs:
                -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
                -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
-               -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
-               -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \
                -postgres_db_host=postgres://tenuser:${{ secrets.TEN_POSTGRES_USER_PWD }}@postgres-ten-${{  github.event.inputs.testnet_type }}.postgres.database.azure.com:5432/ \
                start'
 
@@ -312,9 +330,9 @@ jobs:
       - name: "Wait until obscuro node is healthy"
         shell: bash
         run: |
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
-          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
+          ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com
 
   deploy-l2-contracts:
     needs:
@@ -331,7 +349,7 @@ jobs:
         shell: bash
         run: |
           go run ./testnet/launcher/l2contractdeployer/cmd \
-          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com \
+          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}.uksouth.cloudapp.azure.com \
           -l1_http_url=${{ secrets.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.ACCOUNT_PK_WORKER }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -262,7 +262,7 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/promtail/promtail-config.yaml \
+            " > /home/obscuro/metrics/promtail-config.yaml \
             && echo "
             global:
               scrape_interval: 15s
@@ -311,7 +311,7 @@ jobs:
             && docker run -d --name prometheus \
               --network node_network \
               -p 9090:9090 \
-              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+              -v /home/obscuro/metrics:/etc/prometheus/prometheus.yml \
               -v prometheus-data:/prometheus \
               prom/prometheus:latest \
               --config.file=/etc/prometheus/prometheus.yml \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -311,7 +311,7 @@ jobs:
             && docker run -d --name prometheus \
               --network node_network \
               -p 9090:9090 \
-              -v /home/obscuro/metrics:/etc/prometheus/prometheus.yml \
+              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
               -v prometheus-data:/prometheus \
               prom/prometheus:latest \
               --config.file=/etc/prometheus/prometheus.yml \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -238,7 +238,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -268,7 +268,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -229,7 +229,6 @@ jobs:
             && chmod u+x /home/obscurouser/edb-connect.sh \
             && docker network create --driver bridge node_network || true \
             && mkdir -p /home/obscuro/metrics \
-            && echo "AZURE_METRICS_PROMETHEUS_ENDPOINT=http://localhost:9090/metrics" | tee -a /etc/environment \
             && echo "
             server:
               http_listen_port: 9080
@@ -265,22 +264,48 @@ jobs:
                   target_label: "node_name"
             " > /home/obscuro/metrics/promtail-config.yaml \
             && echo "
+            global:
+              scrape_interval: 15s
+              evaluation_interval: 15s
+            remote_write:
+              - url: ${{ vars.METRICS_URI }}
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: ${{ secrets.LOKI_USER }}
+                  password: ${{ secrets.LOKI_PASSWORD }}
             scrape_configs:
-            - job_name: 'cadvisor'
-              static_configs:
-              - targets: ['host.docker.internal:8080']
-                      - job_name: flog_scrape
-                        docker_sd_configs:
-                          - host: unix:///var/run/docker.sock
-                            refresh_interval: 5s
-              relabel_configs:
-                - source_labels: [\"__meta_docker_container_name\"]
-                  regex: \"/(.*)\"
-                  target_label: \"container\"
-                  target_label: \"job\"
-                - replacement: ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
-                  target_label: "node_name"
-            " > /home/obscuro/metrics/prometheus.yml \
+              # Node metrics
+              - job_name:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s  # Frequent scrapes for node metrics
+                static_configs:
+                  - targets:
+                      - node_exporter:9100  # Node Exporter instance
+                relabel_configs:
+                  - source_labels: [__address__]
+                    regex: '(.+):9100'
+                    replacement: '${1}'
+                    target_label: 'instance'
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+
+              # Container metrics
+              - job_name:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s
+                static_configs:
+                  - targets:
+                      - cadvisor:8080  # cAdvisor instance for container metrics
+                relabel_configs:
+                  - source_labels: [__address__]
+                    regex: '(.+):8080'
+                    replacement: '${1}'
+                    target_label: 'instance'
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
+
+            " > /home/obscuro/metrics/prometheus.yaml \
             && docker run -d --name promtail \
               --network node_network \
               -e HOSTNAME=${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }} \
@@ -290,8 +315,31 @@ jobs:
               -v /var/run/docker.sock:/var/run/docker.sock \
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
-            && docker run -d --name=prometheus -p 9090:9090 -v /home/obscuro/metrics/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus \
-            &&  docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --publish=8080:8080 --detach=true --name=cadvisor google/cadvisor:latest \
+            && docker volume create prometheus-data \
+            docker run -d --name prometheus \
+            --network node_network \
+            -p 9090:9090 \
+            -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+            -v prometheus-data:/prometheus \
+            prom/prometheus:latest \
+            --config.file=/etc/prometheus/prometheus.yml \
+            && docker run -d --name node_exporter \
+            --network node_network \
+            -p 9100:9100 \
+            --pid="host" \
+            -v /:/host:ro \
+            quay.io/prometheus/node-exporter:latest \
+            --path.rootfs=/host \
+            && docker run -d --name cadvisor \
+            --network node_network \
+            -p 8080:8080 \
+            --privileged \
+            -v /:/rootfs:ro \
+            -v /var/run:/var/run:ro \
+            -v /sys:/sys:ro \
+            -v /var/lib/docker/:/var/lib/docker:ro \
+            -v /dev/disk/:/dev/disk:ro \
+            gcr.io/cadvisor/cadvisor:latest \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
                -is_genesis=${{ matrix.is_genesis }} \

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -282,10 +282,6 @@ jobs:
                   - targets:
                       - node_exporter:9100  # Node Exporter instance
                 relabel_configs:
-                  - source_labels: [__address__]
-                    regex: '(.+):9100'
-                    replacement: '${1}'
-                    target_label: 'instance'
                   - source_labels: [job]
                     target_label: 'node'
                     replacement:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}
@@ -297,10 +293,6 @@ jobs:
                   - targets:
                       - cadvisor:8080  # cAdvisor instance for container metrics
                 relabel_configs:
-                  - source_labels: [__address__]
-                    regex: '(.+):8080'
-                    replacement: '${1}'
-                    target_label: 'instance'
                   - source_labels: [job]
                     target_label: 'node'
                     replacement:  ${{ matrix.host_id }}-${{ github.event.inputs.testnet_type }}-${{ GITHUB.RUN_NUMBER }}

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -158,7 +158,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -188,7 +188,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}
+              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -148,7 +148,7 @@ jobs:
             --scripts 'mkdir -p /home/obscuro \
             && git clone --depth 1 -b ${{ env.BRANCH_NAME }} https://github.com/ten-protocol/go-ten.git /home/obscuro/go-obscuro \
             && docker network create --driver bridge node_network || true \
-            && mkdir -p /home/obscuro/promtail \
+            && mkdir -p /home/obscuro/metrics \
             && echo "
             server:
               http_listen_port: 9080
@@ -182,16 +182,75 @@ jobs:
                   target_label: \"job\"
                 - replacement: ${{ vars.AZURE_RESOURCE_PREFIX }}-${{ github.event.inputs.node_id }}-${{ GITHUB.RUN_NUMBER }}
                   target_label: "node_name"
-            " > /home/obscuro/promtail/promtail-config.yaml \
+            " > /home/obscuro/metrics/promtail-config.yaml \
+            && echo "
+            global:
+              scrape_interval: 15s
+              evaluation_interval: 15s
+            remote_write:
+              - url: ${{ vars.METRICS_URI }}
+                tls_config:
+                  insecure_skip_verify: true
+                basic_auth:
+                  username: ${{ secrets.LOKI_USER }}
+                  password: ${{ secrets.LOKI_PASSWORD }}
+            scrape_configs:
+              # Node metrics
+              - job_name:  node-${{ github.event.inputs.testnet_type }}-validator-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s  # Frequent scrapes for node metrics
+                static_configs:
+                  - targets:
+                      - node_exporter:9100  # Node Exporter instance
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  node-${{ github.event.inputs.testnet_type }}-validator-${{ GITHUB.RUN_NUMBER }}
+
+              # Container metrics
+              - job_name:  container-${{ github.event.inputs.testnet_type }}-validator-${{ GITHUB.RUN_NUMBER }}
+                scrape_interval: 5s
+                static_configs:
+                  - targets:
+                      - cadvisor:8080  # cAdvisor instance for container metrics
+                relabel_configs:
+                  - source_labels: [job]
+                    target_label: 'node'
+                    replacement:  container-${{ github.event.inputs.testnet_type }}-validator-${{ GITHUB.RUN_NUMBER }}
+            " > /home/obscuro/metrics/prometheus.yaml \
             && docker run -d --name promtail \
               --network node_network \
               -e HOSTNAME=${{ vars.AZURE_RESOURCE_PREFIX }}-${{ github.event.inputs.node_id }}-${{ GITHUB.RUN_NUMBER }} \
               -v /var/log:/var/log \
-              -v /home/obscuro/promtail:/etc/promtail \
+              -v /home/obscuro/metrics:/etc/promtail \
               -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
               -v /var/run/docker.sock:/var/run/docker.sock \
               grafana/promtail:latest \
               -config.file=/etc/promtail/promtail-config.yaml -config.expand-env=true \
+            && docker volume create prometheus-data \
+            && docker run -d --name prometheus \
+              --network node_network \
+              -p 9090:9090 \
+              -v /home/obscuro/metrics/prometheus.yaml:/etc/prometheus/prometheus.yml \
+              -v prometheus-data:/prometheus \
+              prom/prometheus:latest \
+              --config.file=/etc/prometheus/prometheus.yml \
+            && docker run -d --name node_exporter \
+              --network node_network \
+              -p 9100:9100 \
+              --pid="host" \
+              -v /:/host:ro \
+              quay.io/prometheus/node-exporter:latest \
+              --path.rootfs=/host \
+            && docker run -d --name cadvisor \
+              --network node_network \
+              -p 8080:8080 \
+              --privileged \
+              -v /:/rootfs:ro \
+              -v /var/run:/var/run:ro \
+              -v /sys:/sys:ro \
+              -v /var/lib/docker/:/var/lib/docker:ro \
+              -v /dev/disk/:/dev/disk:ro \
+              gcr.io/cadvisor/cadvisor:latest \
             && cd /home/obscuro/go-obscuro/ \
             && sudo go run /home/obscuro/go-obscuro/go/node/cmd  \
                -is_genesis=false \


### PR DESCRIPTION
### Why this change is needed

We are missing container and node metrics in grafana 

### What changes were made as part of this PR

Deployed cAdvisor and Node Exporter on each VM for system and container-level metrics collection.
Configured Prometheus on the VMs to scrape metrics from cAdvisor and Node Exporter.
Integrated Prometheus with a central metrics endpoint for unified monitoring and visualization.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


