### PR TITLE
Remove hardcoded PKs concerning deployment.

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -430,9 +430,9 @@ jobs:
           -l1_http_url=${{ secrets.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.ACCOUNT_PK_WORKER }} \
-          -l2_private_key=8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b \
-          -l2_hoc_private_key=6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682 \
-          -l2_poc_private_key=4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8 \
+          -l2_private_key=${{ secrets.L2_DEPLOYER_KEY }} \
+          -l2_hoc_private_key=${{ secrets.L2_HOC_KEY }} \
+          -l2_poc_private_key=${{ secrets.L2_POC_KEY}} \
           -management_contract_addr=${{ needs.build.outputs.MGMT_CONTRACT_ADDR }} \
           -message_bus_contract_addr=${{ needs.build.outputs.MSG_BUS_CONTRACT_ADDR }} \
           -docker_image=${{ vars.L2_HARDHATDEPLOYER_DOCKER_BUILD_TAG }} \

--- a/integration/common/constants.go
+++ b/integration/common/constants.go
@@ -30,8 +30,8 @@ const (
 	HOCAddr              = "f3a8bd422097bFdd9B3519Eaeb533393a1c561aC"
 	pocAddr              = "9802F661d17c65527D7ABB59DAAD5439cb125a67"
 	bridgeAddr           = "deB34A740ECa1eC42C8b8204CBEC0bA34FDD27f3"
-	hocOwnerKeyHex       = "6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682"
-	pocOwnerKeyHex       = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
+	hocOwnerKeyHex       = "6e384a07a01263518a09a5424c7b6bbfc3604ba7d93f47e3a455cbdd7f9f0682" // Used only in sim tests. Fine
+	pocOwnerKeyHex       = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8" // Used only in sim tests. Fine
 )
 
 var HOCOwner, _ = crypto.HexToECDSA(hocOwnerKeyHex)

--- a/integration/contractdeployer/contract_deployer_test.go
+++ b/integration/contractdeployer/contract_deployer_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	contractDeployerPrivateKeyHex = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8"
+	contractDeployerPrivateKeyHex = "4bfe14725e685901c062ccd4e220c61cf9c189897b6c78bd18d7f51291b2b8f8" // Used only in tests.
 	latestBlock                   = "latest"
 	emptyCode                     = "0x"
 	erc20ParamOne                 = "Hocus"


### PR DESCRIPTION
### Why this change is needed

We need to make the private keys for the L2 a secret.

### What changes were made as part of this PR

Added new secrets to github:

L2_DEPLOYER_KEY (main account that deploys)
L2_HOC_KEY ( this is still an artefact that needs removal )
L2_POC_KEY ( this too )

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


