### PR TITLE
Fix Segmentation Fault in UnauthenticatedTenRPCCall in audit

### DIFF
--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -64,7 +64,7 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 
 	res, err := cache.WithCache(w.RPCResponsesCache, cfg, generateCacheKey(cacheArgs), func() (*R, error) {
 		return services.WithPlainRPCConnection(ctx, w.BackendRPC, func(client *rpc.Client) (*R, error) {
-			var resp R
+			var resp *R = new(R)
 			var err error
 
 			// wrap the context with a timeout to prevent long executions
@@ -72,7 +72,7 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 			defer cancelCtx()
 
 			err = client.CallContext(timeoutContext, &resp, method, args...)
-			return &resp, err
+			return resp, err
 		})
 	})
 

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -64,7 +64,7 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 
 	res, err := cache.WithCache(w.RPCResponsesCache, cfg, generateCacheKey(cacheArgs), func() (*R, error) {
 		return services.WithPlainRPCConnection(ctx, w.BackendRPC, func(client *rpc.Client) (*R, error) {
-			var resp *R
+			var resp R
 			var err error
 
 			// wrap the context with a timeout to prevent long executions
@@ -72,10 +72,16 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 			defer cancelCtx()
 
 			err = client.CallContext(timeoutContext, &resp, method, args...)
-			return resp, err
+			return &resp, err
 		})
 	})
-	audit(w, "RPC call. method=%s args=%v result=%s error=%s time=%d", method, args, res, err, time.Since(requestStartTime).Milliseconds())
+
+	if err != nil {
+		audit(w, "RPC call failed. method=%s args=%v error=%+v time=%d", method, args, err, time.Since(requestStartTime).Milliseconds())
+		return nil, err
+	}
+
+	audit(w, "RPC call succeeded. method=%s args=%v result=%+v time=%d", method, args, res, time.Since(requestStartTime).Milliseconds())
 	return res, err
 }
 


### PR DESCRIPTION
### Why this change is needed

A segmentation fault was occurring during the audit function call while formatting RPC call results (res) and errors (err).

More details: https://github.com/ten-protocol/ten-internal/issues/4479

- replaced %s with %+v for res and err in audit logs to handle complex or nil values gracefully.
- changed var resp *R to var resp R to avoid unnecessary pointer dereferences
- added separate audit calls for success and error scenarios to prevent undefined behavior


### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


