### PR TITLE
introduce a more robust cache eviction mechanism

### DIFF
--- a/tools/walletextension/cache/RistrettoCache.go
+++ b/tools/walletextension/cache/RistrettoCache.go
@@ -59,7 +59,7 @@ func (c *ristrettoCache) DisableShortLiving() {
 }
 
 func (c *ristrettoCache) IsEvicted(key any, originalTTL time.Duration) bool {
-	if c.shortLivingEnabled.Load() == false {
+	if !c.shortLivingEnabled.Load() {
 		return true
 	}
 	remainingTTL, notExpired := c.cache.GetTTL(key)

--- a/tools/walletextension/cache/RistrettoCache.go
+++ b/tools/walletextension/cache/RistrettoCache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -15,9 +16,10 @@ const (
 )
 
 type ristrettoCache struct {
-	cache        *ristretto.Cache
-	quit         chan struct{}
-	lastEviction time.Time
+	cache              *ristretto.Cache
+	quit               chan struct{}
+	lastEviction       time.Time
+	shortLivingEnabled *atomic.Bool
 }
 
 // NewRistrettoCacheWithEviction returns a new ristrettoCache.
@@ -33,10 +35,12 @@ func NewRistrettoCacheWithEviction(nrElems int, logger log.Logger) (Cache, error
 	}
 
 	c := &ristrettoCache{
-		cache:        cache,
-		quit:         make(chan struct{}),
-		lastEviction: time.Now(),
+		cache:              cache,
+		quit:               make(chan struct{}),
+		lastEviction:       time.Now(),
+		shortLivingEnabled: &atomic.Bool{},
 	}
+	c.shortLivingEnabled.Store(true)
 
 	// Start the metrics logging
 	go c.startMetricsLogging(logger)
@@ -45,10 +49,19 @@ func NewRistrettoCacheWithEviction(nrElems int, logger log.Logger) (Cache, error
 }
 
 func (c *ristrettoCache) EvictShortLiving() {
+	// this event happens when a new batch is received, so the cache can be enabled
+	c.shortLivingEnabled.Store(true)
 	c.lastEviction = time.Now()
 }
 
+func (c *ristrettoCache) DisableShortLiving() {
+	c.shortLivingEnabled.Store(false)
+}
+
 func (c *ristrettoCache) IsEvicted(key any, originalTTL time.Duration) bool {
+	if c.shortLivingEnabled.Load() == false {
+		return true
+	}
 	remainingTTL, notExpired := c.cache.GetTTL(key)
 	if !notExpired {
 		return true

--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -11,6 +11,9 @@ type Cache interface {
 	// EvictShortLiving - notify the cache that all short living elements cached before the events should be considered as evicted.
 	EvictShortLiving()
 
+	// DisableShortLiving disables the caching of short-living elements.
+	DisableShortLiving()
+
 	// IsEvicted - based on the eviction event and the time of caching, calculates whether the key was evicted
 	IsEvicted(key any, originalTTL time.Duration) bool
 

--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -4,23 +4,30 @@ import "time"
 
 // Config contains the configuration required by the WalletExtension.
 type Config struct {
-	WalletExtensionHost            string
-	WalletExtensionPortHTTP        int
-	WalletExtensionPortWS          int
-	NodeRPCHTTPAddress             string
-	NodeRPCWebsocketAddress        string
-	LogPath                        string
-	DBPathOverride                 string // Overrides the database file location. Used in tests.
-	VerboseFlag                    bool
-	DBType                         string
-	DBConnectionURL                string
-	TenChainID                     int
-	StoreIncomingTxs               bool
+	WalletExtensionHost     string
+	WalletExtensionPortHTTP int
+	WalletExtensionPortWS   int
+
+	NodeRPCHTTPAddress      string
+	NodeRPCWebsocketAddress string
+
+	LogPath        string
+	DBPathOverride string // Overrides the database file location. Used in tests.
+	VerboseFlag    bool
+
+	DBType          string
+	DBConnectionURL string
+
+	TenChainID       int
+	StoreIncomingTxs bool
+
 	RateLimitUserComputeTime       time.Duration
 	RateLimitWindow                time.Duration
 	RateLimitMaxConcurrentRequests int
-	InsideEnclave                  bool // Indicates if the program is running inside an enclave
-	KeyExchangeURL                 string
-	EnableTLS                      bool
-	TLSDomain                      string
+
+	InsideEnclave  bool // Indicates if the program is running inside an enclave
+	KeyExchangeURL string
+
+	EnableTLS bool
+	TLSDomain string
 }


### PR DESCRIPTION
### Why this change is needed

the `newHeads` subscription is not entirely reliable, and in case of delays, we can get inconsistent results.

### What changes were made as part of this PR

- introduce a ticker to evict the cache even if the new Head is delayed

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


