### PR TITLE
Replaced loki and prometheus push uris

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway-database.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway-database.yml
@@ -100,7 +100,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
+              - url: ${{ vars.LOKI_URI }}
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -130,7 +130,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
+              - url: ${{ vars.PROMETHEUS_URI }}
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -255,7 +255,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: "${{ vars.METRICS_URI }}/loki/api/v1/push"
+              - url: "${{ vars.LOKI_URI }}"
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -296,7 +296,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: "${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write"
+              - url: "${{ vars.PROMETHEUS_URI }}"
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-testnet-l1.yml
+++ b/.github/workflows/manual-deploy-testnet-l1.yml
@@ -123,7 +123,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
+              - url: ${{ vars.LOKI_URI }}
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -153,7 +153,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
+              - url: ${{ vars.PROMETHEUS_URI }}
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -238,7 +238,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
+              - url: ${{ vars.LOKI_URI }}
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -268,7 +268,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
+              - url: ${{ vars.PROMETHEUS_URI }}
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -158,7 +158,7 @@ jobs:
               filename: /tmp/positions.yaml
 
             clients:
-              - url: ${{ vars.METRICS_URI }}/loki/api/v1/push
+              - url: ${{ vars.LOKI_URI }}
                 batchwait: 3s
                 batchsize: 1048576
                 tls_config:
@@ -188,7 +188,7 @@ jobs:
               scrape_interval: 15s
               evaluation_interval: 15s
             remote_write:
-              - url: ${{ vars.METRICS_URI }}/prometheus/metrics/api/v1/write
+              - url: ${{ vars.PROMETHEUS_URI }}
                 tls_config:
                   insecure_skip_verify: true
                 basic_auth:


### PR DESCRIPTION
### Why this change is needed

We are migrating VM based monitoring stack to k8s 

### What changes were made as part of this PR

Updating loki and prometheus push URIs

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


