### PR TITLE
fix websockets not connecting via secure wss

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -366,7 +366,7 @@ jobs:
             -e OE_SIMULATION=0 \
             "${{ env.DOCKER_BUILD_TAG_GATEWAY }}" \
             ego run /home/ten/go-ten/tools/walletextension/main/main \
-            -host=0.0.0.0 -port=443 -portWS=444 -nodeHost="${{ env.L2_RPC_URL_VALIDATOR }}" -verbose=true \
+            -host=0.0.0.0 -port=443 -portWS=443 -nodeHost="${{ env.L2_RPC_URL_VALIDATOR }}" -verbose=true \
             -logPath=sys_out -dbType=cosmosDB -dbConnectionURL="${{ secrets.COSMOS_DB_CONNECTION_STRING }}" \
             -rateLimitUserComputeTime="${{ env.GATEWAY_RATE_LIMIT_USER_COMPUTE_TIME }}" \
             -rateLimitWindow="${{ env.GATEWAY_RATE_LIMIT_WINDOW }}" \

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -202,7 +202,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az vm open-port -g Testnet -n "${{ env.VM_NAME }}"  --port 80,81,443,444
+            az vm open-port -g Testnet -n "${{ env.VM_NAME }}"  --port 80,81,443
 
         # To overcome issues with critical VM resources being unavailable, we need to wait for the VM to be ready
       - name: "Allow time for VM initialization"
@@ -359,7 +359,7 @@ jobs:
             docker volume create "${{ env.VM_NAME }}-data"
             
             # Start Ten Gateway Container
-            docker run -d -p 80:80 -p 81:81 -p 443:443 -p 444:444 --name "${{ env.VM_NAME }}" \
+            docker run -d -p 80:80 -p 81:81 -p 443:443 --name "${{ env.VM_NAME }}" \
             --device /dev/sgx_enclave --device /dev/sgx_provision \
             -v "${{ env.VM_NAME }}-data:/data" \
             -e OBSCURO_GATEWAY_VERSION="${{ github.run_number }}-${{ github.sha }}" \

