### PR TITLE
fixed ten_health endpoint in wait-node-health script

### DIFF
--- a/.github/workflows/runner-scripts/wait-node-healthy.sh
+++ b/.github/workflows/runner-scripts/wait-node-healthy.sh
@@ -60,7 +60,7 @@ while ! [[ $net_status = *\"OverallHealth\":true* ]]
 do
     net_status=$(curl --request POST "http://${host}:${port}" \
                  --header 'Content-Type: application/json' \
-                 --data-raw '{ "method":"obscuro_health", "params":null, "id":1, "jsonrpc":"2.0" }') || true
+                 --data-raw '{ "method":"ten_health", "params":null, "id":1, "jsonrpc":"2.0" }') || true
     echo $net_status
 
     sleep 2


### PR DESCRIPTION
### Why this change is needed

Health end has been updated    to ten_health
### What changes were made as part of this PR

endpoint method is update to ten_health from obscro_health

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


