### PR TITLE
Add an option to disable certificate encryption

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -99,6 +99,7 @@ jobs:
             "GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER"
             "GATEWAY_KEY_EXCHANGE_URL"
             "GATEWAY_TLS_DOMAIN"
+            "GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED"
           )
 
           for VAR_NAME in "${VAR_NAMES[@]}"; do
@@ -129,6 +130,7 @@ jobs:
           echo "GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER: $GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER"
           echo "GATEWAY_KEY_EXCHANGE_URL: $GATEWAY_KEY_EXCHANGE_URL"
           echo "GATEWAY_TLS_DOMAIN: $GATEWAY_TLS_DOMAIN"
+          echo "GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED: $GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED"
 
       - name: "Print GitHub variables"
         run: |
@@ -424,7 +426,8 @@ jobs:
             -keyExchangeURL="${{ env.GATEWAY_KEY_EXCHANGE_URL }}" \
             -insideEnclave=true \
             -enableTLS=true \
-            -tlsDomain="${{ env.GATEWAY_TLS_DOMAIN }}"
+            -tlsDomain="${{ env.GATEWAY_TLS_DOMAIN }}" \
+            -encryptingCertificateEnabled="${{ env.GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED }}"
             
             docker exec "${{ env.VM_NAME }}" sh -c "
                 echo \"Checking volume mount...\";

--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -23,4 +23,5 @@ type Config struct {
 	KeyExchangeURL                 string
 	EnableTLS                      bool
 	TLSDomain                      string
+	EncryptingCertificateEnabled   bool
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -88,6 +88,10 @@ const (
 	tlsDomainFlagName    = "tlsDomain"
 	tlsDomainFlagDefault = ""
 	tlsDomainFlagUsage   = "Domain name for TLS certificate"
+
+	encryptingCertificateEnabledFlagName    = "encryptingCertificateEnabled"
+	encryptingCertificateEnabledFlagDefault = false
+	encryptingCertificateEnabledFlagUsage   = "Flag to enable encrypting certificate functionality. Default: false"
 )
 
 func parseCLIArgs() wecommon.Config {
@@ -111,6 +115,7 @@ func parseCLIArgs() wecommon.Config {
 	keyExchangeURL := flag.String(keyExchangeURLFlagName, keyExchangeURLFlagDefault, keyExchangeURLFlagUsage)
 	enableTLSFlag := flag.Bool(enableTLSFlagName, enableTLSFlagDefault, enableTLSFlagUsage)
 	tlsDomainFlag := flag.String(tlsDomainFlagName, tlsDomainFlagDefault, tlsDomainFlagUsage)
+	encryptingCertificateEnabled := flag.Bool(encryptingCertificateEnabledFlagName, encryptingCertificateEnabledFlagDefault, encryptingCertificateEnabledFlagUsage)
 	flag.Parse()
 
 	return wecommon.Config{
@@ -133,5 +138,6 @@ func parseCLIArgs() wecommon.Config {
 		KeyExchangeURL:                 *keyExchangeURL,
 		EnableTLS:                      *enableTLSFlag,
 		TLSDomain:                      *tlsDomainFlag,
+		EncryptingCertificateEnabled:   *encryptingCertificateEnabled,
 	}
 }

--- a/tools/walletextension/storage/cert_storage.go
+++ b/tools/walletextension/storage/cert_storage.go
@@ -12,10 +12,10 @@ type CertStorage interface {
 }
 
 // NewCertStorage creates a new certificate storage instance based on the database type
-func NewCertStorage(dbType, dbConnectionURL string, randomKey []byte, logger gethlog.Logger) (CertStorage, error) {
+func NewCertStorage(dbType, dbConnectionURL string, randomKey []byte, encryptionEnabled bool, logger gethlog.Logger) (CertStorage, error) {
 	switch dbType {
 	case "cosmosDB":
-		return cosmosdb.NewCertStorageCosmosDB(dbConnectionURL, randomKey)
+		return cosmosdb.NewCertStorageCosmosDB(dbConnectionURL, randomKey, encryptionEnabled)
 	default:
 		return autocert.DirCache("/data/certs"), nil
 	}

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -81,7 +81,7 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 		// CRS is sent to CA (Let's Encrypt) via ACME (automated certificate management environment) client
 		// CA verifies CRS and issues a certificate
 		// Store certificate and private key in certificate storage based on the database type
-		certStorage, err := storage.NewCertStorage(config.DBType, config.DBConnectionURL, encryptionKey, logger)
+		certStorage, err := storage.NewCertStorage(config.DBType, config.DBConnectionURL, encryptionKey, config.EncryptingCertificateEnabled, logger)
 		if err != nil {
 			logger.Crit("unable to create certificate storage", log.ErrKey, err)
 			os.Exit(1)


### PR DESCRIPTION
### Why this change is needed

At the moment we always encrypt our https certificate. In case we need to do hard redeploy (often during testing different things) we need to request the certificate again from LetsEncrypt. It also has some weekly limits that we started to hit.
By using unencrypted certificate it can be used over redeploys even in case when the encryption key is lost/changed due to a redeploy of a whole VM.
This flag should be set to `true` in mainnet, but for testnets we can use the default value (`false`).


### What changes were made as part of this PR

- new flag that can disable certificate encryption & decryption on testnets.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


