### PR TITLE
Add Input (optional) to Skip Deployment and Perform Build Only - Gateway Frontend

### DIFF
--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -1,5 +1,5 @@
 name: "[M] Deploy Ten Gateway Frontend"
-run-name: "[M] Deploy Ten Gateway Frontend ( ${{ github.event.inputs.testnet_type }} )"
+run-name: "[M] Deploy Ten Gateway Frontend ( ${{ inputs.testnet_type }} )"
 on:
   workflow_dispatch:
     inputs:
@@ -21,7 +21,7 @@ on:
           - "primary"
           - "DEXYNTH"
       deploy_to_azure:
-        description: "Deploy to Azure"
+        description: "Release to ACR"
         required: true
         default: "true"
         type: choice
@@ -39,7 +39,7 @@ on:
       next_public_api_host_environment:
         description: "NEXT_PUBLIC_API_HOST_ENVIRONMENT"
         required: false
-        default: "${{ github.event.inputs.testnet_type }}"
+        default: "dev-testnet"
       next_public_network_name:
         description: "NEXT_PUBLIC_NETWORK_NAME"
         required: false
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: "Check if deployment is allowed"
         run: |
-          if [[ "${{ github.event.inputs.instance_type }}" == "DEXYNTH" && "${{ github.event.inputs.testnet_type }}" != "sepolia-testnet" ]]; then
+          if [[ "${{ inputs.instance_type }}" == "DEXYNTH" && "${{ inputs.testnet_type }}" != "sepolia-testnet" ]]; then
             echo "Error: Dexynth can only be deployed to sepolia-testnet."
             exit 1
           fi
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     environment:
-      name: ${{ github.event.inputs.testnet_type }}
+      name: ${{ inputs.testnet_type }}
     steps:
       - name: "Set up environment variables"
         id: setup_env
@@ -72,18 +72,18 @@ jobs:
           INSTANCE_SUFFIX=""
           INSTANCE_PREFIX=""
 
-          if [[ "${{ github.event.inputs.instance_type }}" != "primary" ]]; then
-            INSTANCE_SUFFIX="_${{ github.event.inputs.instance_type }}"
-            INSTANCE_SUFFIX2="-${{ github.event.inputs.instance_type }}"
-            INSTANCE_PREFIX="${{ github.event.inputs.instance_type }}_"
+          if [[ "${{ inputs.instance_type }}" != "primary" ]]; then
+            INSTANCE_SUFFIX="_${{ inputs.instance_type }}"
+            INSTANCE_SUFFIX2="-${{ inputs.instance_type }}"
+            INSTANCE_PREFIX="${{ inputs.instance_type }}_"
           fi
 
           echo "INSTANCE_SUFFIX=$INSTANCE_SUFFIX" >> $GITHUB_ENV
           echo "INSTANCE_PREFIX=$INSTANCE_PREFIX" >> $GITHUB_ENV
 
 
-          DNS_NAME_LABEL_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-ten-gateway${INSTANCE_SUFFIX2,,}"
-          IMAGE_NAME_GATEWAY_FE="${{ github.event.inputs.testnet_type }}-fe-ten-gateway${INSTANCE_SUFFIX2,,}"
+          DNS_NAME_LABEL_GATEWAY_FE="${{ inputs.testnet_type }}-ten-gateway${INSTANCE_SUFFIX2,,}"
+          IMAGE_NAME_GATEWAY_FE="${{ inputs.testnet_type }}-fe-ten-gateway${INSTANCE_SUFFIX2,,}"
 
           echo "DNS_NAME_LABEL_GATEWAY_FE=$DNS_NAME_LABEL_GATEWAY_FE" >> $GITHUB_ENV
           echo "IMAGE_NAME_GATEWAY_FE=$IMAGE_NAME_GATEWAY_FE" >> $GITHUB_ENV
@@ -108,8 +108,8 @@ jobs:
 
       - name: "Print GitHub variables"
         run: |
