### PR TITLE
refresh when new account is added to improve UX

### DIFF
--- a/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
+++ b/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
@@ -67,9 +67,9 @@ export const WalletConnectionProvider = ({
       setVersion(await fetchVersion());
     } catch (error) {
       showToast(
-          ToastType.DESTRUCTIVE,
-      error instanceof Error ? error.message : "Error initializing wallet connection. Please refresh the page."
-    );
+        ToastType.DESTRUCTIVE,
+        error instanceof Error ? error.message : "Error initializing wallet connection. Please refresh the page."
+      );
     } finally {
       setLoading(false);
     }
@@ -189,16 +189,26 @@ export const WalletConnectionProvider = ({
       setProvider(providerInstance);
       initialize(providerInstance);
 
-      ethereum.on("accountsChanged", fetchUserAccounts);
+      const handleAccountsChanged = async (accounts: string[]) => {
+        if (accounts.length === 0) {
+          setAccounts(null);
+          setWalletConnected(false);
+          setToken("");
+        } else {
+          window.location.reload();
+        }
+      };
+
+      ethereum.on("accountsChanged", handleAccountsChanged);
+
+      return () => {
+        if (ethereum && ethereum.removeListener) {
+          ethereum.removeListener("accountsChanged", handleAccountsChanged);
+        }
+      };
     } else {
       setLoading(false);
     }
-
-    return () => {
-      if (ethereum && ethereum.removeListener) {
-        ethereum.removeListener("accountsChanged", fetchUserAccounts);
-      }
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
### Why this change is needed

In out current frontend code we don't refresh the page after adding new account.  Instead it shows us the page like we never added a network, etc.

PR with video: https://github.com/ten-protocol/ten-internal/issues/3567

### What changes were made as part of this PR

- Improved frontend code with page refresh when new account is added to update everything needed.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


