### PR TITLE
fix address compare

### DIFF
--- a/go/enclave/rpc/GetTransactionReceipt.go
+++ b/go/enclave/rpc/GetTransactionReceipt.go
@@ -145,8 +145,8 @@ func isAddress(topics []gethcommon.Hash, nr int, requester *gethcommon.Address) 
 	if len(topics) < nr+1 {
 		return false
 	}
-	topic := gethcommon.Address(topics[nr].Bytes())
-	return topic == *requester
+	addressFromTopic := gethcommon.BytesToAddress(topics[nr].Bytes())
+	return addressFromTopic == *requester
 }
 
 // marshalReceipt marshals a transaction receipt into a JSON object.

--- a/go/enclave/rpc/GetTransactionReceipt.go
+++ b/go/enclave/rpc/GetTransactionReceipt.go
@@ -86,7 +86,7 @@ func fetchFromCache(ctx context.Context, storage storage.Storage, cacheService *
 	// receipt found in cache
 	// for simplicity only the tx sender will access the cache
 	// check whether the requester is the sender
-	if rec.From != requester {
+	if *rec.From != *requester {
 		return nil, nil
 	}
 

--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -127,7 +127,7 @@ func (e *Service) EvictEnclave(enclaveID *common.EnclaveID) {
 	e.haLock.Lock()
 	defer e.haLock.Unlock()
 	for i, guardian := range e.enclaveGuardians {
-		if guardian.GetEnclaveID() == enclaveID {
+		if *(guardian.GetEnclaveID()) == *enclaveID {
 			failedEnclaveIdx = i
 			break
 		}
@@ -141,7 +141,7 @@ func (e *Service) EvictEnclave(enclaveID *common.EnclaveID) {
 	e.enclaveGuardians = append(e.enclaveGuardians[:failedEnclaveIdx], e.enclaveGuardians[failedEnclaveIdx+1:]...)
 	e.logger.Warn("Evicted enclave from HA pool.", log.EnclaveIDKey, enclaveID)
 
-	if e.activeSequencerID == enclaveID {
+	if *e.activeSequencerID == *enclaveID {
 		// sequencer enclave has failed, so we need to select another one to promote as the active sequencer
 		var i int
 		for i = 0; i < len(e.enclaveGuardians); i++ {

--- a/integration/networktest/tests/nodescenario/sequencer_multi_enclave_test.go
+++ b/integration/networktest/tests/nodescenario/sequencer_multi_enclave_test.go
@@ -38,7 +38,7 @@ func TestMultiEnclaveSequencer(t *testing.T) {
 // This test runs with an HA sequencer, does a transfer then kills the active sequencer enclave,
 // allows it time to failover then performs another transfer to check the failover was successful.
 // Note: this is a happy path failover, we need to test for edge cases etc and test the failover in a live testnet
-func TestHASequencerFailover(t *testing.T) {
+func TestHASequencerBackup(t *testing.T) {
 	networktest.TestOnlyRunsInIDE(t)
 	doubleTransferAmount := big.NewInt(2).Mul(big.NewInt(2), _transferAmount)
 	networktest.Run(


### PR DESCRIPTION
### Why this change is needed

This addresses the performance issue we've been seeing.
The receipt cache was not used

### What changes were made as part of this PR

- compare Addresses instead of pointers to addresses. (thanks golang)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


