### PR TITLE
cache rpc key

### DIFF
--- a/go/host/rpc/clientapi/client_api_ten.go
+++ b/go/host/rpc/clientapi/client_api_ten.go
@@ -16,6 +16,7 @@ import (
 // TenAPI implements Ten-specific JSON RPC operations.
 type TenAPI struct {
 	host   host.Host
+	rpcKey []byte
 	logger gethlog.Logger
 }
 
@@ -46,11 +47,15 @@ func (api *TenAPI) Config() (*ChecksumFormattedTenNetworkConfig, error) {
 }
 
 func (api *TenAPI) RpcKey() ([]byte, error) {
-	key, err := api.host.EnclaveClient().RPCEncryptionKey(context.Background())
+	if api.rpcKey != nil {
+		return api.rpcKey, nil
+	}
+	var err error
+	api.rpcKey, err = api.host.EnclaveClient().RPCEncryptionKey(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	return key, nil
+	return api.rpcKey, nil
 }
 
 func (api *TenAPI) EncryptedRPC(ctx context.Context, encryptedParams common.EncryptedRPCRequest) (responses.EnclaveResponse, error) {

--- a/go/rpc/network_client.go
+++ b/go/rpc/network_client.go
@@ -28,12 +28,8 @@ func NewEncNetworkClient(rpcAddress string, viewingKey *viewingkey.ViewingKey, l
 	return encClient, nil
 }
 
-func NewEncNetworkClientFromConn(connection *gethrpc.Client, viewingKey *viewingkey.ViewingKey, logger gethlog.Logger) (*EncRPCClient, error) {
-	enclavePublicKeyBytes, err := ReadEnclaveKey(connection)
-	if err != nil {
-		return nil, fmt.Errorf("error reading enclave public key: %v", err)
-	}
-	encClient, err := NewEncRPCClient(connection, viewingKey, enclavePublicKeyBytes, logger)
+func NewEncNetworkClientFromConn(connection *gethrpc.Client, encKey []byte, viewingKey *viewingkey.ViewingKey, logger gethlog.Logger) (*EncRPCClient, error) {
+	encClient, err := NewEncRPCClient(connection, viewingKey, encKey, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -36,14 +36,7 @@ func BytesToPrivateKey(keyBytes []byte) (*ecies.PrivateKey, error) {
 	return eciesPrivateKey, nil
 }
 
-func CreateEncClient(
-	conn *gethrpc.Client,
-	addressBytes []byte,
-	privateKeyBytes []byte,
-	signature []byte,
-	signatureType viewingkey.SignatureType,
-	logger gethlog.Logger,
-) (*rpc.EncRPCClient, error) {
+func CreateEncClient(conn *gethrpc.Client, encKey []byte, addressBytes []byte, privateKeyBytes []byte, signature []byte, signatureType viewingkey.SignatureType, logger gethlog.Logger) (*rpc.EncRPCClient, error) {
 	privateKey, err := BytesToPrivateKey(privateKeyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert bytes to ecies private key: %w", err)
@@ -58,7 +51,7 @@ func CreateEncClient(
 		SignatureWithAccountKey: signature,
 		SignatureType:           signatureType,
 	}
-	encClient, err := rpc.NewEncNetworkClientFromConn(conn, vk, logger)
+	encClient, err := rpc.NewEncNetworkClientFromConn(conn, encKey, vk, logger)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create EncRPCClient: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

Cache the RPC key on the client side ( the Ten gateway).
The previous implementation made an extra RPC call for every RPC.

### What changes were made as part of this PR

- cache the rpc key on the client
- cache the rpc key on the host

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


