### PR TITLE
Testnets: temporary disable HA enclaves

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -175,7 +175,7 @@ jobs:
           - node_l1_ws_lookup: L1_WS_URL_2
             host_id: 2
           # sequencer has an HA setup with 2 enclaves
-          - num_enclaves: 2
+          - num_enclaves: 1
             host_id: 0
           - num_enclaves: 1
             host_id: 1

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -135,7 +135,7 @@ jobs:
           - node_l1_ws_lookup: L1_WS_URL_2
             host_id: 2
           # sequencer has an HA setup with 2 enclaves
-          - num_enclaves: 2
+          - num_enclaves: 1
             host_id: 0
           - num_enclaves: 1
             host_id: 1


### PR DESCRIPTION
### Why this change is needed

Testnet environments haven't been starting up cleanly and I think it's because of the multiple enclaves. Seen some worrying errors around PCCS calls and performance, either of which could be caused by HA.

### What changes were made as part of this PR

Turn testnet sequencers back down to 1 enclave.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


