### PR TITLE
fix race condition

### DIFF
--- a/go/enclave/rpc/GetTransactionReceipt.go
+++ b/go/enclave/rpc/GetTransactionReceipt.go
@@ -101,8 +101,12 @@ func fetchFromCache(ctx context.Context, storage storage.Storage, cacheService *
 		// only filter when the transaction calls a contract. Value transfers emit no events.
 		if ctr != nil {
 			logs, err = filterLogs(ctx, storage, rec.Receipt.Logs, ctr, requester)
-			if err != nil {
+			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 				return nil, fmt.Errorf("could not filter cached logs in eth_getTransactionReceipt request. Cause: %w", err)
+			}
+			// in case the contract or event type is not stored yet, we try a db lookup
+			if errors.Is(err, errutil.ErrNotFound) {
+				return nil, nil
 			}
 		}
 	}
@@ -127,8 +131,11 @@ func filterLogs(ctx context.Context, storage storage.Storage, logs []*types.Log,
 func senderCanViewLog(ctx context.Context, storage storage.Storage, ctr *enclavedb.Contract, l *types.Log, sender *gethcommon.Address) (bool, error) {
 	eventSig := l.Topics[0]
 	eventType, err := storage.ReadEventType(ctx, ctr.Address, eventSig)
-	if err != nil {
+	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		return false, fmt.Errorf("could not read event type in eth_getTransactionReceipt request. Cause: %w", err)
+	}
+	if errors.Is(err, errutil.ErrNotFound) {
+		return false, err
 	}
 	// event visibility logic
 	canView := eventType.IsPublic() ||


### PR DESCRIPTION
### Why this change is needed

fixes a race condition when reading receipts

### What changes were made as part of this PR

handle the rpc request made before the batch is executed

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


