### PR TITLE
caching for event topics and contract address

### DIFF
--- a/go/common/types.go
+++ b/go/common/types.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -76,6 +77,9 @@ type (
 
 	EnclaveID = common.Address
 )
+
+// FailedDecryptErr - when the TEN enclave fails to decrypt an RPC request
+var FailedDecryptErr = errors.New("failed to decrypt RPC payload. please use the correct enclave key")
 
 // EncryptedRPCRequest - an encrypted request with extra plaintext metadata
 type EncryptedRPCRequest struct {

--- a/go/enclave/rpc/vk_utils.go
+++ b/go/enclave/rpc/vk_utils.go
@@ -55,7 +55,7 @@ func HandleEncryptedRPC(ctx context.Context,
 	// 1. Decrypt request
 	plaintextRequest, err := encManager.DecryptBytes(encReq)
 	if err != nil {
-		return responses.AsPlaintextError(fmt.Errorf("could not decrypt params - %w", err)), nil
+		return responses.AsPlaintextError(common.FailedDecryptErr), nil
 	}
 
 	// 2. Unmarshall

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -80,16 +80,16 @@ func UpdateEventTypeAutoPublic(ctx context.Context, dbTx *sql.Tx, etId uint64, i
 	return err
 }
 
-func ReadEventTopic(ctx context.Context, dbTX *sql.Tx, topic []byte, eventTypeId uint64) (uint64, *uint64, error) {
+func ReadEventTopic(ctx context.Context, dbTX *sql.Tx, topic []byte, eventTypeId uint64) (*EventTopic, error) {
 	var id uint64
 	var address *uint64
 	err := dbTX.QueryRowContext(ctx,
 		"select id, rel_address from event_topic where topic=? and event_type=?", topic, eventTypeId).Scan(&id, &address)
 	if errors.Is(err, sql.ErrNoRows) {
 		// make sure the error is converted to obscuro-wide not found error
-		return 0, nil, errutil.ErrNotFound
+		return nil, errutil.ErrNotFound
 	}
-	return id, address, err
+	return &EventTopic{Id: id, RelevantAddressId: address}, err
 }
 
 func ReadRelevantAddressFromEventTopic(ctx context.Context, dbTX *sql.Tx, id uint64) (*uint64, error) {

--- a/go/enclave/storage/enclavedb/interfaces.go
+++ b/go/enclave/storage/enclavedb/interfaces.go
@@ -61,3 +61,9 @@ func (et EventType) IsTopicRelevant(topicNo int) bool {
 	// this should not happen under any circumstance
 	panic(fmt.Sprintf("unknown topic no: %d", topicNo))
 }
+
+// EventTopic - maps to the "event_topic" table
+type EventTopic struct {
+	Id                uint64
+	RelevantAddressId *uint64
+}

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -621,7 +621,7 @@ func (s *storageImpl) handleTxSendersAndReceivers(ctx context.Context, transacti
 
 		to := tx.Tx.To()
 		if to != nil {
-			ctr, err := s.ReadContract(ctx, *to)
+			ctr, err := s.eventsStorage.ReadContract(ctx, *to)
 			if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 				return nil, nil, fmt.Errorf("could not read contract. cause: %w", err)
 			}
@@ -857,12 +857,7 @@ func (s *storageImpl) readOrWriteEOA(ctx context.Context, dbTX *sql.Tx, addr get
 }
 
 func (s *storageImpl) ReadContract(ctx context.Context, address gethcommon.Address) (*enclavedb.Contract, error) {
-	dbtx, err := s.db.GetSQLDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer dbtx.Rollback()
-	return enclavedb.ReadContractByAddress(ctx, dbtx, address)
+	return s.eventsStorage.ReadContract(ctx, address)
 }
 
 func (s *storageImpl) ReadEventType(ctx context.Context, contractAddress gethcommon.Address, eventSignature gethcommon.Hash) (*enclavedb.EventType, error) {


### PR DESCRIPTION
### Why this change is needed

- to improve performance
- fix for gateway when running against a different network ( which happens during redeploys)

### What changes were made as part of this PR

- add caching for event topics
- use the contract cache everywhere
- add error handling when executing sensitive requests to read the key and retry

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


