### PR TITLE
Fix network test startup; Wait in a loop for rpc key to be initialised in the gateway

### DIFF
--- a/go/enclave/crypto/rpc_key_service.go
+++ b/go/enclave/crypto/rpc_key_service.go
@@ -1,7 +1,7 @@
 package crypto
 
 import (
-	"fmt"
+	"errors"
 
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
@@ -10,6 +10,8 @@ import (
 )
 
 const rpcSuffix = 1
+
+var ErrNotInitialised = errors.New("rpc key service is not initialised")
 
 // RPCKeyService - manages the "TEN - RPC key" used by clients (like the TEN gateway) to make RPC requests
 type RPCKeyService struct {
@@ -51,7 +53,7 @@ func (s *RPCKeyService) DecryptRPCRequest(bytes []byte) ([]byte, error) {
 
 func (s *RPCKeyService) PublicKey() ([]byte, error) {
 	if s.privKey == nil {
-		return nil, fmt.Errorf("rpc key service is not initialised")
+		return nil, ErrNotInitialised
 	}
 	return gethcrypto.CompressPubkey(s.privKey.PublicKey.ExportECDSA()), nil
 }


### PR DESCRIPTION
### Why this change is needed

The network test fails whenever the rpc key is not initialised as this is a critical issue instead of waiting.

### What changes were made as part of this PR

Made RPC key not initialised non crit issue; Code will now loop and wait for it.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


