### PR TITLE
Remove balance of message bus for burned native value.

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -143,6 +143,7 @@ func (executor *batchExecutor) ComputeBatch(ctx context.Context, ec *BatchExecut
 		return nil, ErrNoTransactionsToProcess
 	}
 
+	// Step 5: burn native value on the message bus according to what has been bridged out to the L1.
 	if err := executor.postProcessState(ec); err != nil {
 		return nil, fmt.Errorf("failed to post process state. Cause: %w", err)
 	}
@@ -340,6 +341,7 @@ func (executor *batchExecutor) execRegisteredCallbacks(ec *BatchExecutionContext
 	return nil
 }
 
+// postProcessState - Function for applying post processing, which currently is removing the value from the balance of the message bus contract.
 func (executor *batchExecutor) postProcessState(ec *BatchExecutionContext) error {
 	receipts := ec.batchTxResults.Receipts()
 	valueTransferMessages, err := executor.crossChainProcessors.Local.ExtractOutboundTransfers(ec.ctx, receipts)


### PR DESCRIPTION
### Why this change is needed

In order to have better book keeping on the message bus, the native transfers that get sent back to l1 need to be burned (as they are minted when they are inbound)

### What changes were made as part of this PR

A new function in the batch executor that goes over the transfers and burns the value.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


