### PR TITLE
Remove message bus owner key

### DIFF
--- a/go/enclave/crosschain/interfaces.go
+++ b/go/enclave/crosschain/interfaces.go
@@ -31,20 +31,12 @@ type BlockMessageExtractor interface {
 }
 
 type Manager interface {
-	// IsSyntheticTransaction - Determines if a given L2 transaction is coming from the synthetic owner address.
-	IsSyntheticTransaction(transaction *common.L2Tx) bool
-
-	// GetOwner - Returns the address of the identity owning the message bus.
-	GetOwner() common.L2Address
 
 	// GetBusAddress - Returns the L2 address of the message bus contract.
 	GetBusAddress() *common.L2Address
 
 	// Initialize - Derives the address of the message bus contract.
 	Initialize(systemAddresses common.SystemContractAddresses) error
-
-	// GenerateMessageBusDeployTx - Returns a signed message bus deployment transaction.
-	GenerateMessageBusDeployTx() (*common.L2Tx, error)
 
 	// ExtractOutboundMessages - Finds relevant logs in the receipts and converts them to cross chain messages.
 	ExtractOutboundMessages(ctx context.Context, receipts common.L2Receipts) (common.CrossChainMessages, error)

--- a/go/enclave/crosschain/interfaces.go
+++ b/go/enclave/crosschain/interfaces.go
@@ -31,7 +31,6 @@ type BlockMessageExtractor interface {
 }
 
 type Manager interface {
-
 	// GetBusAddress - Returns the L2 address of the message bus contract.
 	GetBusAddress() *common.L2Address
 

--- a/go/enclave/crosschain/processors.go
+++ b/go/enclave/crosschain/processors.go
@@ -2,8 +2,6 @@ package crosschain
 
 import (
 	"fmt"
-	"math/big"
-
 	"github.com/ten-protocol/go-ten/go/common"
 
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
@@ -22,11 +20,10 @@ type Processors struct {
 func New(
 	l1BusAddress *gethcommon.Address,
 	storage storage.Storage,
-	chainID *big.Int,
 	logger gethlog.Logger,
 ) *Processors {
 	processors := Processors{}
-	processors.Local = NewObscuroMessageBusManager(storage, chainID, logger)
+	processors.Local = NewTenMessageBusManager(storage, logger)
 	processors.Remote = NewBlockMessageExtractor(l1BusAddress, storage, logger)
 	return &processors
 }

--- a/go/enclave/crosschain/processors.go
+++ b/go/enclave/crosschain/processors.go
@@ -2,6 +2,7 @@ package crosschain
 
 import (
 	"fmt"
+
 	"github.com/ten-protocol/go-ten/go/common"
 
 	"github.com/ten-protocol/go-ten/go/enclave/storage"

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -82,7 +82,7 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 	daEncryptionService := crypto.NewDAEncryptionService(sharedSecretService, logger)
 	rpcKeyService := crypto.NewRPCKeyService(sharedSecretService, logger)
 
-	crossChainProcessors := crosschain.New(&config.MessageBusAddress, storage, big.NewInt(config.TenChainID), logger)
+	crossChainProcessors := crosschain.New(&config.MessageBusAddress, storage, logger)
 
 	// initialise system contracts
 	scb := system.NewSystemContractCallbacks(storage, &config.SystemContractOwner, logger)

--- a/go/enclave/rpc/SubmitTx.go
+++ b/go/enclave/rpc/SubmitTx.go
@@ -24,11 +24,6 @@ func SubmitTxValidate(reqParams []any, builder *CallBuilder[common.L2Tx, gethcom
 }
 
 func SubmitTxExecute(builder *CallBuilder[common.L2Tx, gethcommon.Hash], rpc *EncryptionManager) error {
-	if rpc.processors.Local.IsSyntheticTransaction(builder.Param) {
-		builder.Err = fmt.Errorf("synthetic transaction coming from external rpc")
-		return nil
-	}
-
 	if err := rpc.mempool.SubmitTx(builder.Param); err != nil {
 		rpc.logger.Debug("Could not submit transaction", log.TxKey, builder.Param.Hash(), log.ErrKey, err)
 		builder.Err = err


### PR DESCRIPTION
### Why this change is needed

We don't use this now we've got keyless transactions. 

### What changes were made as part of this PR

* Removing a bunch of unused code from message bus interface

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


