### PR TITLE
Enclave: update cache on nodetype change

### DIFF
--- a/go/enclave/storage/cache_service.go
+++ b/go/enclave/storage/cache_service.go
@@ -214,6 +214,16 @@ func (cs *CacheService) ReadEnclavePubKey(ctx context.Context, enclaveId common.
 	return getCachedValue(ctx, cs.attestedEnclavesCache, cs.logger, enclaveId, enclaveCost, onCacheMiss, true)
 }
 
+func (cs *CacheService) UpdateEnclaveNodeType(ctx context.Context, enclaveId common.EnclaveID, nodeType common.NodeType) {
+	enclave, err := cs.ReadEnclavePubKey(ctx, enclaveId, nil)
+	if err != nil {
+		cs.logger.Debug("No cache entry found to update", log.ErrKey, err)
+		return
+	}
+	enclave.Type = nodeType
+	cacheValue(ctx, cs.attestedEnclavesCache, cs.logger, enclaveId, enclave, enclaveCost)
+}
+
 // getCachedValue - returns the cached value for the provided key. If the key is not found, then invoke the 'onCacheMiss' function
 // which returns the value, and cache it
 func getCachedValue[V any](ctx context.Context, cache *cache.Cache[*V], logger gethlog.Logger, key any, cost int64, onCacheMiss func(any) (*V, error), cacheIfMissing bool) (*V, error) {

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -483,7 +483,13 @@ func (s *storageImpl) StoreNodeType(ctx context.Context, enclaveId common.Enclav
 	if err != nil {
 		return err
 	}
-	return dbTx.Commit()
+	err = dbTx.Commit()
+	if err != nil {
+		return fmt.Errorf("could not commit transaction - %w", err)
+	}
+	// set value in cache to ensure it is up to date
+	s.cachingService.UpdateEnclaveNodeType(ctx, enclaveId, nodeType)
+	return nil
 }
 
 func (s *storageImpl) StoreNewEnclave(ctx context.Context, enclaveId common.EnclaveID, key *ecdsa.PublicKey) error {


### PR DESCRIPTION
### Why this change is needed

Cache reads after node was promoted to sequencer were still returning old node type value in HA testing.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