--- a/lib/gethfork/node/rpcstack.go
+++ b/lib/gethfork/node/rpcstack.go
@@ -175,17 +175,24 @@ func (h *httpServer) start() error {
 	h.listener = listener
 	go h.server.Serve(listener)
 
+	// Determine the scheme for WebSockets based on TLS presence
 	if h.wsAllowed() {
-		url := fmt.Sprintf("ws://%v", listener.Addr())
+		scheme := "ws"
+		if h.tlsConfig != nil {
+			scheme = "wss"
+		}
+		url := fmt.Sprintf("%s://%v", scheme, listener.Addr())
 		if h.wsConfig.prefix != "" {
 			url += h.wsConfig.prefix
 		}
 		h.log.Info("WebSocket enabled", "url", url)
 	}
-	// if server is websocket only, return after logging
+
+	// If server is websocket only, return after logging
 	if !h.rpcAllowed() {
 		return nil
 	}
+
 	// Log http endpoint.
 	h.log.Info("HTTP server started",
 		"endpoint", listener.Addr(), "auth", (h.httpConfig.jwtSecret != nil),

--- a/lib/gethfork/node/rpcstack.go
+++ b/lib/gethfork/node/rpcstack.go
@@ -160,6 +160,7 @@ func (h *httpServer) start() error {
 
 	if h.tlsConfig != nil {
 		// If TLS is enabled, use tls.Listen to create a TLS listener
+		fmt.Println("STARTING HTTPS ENDPOINT")
 		listener, err = tls.Listen("tcp", h.endpoint, h.tlsConfig)
 	} else {
 		listener, err = net.Listen("tcp", h.endpoint)
@@ -179,12 +180,15 @@ func (h *httpServer) start() error {
 	if h.wsAllowed() {
 		scheme := "ws"
 		if h.tlsConfig != nil {
+			fmt.Println("h.tlsConfig != nil")
 			scheme = "wss"
 		}
+		fmt.Println("scheme", scheme)
 		url := fmt.Sprintf("%s://%v", scheme, listener.Addr())
 		if h.wsConfig.prefix != "" {
 			url += h.wsConfig.prefix
 		}
+		fmt.Println("WEBSOCKETurl", url)
 		h.log.Info("WebSocket enabled", "url", url)
 	}
 
@@ -200,6 +204,11 @@ func (h *httpServer) start() error {
 		"cors", strings.Join(h.httpConfig.CorsAllowedOrigins, ","),
 		"vhosts", strings.Join(h.httpConfig.Vhosts, ","),
 	)
+
+	fmt.Println("endpoint", listener.Addr())
+	fmt.Println("h.httpConfig.prefix", h.httpConfig.prefix)
+	fmt.Println("h.httpConfig.CorsAllowedOrigins", h.httpConfig.CorsAllowedOrigins)
+	fmt.Println("h.httpConfig.Vhosts", h.httpConfig.Vhosts)
 
 	// Log all handlers mounted on server.
 	var paths []string

--- a/lib/gethfork/node/rpcstack.go
+++ b/lib/gethfork/node/rpcstack.go
@@ -160,7 +160,6 @@ func (h *httpServer) start() error {
 
 	if h.tlsConfig != nil {
 		// If TLS is enabled, use tls.Listen to create a TLS listener
-		fmt.Println("STARTING HTTPS ENDPOINT")
 		listener, err = tls.Listen("tcp", h.endpoint, h.tlsConfig)
 	} else {
 		listener, err = net.Listen("tcp", h.endpoint)
@@ -180,15 +179,12 @@ func (h *httpServer) start() error {
 	if h.wsAllowed() {
 		scheme := "ws"
 		if h.tlsConfig != nil {
-			fmt.Println("h.tlsConfig != nil")
 			scheme = "wss"
 		}
-		fmt.Println("scheme", scheme)
 		url := fmt.Sprintf("%s://%v", scheme, listener.Addr())
 		if h.wsConfig.prefix != "" {
 			url += h.wsConfig.prefix
 		}
-		fmt.Println("WEBSOCKETurl", url)
 		h.log.Info("WebSocket enabled", "url", url)
 	}
 
@@ -204,11 +200,6 @@ func (h *httpServer) start() error {
 		"cors", strings.Join(h.httpConfig.CorsAllowedOrigins, ","),
 		"vhosts", strings.Join(h.httpConfig.Vhosts, ","),
 	)
-
-	fmt.Println("endpoint", listener.Addr())
-	fmt.Println("h.httpConfig.prefix", h.httpConfig.prefix)
-	fmt.Println("h.httpConfig.CorsAllowedOrigins", h.httpConfig.CorsAllowedOrigins)
-	fmt.Println("h.httpConfig.Vhosts", h.httpConfig.Vhosts)
 
 	// Log all handlers mounted on server.
 	var paths []string

--- a/lib/gethfork/rpc/websocket.go
+++ b/lib/gethfork/rpc/websocket.go
@@ -52,6 +52,8 @@ var wsBufferPool = new(sync.Pool)
 // allowedOrigins should be a comma-separated list of allowed origin URLs.
 // To allow connections with any origin, pass "*".
 func (s *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
+	fmt.Println("WebsocketHandler")
+	fmt.Println("allowedOrigins", allowedOrigins)
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  wsReadBuffer,
 		WriteBufferSize: wsWriteBuffer,

--- a/lib/gethfork/rpc/websocket.go
+++ b/lib/gethfork/rpc/websocket.go
@@ -52,8 +52,6 @@ var wsBufferPool = new(sync.Pool)
 // allowedOrigins should be a comma-separated list of allowed origin URLs.
 // To allow connections with any origin, pass "*".
 func (s *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
-	fmt.Println("WebsocketHandler")
-	fmt.Println("allowedOrigins", allowedOrigins)
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  wsReadBuffer,
 		WriteBufferSize: wsWriteBuffer,


### PR DESCRIPTION
### Why this change is needed

After using separate domains for backend and frontend we are connecting to the backend directly (to VM) and the traffic doesn't go through Azure Application Gateway anymore. This gateway was handling TLS termination for websockets before.

### What changes were made as part of this PR

- Using wss in case we have TLSConfig and https connection
- Using the same port for wss and https as is the standard

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


