### PR TITLE
fix bug with net_version call on the gateway

### DIFF
--- a/tools/walletextension/rpcapi/net_api.go
+++ b/tools/walletextension/rpcapi/net_api.go
@@ -17,7 +17,7 @@ func NewNetAPI(we *services.Services) *NetAPI {
 }
 
 func (api *NetAPI) Version(ctx context.Context) (*string, error) {
-	return UnauthenticatedTenRPCCall[string](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "net_version")
+	return UnauthenticatedTenRPCCall[string](ctx, api.we, &cache.Cfg{Type: cache.LongLiving}, "ten_version")
 }
 
 type ConfigResponseJson struct {


### PR DESCRIPTION
### Why this change is needed

net_version call was not working on the gateway

### What changes were made as part of this PR

change name of the function called to match actual endpoint

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