-          echo "Selected Testnet Type: ${{ github.event.inputs.testnet_type }}"
-          echo "Selected Instance Type: ${{ github.event.inputs.instance_type }}"
+          echo "Selected Testnet Type: ${{ inputs.testnet_type }}"
+          echo "Selected Instance Type: ${{ inputs.instance_type }}"
           echo "DNS_NAME_LABEL_GATEWAY_FE: $DNS_NAME_LABEL_GATEWAY_FE"
           echo "IMAGE_NAME_GATEWAY_FE: $IMAGE_NAME_GATEWAY_FE"
           echo "DOCKER_BUILD_TAG_GATEWAY_FE: $DOCKER_BUILD_TAG_GATEWAY_FE"
@@ -129,7 +129,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.6.1
 
       - name: "Login to Azure docker registry"
-        if: github.event.inputs.deploy_to_azure == 'true'
+        if: inputs.deploy_to_azure == 'true'
         uses: azure/docker-login@v1
         with:
           login-server: testnetobscuronet.azurecr.io
@@ -137,7 +137,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: "Login via Azure CLI"
-        if: github.event.inputs.deploy_to_azure == 'true'
+        if: inputs.deploy_to_azure == 'true'
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -145,16 +145,16 @@ jobs:
       - name: "Build and Push Docker Image"
         run: |
           DOCKER_BUILDKIT=1 docker build \
-            --build-arg NEXT_PUBLIC_API_HOST_ENVIRONMENT="${{ github.event.inputs.next_public_api_host_environment }}" \
-            --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ github.event.inputs.next_public_network_name }}" \
-            --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ github.event.inputs.next_public_tenscan_url }}" \
-            --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ github.event.inputs.next_public_gateway_url }}" \
+            --build-arg NEXT_PUBLIC_API_HOST_ENVIRONMENT="${{ inputs.next_public_api_host_environment }}" \
+            --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ inputs.next_public_network_name }}" \
+            --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ inputs.next_public_tenscan_url }}" \
+            --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ inputs.next_public_gateway_url }}" \
             -t "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
           docker push "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}"
 
       - name: "Deploy Gateway FE to Azure Container Instances"
-        if: github.event.inputs.deploy_gateway_fe == 'true'
+        if: inputs.deploy_gateway_fe == 'true'
         uses: "azure/aci-deploy@v1"
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -43,6 +43,7 @@ on:
       next_public_network_name:
         description: "NEXT_PUBLIC_NETWORK_NAME"
         required: true
+        default: "Ten Testnet"
       next_public_tenscan_url:
         description: "NEXT_PUBLIC_TENSCAN_URL"
         required: true

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -1,5 +1,5 @@
-name: "[M] Deploy Ten Gateway Frontend"
-run-name: "[M] Deploy Ten Gateway Frontend ( ${{ inputs.testnet_type }} )"
+name: "[M] Build and Deploy Ten Gateway Frontend"
+run-name: "[M] Build and Deploy Ten Gateway Frontend ( ${{ inputs.testnet_type }} )"
 on:
   workflow_dispatch:
     inputs:
@@ -94,7 +94,7 @@ jobs:
 
           echo "DNS_NAME_LABEL_GATEWAY_FE=$DNS_NAME_LABEL_GATEWAY_FE" >> $GITHUB_ENV
           echo "IMAGE_NAME_GATEWAY_FE=$IMAGE_NAME_GATEWAY_FE" >> $GITHUB_ENV
