### PR TITLE
Local testnet: fix node starter param

### DIFF
--- a/go/config/defaults/testnet-launcher/2-sequencer.yaml
+++ b/go/config/defaults/testnet-launcher/2-sequencer.yaml
@@ -9,9 +9,9 @@ host:
    p2p:
       bindAddress: 0.0.0.0:15000
    enclave:
-      rpcAddresses: [ "sequencer-enclave:11000" ]
+      rpcAddresses: [ "sequencer-enclave-0:11000" ]
 enclave:
    db:
-      edgelessDBHost: sequencer-edgelessdb
+      edgelessDBHost: sequencer-edgelessdb-0
    rpc:
       bindAddress: 0.0.0.0:11000

--- a/go/config/defaults/testnet-launcher/2-validator.yaml
+++ b/go/config/defaults/testnet-launcher/2-validator.yaml
@@ -9,12 +9,12 @@ host:
    p2p:
       bindAddress: 0.0.0.0:15010
    enclave:
-      rpcAddresses: [ "validator-enclave:11010" ]
+      rpcAddresses: [ "validator-enclave-0:11010" ]
    rpc:
       httpPort: 13010
       wsPort: 13011
 enclave:
    db:
-      edgelessDBHost: validator-edgelessdb
+      edgelessDBHost: validator-edgelessdb-0
    rpc:
       bindAddress: 0.0.0.0:11010

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -62,7 +62,7 @@ func (t *Testnet) Start() error {
 	sequencerCfg.Network.L1.L1Contracts.ManagementContract = common.HexToAddress(networkConfig.ManagementContractAddress)
 	sequencerCfg.Network.L1.L1Contracts.MessageBusContract = common.HexToAddress(networkConfig.MessageBusAddress)
 
-	sequencerNode := node.NewDockerNode(sequencerCfg, "testnetobscuronet.azurecr.io/obscuronet/host:latest", "testnetobscuronet.azurecr.io/obscuronet/enclave:latest", edgelessDBImage, false, "", 0)
+	sequencerNode := node.NewDockerNode(sequencerCfg, "testnetobscuronet.azurecr.io/obscuronet/host:latest", "testnetobscuronet.azurecr.io/obscuronet/enclave:latest", edgelessDBImage, false, "", 1)
 
 	err = sequencerNode.Start()
 	if err != nil {
@@ -87,7 +87,7 @@ func (t *Testnet) Start() error {
 	validatorNodeCfg.Network.L1.L1Contracts.ManagementContract = common.HexToAddress(networkConfig.ManagementContractAddress)
 	validatorNodeCfg.Network.L1.L1Contracts.MessageBusContract = common.HexToAddress(networkConfig.MessageBusAddress)
 
-	validatorNode := node.NewDockerNode(validatorNodeCfg, "testnetobscuronet.azurecr.io/obscuronet/host:latest", "testnetobscuronet.azurecr.io/obscuronet/enclave:latest", edgelessDBImage, false, "", 0)
+	validatorNode := node.NewDockerNode(validatorNodeCfg, "testnetobscuronet.azurecr.io/obscuronet/host:latest", "testnetobscuronet.azurecr.io/obscuronet/enclave:latest", edgelessDBImage, false, "", 1)
 	err = validatorNode.Start()
 	if err != nil {
 		return fmt.Errorf("unable to start the obscuro node - %w", err)


### PR DESCRIPTION
### Why this change is needed

[This PR](https://github.com/ten-protocol/go-ten/pull/2201) broke the local testnet starter script (which breaks the e2e tests).

Auto-refactor of a method had it trying to start the nodes with 0 enclaves instead of 1.

Missed updating launcher config with new indexed naming convention for enclaves.

### What changes were made as part of this PR

Fix the param and config.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


