### PR TITLE
edb-connect: fix edb default host and allow caller to set it

### DIFF
--- a/tools/edbconnect/edb-connect.sh
+++ b/tools/edbconnect/edb-connect.sh
@@ -5,11 +5,12 @@ IMAGE_NAME="testnetobscuronet.azurecr.io/obscuronet/edbconnect:latest"
 CONTAINER_BASE_NAME="edb-connect"
 UNIQUE_ID=$(date +%s%3N) # Using milliseconds for uniqueness
 CONTAINER_NAME="${CONTAINER_BASE_NAME}-${UNIQUE_ID}"
-VOLUME_NAME="obscuronode-enclave-volume"
+VOLUME_NAME="obscuronode-enclave-volume-0"
+DB_HOST="obscuronode-edgelessdb-0"
 NETWORK_NAME="node_network"
 SGX_ENCLAVE_DEVICE="/dev/sgx_enclave"
 SGX_PROVISION_DEVICE="/dev/sgx_provision"
-COMMAND="ego run /home/ten/go-ten/tools/edbconnect/main/main"
+COMMAND="ego run /home/ten/go-ten/tools/edbconnect/main/main $DB_HOST"
 
 # Function to destroy exited containers matching the base name
 destroy_exited_containers() {

--- a/tools/edbconnect/main/main.go
+++ b/tools/edbconnect/main/main.go
@@ -12,10 +12,14 @@ import (
 )
 
 func main() {
-	// optionally set edbHost from cli flag, default to obscuronode-edgelessdb-0
-	edbHost := "obscuronode-edgelessdb-0"
+	// get edbHost from first command line arg
+	var edbHost string
 	if len(os.Args) > 1 {
 		edbHost = os.Args[1]
+	} else {
+		fmt.Println("Usage: edbconnect <edb-host>")
+		fmt.Println("Ensure you have the latest copy of the ./edb-connect.sh launch script if you see this error.")
+		os.Exit(1)
 	}
 
 	fmt.Println("Retrieving Edgeless DB credentials...")

--- a/tools/edbconnect/main/main.go
+++ b/tools/edbconnect/main/main.go
@@ -12,6 +12,12 @@ import (
 )
 
 func main() {
+	// optionally set edbHost from cli flag, default to obscuronode-edgelessdb-0
+	edbHost := "obscuronode-edgelessdb-0"
+	if len(os.Args) > 1 {
+		edbHost = os.Args[1]
+	}
+
 	fmt.Println("Retrieving Edgeless DB credentials...")
 	creds, found, err := edgelessdb.LoadCredentialsFromFile()
 	if err != nil {
@@ -29,9 +35,9 @@ func main() {
 	}
 	fmt.Println("TLS config created. Connecting to Edgeless DB...")
 	testlog.SetupSysOut()
-	db, err := edgelessdb.ConnectToEdgelessDB("obscuronode-edgelessdb", cfg, testlog.Logger())
+	db, err := edgelessdb.ConnectToEdgelessDB(edbHost, cfg, testlog.Logger())
 	if err != nil {
-		fmt.Println("Error connecting to Edgeless DB:", err)
+		fmt.Printf("Error connecting to Edgeless DB at %s: %v\n", edbHost, err)
 		panic(err)
 	}
 	fmt.Println("Connected to Edgeless DB.")


### PR DESCRIPTION
### Why this change is needed

We changed the edb default host name (obscuronode-edgelessdb-0). Allowing us to set it means the tool can still be used for sepolia and for the HA db (obscuronode-edgelessdb-1).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