-          echo "DOCKER_BUILD_TAG_GATEWAY_FE=${{ inputs.docker_build_tag_gateway_fe }}" >> $GITHUB_ENV
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE=$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}" >> $GITHUB_ENV
 
           # Set instance-specific variables
           declare -a VAR_NAMES=(
@@ -119,7 +119,7 @@ jobs:
           echo "Selected Instance Type: ${{ inputs.instance_type }}"
           echo "DNS_NAME_LABEL_GATEWAY_FE: $DNS_NAME_LABEL_GATEWAY_FE"
           echo "IMAGE_NAME_GATEWAY_FE: $IMAGE_NAME_GATEWAY_FE"
-          echo "DOCKER_BUILD_TAG_GATEWAY_FE: ${{ inputs.docker_build_tag_gateway_fe }}"
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE: $DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}"
           echo "GATEWAY_URL: $GATEWAY_URL"
           echo "NETWORK_NAME: $NETWORK_NAME"
           echo "TENSCAN_URL: $TENSCAN_URL"
@@ -156,9 +156,9 @@ jobs:
             --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ inputs.next_public_network_name }}" \
             --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ inputs.next_public_tenscan_url }}" \
             --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ inputs.next_public_gateway_url }}" \
-            -t "${{ inputs.docker_build_tag_gateway_fe }}" \
+            -t "$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
-          docker push "${{ inputs.docker_build_tag_gateway_fe }}"
+          docker push "$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}"
 
       - name: "Deploy Gateway FE to Azure Container Instances"
         if: inputs.deploy_gateway_fe == 'true'
@@ -166,7 +166,7 @@ jobs:
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: ${{ env.DNS_NAME_LABEL_GATEWAY_FE }}
-          image: ${{ inputs.docker_build_tag_gateway_fe }}
+          image: $DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}
           name: ${{ env.IMAGE_NAME_GATEWAY_FE }}
           location: "uksouth"
           restart-policy: "Never"

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -38,17 +38,19 @@ on:
           - "false"
       next_public_api_host_environment:
         description: "NEXT_PUBLIC_API_HOST_ENVIRONMENT"
-        required: false
+        required: true
         default: "dev-testnet"
       next_public_network_name:
         description: "NEXT_PUBLIC_NETWORK_NAME"
-        required: false
+        required: true
       next_public_tenscan_url:
         description: "NEXT_PUBLIC_TENSCAN_URL"
-        required: false
+        required: true
+        default: "https://tenscan.io"
       next_public_gateway_url:
         description: "NEXT_PUBLIC_GATEWAY_URL"
-        required: false
+        required: true
+        default: "https://dev-testnet.ten.xyz/"
 
 jobs:
   validate-inputs:

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -94,7 +94,7 @@ jobs:
 
           echo "DNS_NAME_LABEL_GATEWAY_FE=$DNS_NAME_LABEL_GATEWAY_FE" >> $GITHUB_ENV
           echo "IMAGE_NAME_GATEWAY_FE=$IMAGE_NAME_GATEWAY_FE" >> $GITHUB_ENV
