### PR TITLE
fix errors and gas estimate

### DIFF
--- a/go/common/errutil/evm_serialisable.go
+++ b/go/common/errutil/evm_serialisable.go
@@ -1,5 +1,7 @@
 package errutil
 
+import "fmt"
+
 // DataError is an API error that encompasses an EVM error with a code and a reason
 type DataError struct {
 	Code   int         `json:"code"`
@@ -17,4 +19,8 @@ func (e DataError) ErrorCode() int {
 
 func (e DataError) ErrorData() interface{} {
 	return e.Reason
+}
+
+func (e DataError) String() string {
+	return fmt.Sprintf("Data Error. Message: %s, Data: %v", e.Err, e.Reason)
 }

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -15,14 +15,11 @@ import (
 	"github.com/holiman/uint256"
 	enclaveconfig "github.com/ten-protocol/go-ten/go/enclave/config"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ten-protocol/go-ten/go/common"
-	"github.com/ten-protocol/go-ten/go/common/errutil"
 	"github.com/ten-protocol/go-ten/go/common/gethencoding"
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/measure"
@@ -32,7 +29,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethcore "github.com/ethereum/go-ethereum/core"
 	gethlog "github.com/ethereum/go-ethereum/log"
-	gethrpc "github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 )
 
 var ErrGasNotEnoughForL1 = errors.New("gas limit too low to pay for execution and l1 fees")
@@ -313,19 +309,14 @@ func ExecuteCall(
 	// 3 - error check the ApplyMessage
 
 	// Read the error stored in the database.
-	if dbErr := cleanState.Error(); dbErr != nil {
-		return nil, newErrorWithReasonAndCode(dbErr)
-	}
-
-	// If the result contains a revert reason, try to unpack and return it.
-	if result != nil && len(result.Revert()) > 0 {
-		return nil, newRevertError(result)
+	if vmerr := cleanState.Error(); vmerr != nil {
+		return nil, vmerr
 	}
 
 	if err != nil {
 		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
 		logger.Debug(fmt.Sprintf("Error applying msg %v:", msg), log.CtrErrKey, err)
-		return result, err
+		return result, fmt.Errorf("err: %w (supplied gas %d)", err, msg.GasLimit)
 	}
 
 	return result, nil
@@ -342,37 +333,6 @@ func initParams(storage storage.Storage, gethEncodingService gethencoding.Encodi
 		NoBaseFee: noBaseFee,
 	}
 	return NewTenChainContext(storage, gethEncodingService, config, l), vmCfg
-}
-
-func newErrorWithReasonAndCode(err error) error {
-	result := &errutil.DataError{
-		Err: err.Error(),
-	}
-
-	var e gethrpc.Error
-	ok := errors.As(err, &e)
-	if ok {
-		result.Code = e.ErrorCode()
-	}
-	var de gethrpc.DataError
-	ok = errors.As(err, &de)
-	if ok {
-		result.Reason = de.ErrorData()
-	}
-	return result
-}
-
-func newRevertError(result *gethcore.ExecutionResult) error {
-	reason, errUnpack := abi.UnpackRevert(result.Revert())
-	err := errors.New("execution reverted")
-	if errUnpack == nil {
-		err = fmt.Errorf("execution reverted: %v", reason)
-	}
-	return &errutil.DataError{
-		Err:    err.Error(),
-		Reason: hexutil.Encode(result.Revert()),
-		Code:   3, // todo - magic number, really needs thought around the value and made a constant
-	}
 }
 
 // used as a wrapper around the vm.EVM to allow for easier calling of smart contract view functions

--- a/go/enclave/l2chain/l2_chain.go
+++ b/go/enclave/l2chain/l2_chain.go
@@ -79,12 +79,6 @@ func (oc *tenChain) Call(ctx context.Context, apiArgs *gethapi.TransactionArgs, 
 		return nil, err
 	}
 
-	// the execution might have succeeded (err == nil) but the evm contract logic might have failed (result.Failed() == true)
-	if result.Failed() {
-		oc.logger.Debug(fmt.Sprintf("Obs_Call: Failed to execute contract %s.", apiArgs.To), log.CtrErrKey, result.Err)
-		return nil, result.Err
-	}
-
 	if oc.logger.Enabled(context.Background(), gethlog.LevelTrace) {
 		oc.logger.Trace("Obs_Call successful", "result", hexutils.BytesToHex(result.ReturnData))
 	}
@@ -117,13 +111,7 @@ func (oc *tenChain) ObsCallAtBlock(ctx context.Context, apiArgs *gethapi.Transac
 			batch.Header.Root.Hex()))
 	}
 
-	result, err := evm.ExecuteCall(ctx, callMsg, blockState, batch.Header, oc.storage, oc.gethEncodingService, oc.chainConfig, oc.gasEstimationCap, oc.config, oc.logger)
-	if err != nil {
-		// also return the result as the result can be evaluated on some errors like ErrIntrinsicGas
-		return result, err
-	}
-
-	return result, nil
+	return evm.ExecuteCall(ctx, callMsg, blockState, batch.Header, oc.storage, oc.gethEncodingService, oc.chainConfig, oc.gasEstimationCap, oc.config, oc.logger)
 }
 
 // GetChainStateAtTransaction Returns the state of the chain at certain block height after executing transactions up to the selected transaction

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/status-im/keycard-go/hexutils"
-
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -103,7 +101,6 @@ func EstimateGasExecute(builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64
 	// but is quick.
 	executionGasEstimate, revert, gasPrice, err := estimateGasSinglePass(builder.ctx, rpc, txArgs, blockNumber, rpc.config.GasLocalExecutionCapFlag)
 	if err != nil {
-		rpc.logger.Debug("Gas estimation failed", "revert", hexutils.BytesToHex(revert), "error", err)
 		if len(revert) > 0 {
 			builder.Err = newRevertError(revert)
 			rpc.logger.Debug("revert error", "err", builder.Err)
@@ -204,27 +201,23 @@ func estimateGasSinglePass(ctx context.Context, rpc *EncryptionManager, args *ge
 	// Perform a single gas estimation pass using isGasEnough
 	failed, result, err := isGasEnough(ctx, rpc, args, allowance, blkNumber)
 	if err != nil {
-		rpc.logger.Debug("1", "error", err)
 		// Return zero values and the encountered error if estimation fails
 		return 0, nil, nil, err
 	}
 
 	if failed {
 		if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
-			rpc.logger.Debug("2", "error", result.Err)
+			rpc.logger.Debug("Failed gas estimation", "error", result.Err)
 			return 0, result.Revert(), nil, result.Err
 		}
-		rpc.logger.Debug("3")
 		// If the gas cap is insufficient, return an appropriate error
 		return 0, nil, nil, fmt.Errorf("gas required exceeds allowance (%d)", globalGasCap)
 	}
 
 	if result == nil {
-		rpc.logger.Debug("4")
 		// If there's no result, something went wrong
 		return 0, nil, nil, fmt.Errorf("no execution result returned")
 	}
-	rpc.logger.Debug("5")
 
 	// Extract the gas used from the execution result.
 	// Add an overhead buffer to account for the fact that the execution might not be able to be completed in the same batch.

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/vm"
+
 	"github.com/ethereum/go-ethereum/params"
 
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ten-protocol/go-ten/go/common/measure"
 	"github.com/ten-protocol/go-ten/go/enclave/core"
 
@@ -286,9 +287,7 @@ func isGasEnough(ctx context.Context, rpc *EncryptionManager, args *gethapi.Tran
 	args.Gas = (*hexutil.Uint64)(&gas)
 	result, err := rpc.chain.ObsCallAtBlock(ctx, args, blkNumber)
 	if err != nil {
-		if errors.Is(err, gethcore.ErrIntrinsicGas) {
-			return true, nil, nil // Special case, raise gas limit
-		}
+		// since we estimate gas in a single pass, any error is just returned
 		return true, nil, err // Bail out
 	}
 	return result.Failed(), result, nil

--- a/go/enclave/rpc/TenEthCall.go
+++ b/go/enclave/rpc/TenEthCall.go
@@ -1,13 +1,11 @@
 package rpc
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ten-protocol/go-ten/go/common/gethencoding"
 	"github.com/ten-protocol/go-ten/go/common/log"
-	"github.com/ten-protocol/go-ten/go/common/syserr"
 )
 
 func TenCallValidate(reqParams []any, builder *CallBuilder[CallParamsWithBlock, string], _ *EncryptionManager) error {
@@ -52,15 +50,15 @@ func TenCallExecute(builder *CallBuilder[CallParamsWithBlock, string], rpc *Encr
 	execResult, err := rpc.chain.Call(builder.ctx, apiArgs, blkNumber)
 	if err != nil {
 		rpc.logger.Debug("Failed eth_call.", log.ErrKey, err)
-
-		// return system errors to the host
-		if errors.Is(err, syserr.InternalError{}) {
-			return err
-		}
-
-		builder.Err = err
+		return err
+	}
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(execResult.Revert()) > 0 {
+		builder.Err = newRevertError(execResult.Revert())
 		return nil
 	}
+
+	builder.Err = execResult.Err
 
 	var encodedResult string
 	if len(execResult.ReturnData) != 0 {

--- a/go/enclave/rpc/rpc_utils.go
+++ b/go/enclave/rpc/rpc_utils.go
@@ -3,6 +3,10 @@ package rpc
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/vm"
+
 	"github.com/ten-protocol/go-ten/go/common/gethapi"
 	gethrpc "github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 
@@ -35,4 +39,37 @@ func storeTxEnabled[P any, R any](rpc *EncryptionManager, builder *CallBuilder[P
 		return false
 	}
 	return true
+}
+
+// lifted from go-ethereum
+// revertError is an API error that encompasses an EVM revert with JSON error
+// code and a binary data blob.
+type revertError struct {
+	error
+	reason string // revert reason hex encoded
+}
+
+// ErrorCode returns the JSON error code for a revert.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) ErrorCode() int {
+	return 3
+}
+
+// ErrorData returns the hex encoded revert reason.
+func (e *revertError) ErrorData() interface{} {
+	return e.reason
+}
+
+// newRevertError creates a revertError instance with the provided revert data.
+func newRevertError(revert []byte) *revertError {
+	err := vm.ErrExecutionReverted
+
+	reason, errUnpack := abi.UnpackRevert(revert)
+	if errUnpack == nil {
+		err = fmt.Errorf("%w: %v", vm.ErrExecutionReverted, reason)
+	}
+	return &revertError{
+		error:  err,
+		reason: hexutil.Encode(revert),
+	}
 }

--- a/go/responses/responses.go
+++ b/go/responses/responses.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
+
 	"github.com/ten-protocol/go-ten/go/common/errutil"
 
 	"github.com/ten-protocol/go-ten/go/common/syserr"
@@ -170,9 +172,9 @@ func DecodeResponse[T any](encoded []byte) (*T, error) {
 	return resp.Result, nil
 }
 
-func convertError(err error) *errutil.DataError {
+func convertError(err error) rpc.DataError {
 	// check if it's a serialized error and handle any error wrapping that might have occurred
-	var e *errutil.DataError
+	var e rpc.DataError
 	if ok := errors.As(err, &e); ok {
 		return e
 	}

--- a/go/responses/types.go
+++ b/go/responses/types.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
+	"github.com/ten-protocol/go-ten/go/common/errutil"
 )
 
 type ViewingKeyEncryptor func([]byte) ([]byte, error)
@@ -13,7 +13,7 @@ type ViewingKeyEncryptor func([]byte) ([]byte, error)
 // which will be decoded only on the client side.
 type UserResponse[T any] struct {
 	Result *T
-	Err    rpc.DataError
+	Err    *errutil.DataError
 }
 
 // Error - converts the encoded string in the response into a normal error and returns it.

--- a/go/responses/types.go
+++ b/go/responses/types.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ten-protocol/go-ten/go/common/errutil"
+	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 )
 
 type ViewingKeyEncryptor func([]byte) ([]byte, error)
@@ -13,7 +13,7 @@ type ViewingKeyEncryptor func([]byte) ([]byte, error)
 // which will be decoded only on the client side.
 type UserResponse[T any] struct {
 	Result *T
-	Err    *errutil.DataError
+	Err    rpc.DataError
 }
 
 // Error - converts the encoded string in the response into a normal error and returns it.

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -101,7 +101,7 @@ func createInMemTenNode(
 		MaxRollupSize:             1024 * 128,
 		BaseFee:                   big.NewInt(1), // todo @siliev:: fix test transaction builders so this can be different
 		GasLocalExecutionCapFlag:  params.MaxGasLimit / 2,
-		GasBatchExecutionLimit:    params.MaxGasLimit / 2,
+		GasBatchExecutionLimit:    30_000_000,
 		RPCTimeout:                5 * time.Second,
 		StoreExecutedTransactions: true,
 	}


### PR DESCRIPTION
### Why this change is needed

- convert EVM errors at a higher level 
- estimate gas was losing a revert error
- remove intrinsic gas low check because we are doing a single gas estimate pass

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


