### PR TITLE
force docker pull on each redeploy

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -406,6 +406,8 @@ jobs:
             docker stop "${{ env.VM_NAME }}" || true
             docker rm "${{ env.VM_NAME }}" || true
             
+            docker pull ${{ env.DOCKER_BUILD_TAG_GATEWAY }}
+
             # Start Ten Gateway Container
             docker run -d -p 80:80 -p 81:81 -p 443:443 --name "${{ env.VM_NAME }}" \
             --device /dev/sgx_enclave --device /dev/sgx_provision \


### PR DESCRIPTION
### Why this change is needed

Previously docker sometimes used cached version of the gateway image to redeploy. Now we force pull and we get the latest image.

### What changes were made as part of this PR

force docker pull

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