-          echo "DOCKER_BUILD_TAG_GATEWAY_FE=$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}" >> $GITHUB_ENV
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE=${{ vars.DOCKER_REPO_GATEWAY_FE }}:${{ inputs.docker_build_tag_gateway_fe }}" >> $GITHUB_ENV
 
           # Set instance-specific variables
           declare -a VAR_NAMES=(
@@ -119,7 +119,7 @@ jobs:
           echo "Selected Instance Type: ${{ inputs.instance_type }}"
           echo "DNS_NAME_LABEL_GATEWAY_FE: $DNS_NAME_LABEL_GATEWAY_FE"
           echo "IMAGE_NAME_GATEWAY_FE: $IMAGE_NAME_GATEWAY_FE"
-          echo "DOCKER_BUILD_TAG_GATEWAY_FE: $DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}"
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE: ${{ vars.DOCKER_REPO_GATEWAY_FE }}:${{ inputs.docker_build_tag_gateway_fe }}"
           echo "GATEWAY_URL: $GATEWAY_URL"
           echo "NETWORK_NAME: $NETWORK_NAME"
           echo "TENSCAN_URL: $TENSCAN_URL"
@@ -156,9 +156,9 @@ jobs:
             --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ inputs.next_public_network_name }}" \
             --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ inputs.next_public_tenscan_url }}" \
             --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ inputs.next_public_gateway_url }}" \
-            -t "$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}" \
+            -t "${{ vars.DOCKER_REPO_GATEWAY_FE }}:${{ inputs.docker_build_tag_gateway_fe }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
-          docker push "$DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}"
+          docker push "${{ vars.DOCKER_REPO_GATEWAY_FE }}:${{ inputs.docker_build_tag_gateway_fe }}"
 
       - name: "Deploy Gateway FE to Azure Container Instances"
         if: inputs.deploy_gateway_fe == 'true'
@@ -166,7 +166,7 @@ jobs:
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: ${{ env.DNS_NAME_LABEL_GATEWAY_FE }}
-          image: $DOCKER_REPO_GATEWAY_FE:${{ inputs.docker_build_tag_gateway_fe }}
+          image: ${{ vars.DOCKER_REPO_GATEWAY_FE }}:${{ inputs.docker_build_tag_gateway_fe }}
           name: ${{ env.IMAGE_NAME_GATEWAY_FE }}
           location: "uksouth"
           restart-policy: "Never"

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -51,6 +51,10 @@ on:
         description: "NEXT_PUBLIC_GATEWAY_URL"
         required: true
         default: "https://dev-testnet.ten.xyz/"
+      docker_build_tag_gateway_fe:
+        description: "DOCKER_BUILD_TAG_GATEWAY_FE"
+        required: true
+        default: "latest"
 
 jobs:
   validate-inputs:
@@ -89,10 +93,10 @@ jobs:
 
           echo "DNS_NAME_LABEL_GATEWAY_FE=$DNS_NAME_LABEL_GATEWAY_FE" >> $GITHUB_ENV
           echo "IMAGE_NAME_GATEWAY_FE=$IMAGE_NAME_GATEWAY_FE" >> $GITHUB_ENV
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE=${{ inputs.docker_build_tag_gateway_fe }}" >> $GITHUB_ENV
 
           # Set instance-specific variables
           declare -a VAR_NAMES=(
-            "DOCKER_BUILD_TAG_GATEWAY_FE"
             "GATEWAY_URL"
             "NETWORK_NAME"
             "TENSCAN_URL"
@@ -114,7 +118,7 @@ jobs:
           echo "Selected Instance Type: ${{ inputs.instance_type }}"
           echo "DNS_NAME_LABEL_GATEWAY_FE: $DNS_NAME_LABEL_GATEWAY_FE"
           echo "IMAGE_NAME_GATEWAY_FE: $IMAGE_NAME_GATEWAY_FE"
-          echo "DOCKER_BUILD_TAG_GATEWAY_FE: $DOCKER_BUILD_TAG_GATEWAY_FE"
+          echo "DOCKER_BUILD_TAG_GATEWAY_FE: ${{ inputs.docker_build_tag_gateway_fe }}"
           echo "GATEWAY_URL: $GATEWAY_URL"
           echo "NETWORK_NAME: $NETWORK_NAME"
           echo "TENSCAN_URL: $TENSCAN_URL"
@@ -151,9 +155,9 @@ jobs:
             --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ inputs.next_public_network_name }}" \
             --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ inputs.next_public_tenscan_url }}" \
             --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ inputs.next_public_gateway_url }}" \
-            -t "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}" \
+            -t "${{ inputs.docker_build_tag_gateway_fe }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
-          docker push "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}"
+          docker push "${{ inputs.docker_build_tag_gateway_fe }}"
 
       - name: "Deploy Gateway FE to Azure Container Instances"
         if: inputs.deploy_gateway_fe == 'true'
@@ -161,7 +165,7 @@ jobs:
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}
           dns-name-label: ${{ env.DNS_NAME_LABEL_GATEWAY_FE }}
