### PR TITLE
Changed how loading works.

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -426,7 +426,7 @@ jobs:
         shell: bash
         run: |
           go run ./testnet/launcher/l2contractdeployer/cmd \
-          -l2_host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com \
+          -l2_host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com \
           -l1_http_url=${{ secrets.L1_HTTP_URL }} \
           -l2_ws_port=81 \
           -private_key=${{ secrets.ACCOUNT_PK_WORKER }} \

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -195,4 +196,14 @@ func (cf *ChainFork) String() string {
 
 func MaskedSender(address L2Address) L2Address {
 	return common.BigToAddress(big.NewInt(0).Sub(address.Big(), big.NewInt(1)))
+}
+
+type SystemContractAddresses map[string]*gethcommon.Address
+
+func (s *SystemContractAddresses) ToString() string {
+	var str string
+	for name, addr := range *s {
+		str += fmt.Sprintf("%s: %s; ", name, addr.Hex())
+	}
+	return str
 }

--- a/go/enclave/crosschain/interfaces.go
+++ b/go/enclave/crosschain/interfaces.go
@@ -41,7 +41,7 @@ type Manager interface {
 	GetBusAddress() *common.L2Address
 
 	// Initialize - Derives the address of the message bus contract.
-	Initialize(systemAddresses system.SystemContractAddresses) error
+	Initialize(systemAddresses common.SystemContractAddresses) error
 
 	// GenerateMessageBusDeployTx - Returns a signed message bus deployment transaction.
 	GenerateMessageBusDeployTx() (*common.L2Tx, error)

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ten-protocol/go-ten/go/enclave/core"
-	"github.com/ten-protocol/go-ten/go/enclave/system"
 
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
 
@@ -79,7 +78,7 @@ func (m *MessageBusManager) GetBusAddress() *common.L2Address {
 }
 
 // DeriveMessageBusAddress - Derives the address of the message bus contract.
-func (m *MessageBusManager) Initialize(systemAddresses system.SystemContractAddresses) error {
+func (m *MessageBusManager) Initialize(systemAddresses common.SystemContractAddresses) error {
 	address, ok := systemAddresses["MessageBus"]
 	if !ok {
 		return fmt.Errorf("message bus contract not found in system addresses")

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -84,7 +84,7 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 
 	// initialise system contracts
 	scb := system.NewSystemContractCallbacks(storage, &config.SystemContractOwner, logger)
-	err = scb.Load()
+	err = scb.Load(crossChainProcessors.Local)
 	if err != nil && !errors.Is(err, errutil.ErrNotFound) {
 		logger.Crit("failed to load system contracts", log.ErrKey, err)
 	}

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -121,6 +121,11 @@ type EnclaveKeyStorage interface {
 	GetEnclaveKey(ctx context.Context) ([]byte, error)
 }
 
+type SystemContractAddressesStorage interface {
+	StoreSystemContractAddresses(ctx context.Context, addresses common.SystemContractAddresses) error
+	GetSystemContractAddresses(ctx context.Context) (common.SystemContractAddresses, error)
+}
+
 // Storage is the enclave's interface for interacting with the enclave's datastore
 type Storage interface {
 	BlockResolver
@@ -132,6 +137,7 @@ type Storage interface {
 	CrossChainMessagesStorage
 	EnclaveKeyStorage
 	ScanStorage
+	SystemContractAddressesStorage
 	io.Closer
 
 	// HealthCheck returns whether the storage is deemed healthy or not

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -41,8 +42,9 @@ import (
 // these are the keys from the config table
 const (
 	// todo - this will require a dedicated table when upgrades are implemented
-	masterSeedCfg = "MASTER_SEED"
-	enclaveKeyCfg = "ENCLAVE_KEY"
+	masterSeedCfg              = "MASTER_SEED"
+	enclaveKeyCfg              = "ENCLAVE_KEY"
+	systemContractAddressesCfg = "SYSTEM_CONTRACT_ADDRESSES"
 )
 
 type AttestedEnclave struct {
@@ -871,4 +873,41 @@ func (s *storageImpl) ReadEventType(ctx context.Context, contractAddress gethcom
 
 func (s *storageImpl) logDuration(method string, stopWatch *measure.Stopwatch) {
 	core.LogMethodDuration(s.logger, stopWatch, fmt.Sprintf("Storage::%s completed", method))
+}
+
+func (s *storageImpl) StoreSystemContractAddresses(ctx context.Context, addresses common.SystemContractAddresses) error {
+	defer s.logDuration("StoreSystemContractAddresses", measure.NewStopwatch())
+
+	dbTx, err := s.db.NewDBTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("could not create DB transaction - %w", err)
+	}
+	defer dbTx.Rollback()
+
+	addressesBytes, err := json.Marshal(addresses)
+	if err != nil {
+		return fmt.Errorf("could not marshal system contract addresses - %w", err)
+	}
+	_, err = enclavedb.WriteConfig(ctx, dbTx, systemContractAddressesCfg, addressesBytes)
+	if err != nil {
+		return fmt.Errorf("could not write system contract addresses - %w", err)
+	}
+
+	if err := dbTx.Commit(); err != nil {
+		return fmt.Errorf("could not commit system contract addresses - %w", err)
+	}
+	return nil
+}
+
+func (s *storageImpl) GetSystemContractAddresses(ctx context.Context) (common.SystemContractAddresses, error) {
+	defer s.logDuration("GetSystemContractAddresses", measure.NewStopwatch())
+	addressesBytes, err := enclavedb.FetchConfig(ctx, s.db.GetSQLDB(), systemContractAddressesCfg)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch system contract addresses - %w", err)
+	}
+	var addresses common.SystemContractAddresses
+	if err := json.Unmarshal(addressesBytes, &addresses); err != nil {
+		return nil, fmt.Errorf("could not unmarshal system contract addresses - %w", err)
+	}
+	return addresses, nil
 }

--- a/go/enclave/system/contracts.go
+++ b/go/enclave/system/contracts.go
@@ -45,7 +45,7 @@ func VerifyLogs(receipt *types.Receipt) error {
 	return nil
 }
 
-func DeriveAddresses(receipt *types.Receipt) (SystemContractAddresses, error) {
+func DeriveAddresses(receipt *types.Receipt) (common.SystemContractAddresses, error) {
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		return nil, fmt.Errorf("cannot derive system contract addresses from failed receipt")
 	}
@@ -75,14 +75,4 @@ func DeriveAddresses(receipt *types.Receipt) (SystemContractAddresses, error) {
 	}
 
 	return addresses, nil
-}
-
-type SystemContractAddresses map[string]*gethcommon.Address
-
-func (s *SystemContractAddresses) ToString() string {
-	var str string
-	for name, addr := range *s {
-		str += fmt.Sprintf("%s: %s; ", name, addr.Hex())
-	}
-	return str
 }

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -1,7 +1,6 @@
 package helpful
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"os"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ten-protocol/go-ten/go/ethadapter"
 	"github.com/ten-protocol/go-ten/go/wallet"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
@@ -43,29 +41,6 @@ func TestRunLocalNetwork(t *testing.T) {
 	defer cleanUp()
 
 	keepRunning(networkConnector)
-}
-
-func TestGenerateKeys(t *testing.T) {
-	genKey := func() {
-		pk, err := crypto.GenerateKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-		fmt.Println(hex.EncodeToString(crypto.FromECDSA(pk)))
-		fmt.Printf("Address: 0x%x\n", crypto.PubkeyToAddress(pk.PublicKey))
-	}
-
-	genKey()
-	genKey()
-	genKey()
-}
-
-func TestPrintAddress(t *testing.T) {
-	pk, err := crypto.HexToECDSA("c5f74c49670c0151261af346efb9022792585110bd45ed44933acfde5063067c")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(crypto.PubkeyToAddress(pk.PublicKey))
 }
 
 func TestRunLocalGatewayAgainstRemoteTestnet(t *testing.T) {

--- a/integration/networktest/tests/helpful/spin_up_local_network_test.go
+++ b/integration/networktest/tests/helpful/spin_up_local_network_test.go
@@ -1,6 +1,7 @@
 package helpful
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ten-protocol/go-ten/go/ethadapter"
 	"github.com/ten-protocol/go-ten/go/wallet"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
@@ -41,6 +43,29 @@ func TestRunLocalNetwork(t *testing.T) {
 	defer cleanUp()
 
 	keepRunning(networkConnector)
+}
+
+func TestGenerateKeys(t *testing.T) {
+	genKey := func() {
+		pk, err := crypto.GenerateKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fmt.Println(hex.EncodeToString(crypto.FromECDSA(pk)))
+		fmt.Printf("Address: 0x%x\n", crypto.PubkeyToAddress(pk.PublicKey))
+	}
+
+	genKey()
+	genKey()
+	genKey()
+}
+
+func TestPrintAddress(t *testing.T) {
+	pk, err := crypto.HexToECDSA("c5f74c49670c0151261af346efb9022792585110bd45ed44933acfde5063067c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(crypto.PubkeyToAddress(pk.PublicKey))
 }
 
 func TestRunLocalGatewayAgainstRemoteTestnet(t *testing.T) {


### PR DESCRIPTION
### Why this change is needed

Currently we have a bug in hooks.go:Load() method; It does not initialize the message, bus and upon change of the bytecode is unable to find the correct receipt for the unmarked synethic transaction. 

### What changes were made as part of this PR

Removed dependence on the receipt and moved to use config table. First time init will write into it, Load fetches.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


