### PR TITLE
remove getStorageAt returning token and use local storage instead 

### DIFF
--- a/go/common/custom_query_types.go
+++ b/go/common/custom_query_types.go
@@ -19,7 +19,6 @@ import "github.com/ethereum/go-ethereum/common"
 
 // CustomQuery methods
 const (
-	UserIDRequestCQMethod           = "0x0000000000000000000000000000000000000001"
 	ListPrivateTransactionsCQMethod = "0x0000000000000000000000000000000000000002"
 	CreateSessionKeyCQMethod        = "0x0000000000000000000000000000000000000003"
 	ActivateSessionKeyCQMethod      = "0x0000000000000000000000000000000000000004"

--- a/packages/ui/routes/index.ts
+++ b/packages/ui/routes/index.ts
@@ -2,7 +2,6 @@ export const requestMethods = {
   requestAccounts: "eth_requestAccounts",
   switchNetwork: "wallet_switchEthereumChain",
   addNetwork: "wallet_addEthereumChain",
-  getStorageAt: "eth_getStorageAt",
   signTypedData: "eth_signTypedData_v4",
   getChainId: "eth_chainId",
 };

--- a/tools/walletextension/frontend/src/api/ethRequests.ts
+++ b/tools/walletextension/frontend/src/api/ethRequests.ts
@@ -82,25 +82,18 @@ export const getSignature = async (account: string, data: any) => {
   }
 };
 
-export const getToken = async (provider: ethers.providers.Web3Provider) => {
-  if (!provider.send) {
-    return null;
-  }
+export const getToken = async () => {
   try {
-    if (await isTenChain()) {
-      const token = await provider.send(requestMethods.getStorageAt, [
-        userStorageAddress,
-        getRandomIntAsString(0, 1000),
-        null,
-      ]);
-      return token;
-    } else {
-      return null;
-    }
+    const token = localStorage.getItem('ten_token') || '';
+    return token;
   } catch (e: any) {
     console.error(e);
     throw e;
   }
+};
+
+export const clearToken = () => {
+  localStorage.removeItem('ten_token');
 };
 
 export async function addNetworkToMetaMask(rpcUrls: string[]) {
@@ -150,7 +143,7 @@ export async function authenticateAccountWithTenGatewayEIP712(
       ...typedData,
       message: {
         ...typedData.message,
-        "Encryption Token":  token,
+        "Encryption Token": token,
       },
     };
     const signature = await getSignature(account, data);

--- a/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
+++ b/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
@@ -56,7 +56,7 @@ export const WalletConnectionProvider = ({
     try {
       await ethService.checkIfMetamaskIsLoaded(providerInstance);
 
-      const fetchedToken = await getToken(providerInstance);
+      const fetchedToken = await getToken();
       setToken(fetchedToken);
 
       const status = await ethService.isUserConnectedToTenChain(fetchedToken);
@@ -135,7 +135,7 @@ export const WalletConnectionProvider = ({
       );
       return;
     }
-    const token = await getToken(provider);
+    const token = await getToken();
 
     if (!isValidTokenFormat(token)) {
       showToast(

--- a/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
+++ b/tools/walletextension/frontend/src/components/providers/wallet-provider.tsx
@@ -15,6 +15,7 @@ import { ToastType } from "@/types/interfaces";
 import {
   authenticateAccountWithTenGatewayEIP712,
   getToken,
+  clearToken
 } from "@/api/ethRequests";
 import { ethers } from "ethers";
 import ethService from "@/services/ethService";
@@ -124,6 +125,7 @@ export const WalletConnectionProvider = ({
       setAccounts(null);
       setWalletConnected(false);
       setToken("");
+      clearToken();
     }
   };
 
@@ -194,6 +196,7 @@ export const WalletConnectionProvider = ({
           setAccounts(null);
           setWalletConnected(false);
           setToken("");
+          clearToken();
         } else {
           window.location.reload();
         }

--- a/tools/walletextension/frontend/src/services/ethService.ts
+++ b/tools/walletextension/frontend/src/services/ethService.ts
@@ -127,7 +127,7 @@ const ethService = {
       return;
     }
 
-    const token = await getToken(provider);
+    const token = await getToken();
 
     if (!token || !isValidTokenFormat(token)) {
       return;

--- a/tools/walletextension/frontend/src/services/useGatewayService.ts
+++ b/tools/walletextension/frontend/src/services/useGatewayService.ts
@@ -52,10 +52,14 @@ const useGatewayService = () => {
       // SWITCHED_CODE=4902; error 4902 means that the chain does not exist
       if (
         switched === SWITCHED_CODE ||
-        !isValidTokenFormat(await getToken(provider))
+        !isValidTokenFormat(await getToken())
       ) {
         showToast(ToastType.INFO, "Adding TEN Testnet...");
         const user = await joinTestnet();
+
+        // Store the token in localStorage
+        localStorage.setItem("ten_token", "0x" + user);
+
         const rpcUrls = [
           `${tenGatewayAddress}/${tenGatewayVersion}/?token=${user}`,
         ];

--- a/tools/walletextension/rpcapi/blockchain_api.go
+++ b/tools/walletextension/rpcapi/blockchain_api.go
@@ -190,8 +190,6 @@ func (api *BlockChainAPI) GetStorageAt(ctx context.Context, address gethcommon.A
 	}
 
 	switch address.Hex() {
-	case common.UserIDRequestCQMethod: // todo - review whether we need this endpoint
-		return user.ID, nil
 	case common.ListPrivateTransactionsCQMethod:
 		// sensitive CustomQuery methods use the convention of having "address" at the top level of the params json
 		userAddr, err := extractCustomQueryAddress(params)


### PR DESCRIPTION
### Why this change is needed

At the moment we are using local getStorageAt with argument 0x0 to get userID/token that is used in Metamask.
This is very risky and security vulnerability since any app that we connect to can make this call and it will be able to see token and with it our private data.

### What changes were made as part of this PR

- sqlite fix that allows us to run it locally 
- removing getStorageAt part where the gateway returns usedID and test that tests that
- frontend change to use local storage instead of getStorageAt calls

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