-          image: ${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}
+          image: ${{ inputs.docker_build_tag_gateway_fe }}
           name: ${{ env.IMAGE_NAME_GATEWAY_FE }}
           location: "uksouth"
           restart-policy: "Never"

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -1,14 +1,3 @@
-# Deploys TEN Gateway Frontend on Azure for Testnet
-# Builds the TEN Gateway image, pushes the image to dockerhub and starts the TEN Gateway on Azure VM
-# This action requires the following environment variables to be set:
-# - DOCKER_BUILD_TAG_GATEWAY_FE
-# - GATEWAY_URL
-# - NETWORK_NAME
-# - TENSCAN_URL
-
-# If we are deploying to a non primary instance all those variables should be prefixed with the instance name
-# example: DEXYNTH_GATEWAY_URL
-
 name: "[M] Deploy Ten Gateway Frontend"
 run-name: "[M] Deploy Ten Gateway Frontend ( ${{ github.event.inputs.testnet_type }} )"
 on:
@@ -31,6 +20,36 @@ on:
         options:
           - "primary"
           - "DEXYNTH"
+      deploy_to_azure:
+        description: "Deploy to Azure"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      deploy_gateway_fe:
+        description: "Deploy Gateway FE to Azure"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      next_public_api_host_environment:
+        description: "NEXT_PUBLIC_API_HOST_ENVIRONMENT"
+        required: false
+        default: "${{ github.event.inputs.testnet_type }}"
+      next_public_network_name:
+        description: "NEXT_PUBLIC_NETWORK_NAME"
+        required: false
+      next_public_tenscan_url:
+        description: "NEXT_PUBLIC_TENSCAN_URL"
+        required: false
+      next_public_gateway_url:
+        description: "NEXT_PUBLIC_GATEWAY_URL"
+        required: false
+
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
@@ -43,6 +62,7 @@ jobs:
           fi
   build-and-deploy:
     runs-on: ubuntu-latest
+    needs: validate-inputs
     environment:
       name: ${{ github.event.inputs.testnet_type }}
     steps:
@@ -109,6 +129,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.6.1
 
       - name: "Login to Azure docker registry"
+        if: github.event.inputs.deploy_to_azure == 'true'
         uses: azure/docker-login@v1
         with:
           login-server: testnetobscuronet.azurecr.io
@@ -116,6 +137,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: "Login via Azure CLI"
+        if: github.event.inputs.deploy_to_azure == 'true'
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -123,15 +145,16 @@ jobs:
       - name: "Build and Push Docker Image"
         run: |
           DOCKER_BUILDKIT=1 docker build \
-            --build-arg NEXT_PUBLIC_API_HOST_ENVIRONMENT="${{ github.event.inputs.testnet_type }}" \
-            --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ env.NETWORK_NAME }}" \
-            --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ env.TENSCAN_URL }}" \
-            --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ env.GATEWAY_URL }}" \
+            --build-arg NEXT_PUBLIC_API_HOST_ENVIRONMENT="${{ github.event.inputs.next_public_api_host_environment }}" \
+            --build-arg NEXT_PUBLIC_NETWORK_NAME="${{ github.event.inputs.next_public_network_name }}" \
+            --build-arg NEXT_PUBLIC_TENSCAN_URL="${{ github.event.inputs.next_public_tenscan_url }}" \
+            --build-arg NEXT_PUBLIC_GATEWAY_URL="${{ github.event.inputs.next_public_gateway_url }}" \
             -t "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}" \
             -f ./tools/walletextension/frontend/Dockerfile .
           docker push "${{ env.DOCKER_BUILD_TAG_GATEWAY_FE }}"
 
       - name: "Deploy Gateway FE to Azure Container Instances"
+        if: github.event.inputs.deploy_gateway_fe == 'true'
         uses: "azure/aci-deploy@v1"
         with:
           resource-group: ${{ secrets.RESOURCE_GROUP }}


### PR DESCRIPTION
### Why this change is needed

The current GitHub Action is configured to perform both build and deployment steps, but for Kubernetes deployments, the deployment step is unnecessary and can be removed to simplify the workflow.
### What changes were made as part of this PR

GH Action workflow file 

- [ ] PR checks reviewed and performed 


