### PR TITLE
add an option to disable caching in the gateway

### DIFF
--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -86,3 +86,27 @@ func WithCache[R any](cache Cache, cfg *Cfg, cacheKey []byte, onCacheMiss func()
 
 	return result, err
 }
+
+type noOpCache struct{}
+
+func NewNoOpCache() Cache {
+	return &noOpCache{}
+}
+
+func (c *noOpCache) EvictShortLiving() {}
+
+func (c *noOpCache) DisableShortLiving() {}
+
+func (c *noOpCache) IsEvicted(key []byte, originalTTL time.Duration) bool {
+	return false
+}
+
+func (c *noOpCache) Set(key []byte, value any, ttl time.Duration) bool {
+	return false
+}
+
+func (c *noOpCache) Get(key []byte) (value any, ok bool) {
+	return nil, false
+}
+
+func (c *noOpCache) Remove(key []byte) {}

--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -30,4 +30,5 @@ type Config struct {
 	EnableTLS                    bool
 	TLSDomain                    string
 	EncryptingCertificateEnabled bool
+	DisableCaching               bool
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -92,6 +92,10 @@ const (
 	encryptingCertificateEnabledFlagName    = "encryptingCertificateEnabled"
 	encryptingCertificateEnabledFlagDefault = false
 	encryptingCertificateEnabledFlagUsage   = "Flag to enable encrypting certificate functionality. Default: false"
+
+	disableCachingFlagName    = "disableCaching"
+	disableCachingFlagDefault = false
+	disableCachingFlagUsage   = "Flag to disable response caching in the gateway. Default: false"
 )
 
 func parseCLIArgs() wecommon.Config {
@@ -116,6 +120,7 @@ func parseCLIArgs() wecommon.Config {
 	enableTLSFlag := flag.Bool(enableTLSFlagName, enableTLSFlagDefault, enableTLSFlagUsage)
 	tlsDomainFlag := flag.String(tlsDomainFlagName, tlsDomainFlagDefault, tlsDomainFlagUsage)
 	encryptingCertificateEnabled := flag.Bool(encryptingCertificateEnabledFlagName, encryptingCertificateEnabledFlagDefault, encryptingCertificateEnabledFlagUsage)
+	disableCaching := flag.Bool(disableCachingFlagName, disableCachingFlagDefault, disableCachingFlagUsage)
 	flag.Parse()
 
 	return wecommon.Config{
@@ -139,5 +144,6 @@ func parseCLIArgs() wecommon.Config {
 		EnableTLS:                      *enableTLSFlag,
 		TLSDomain:                      *tlsDomainFlag,
 		EncryptingCertificateEnabled:   *encryptingCertificateEnabled,
+		DisableCaching:                 *disableCaching,
 	}
 }

--- a/tools/walletextension/services/wallet_extension.go
+++ b/tools/walletextension/services/wallet_extension.go
@@ -59,10 +59,18 @@ type NewHeadNotifier interface {
 const rpcResponseCacheSize = 1_000_000
 
 func NewServices(hostAddrHTTP string, hostAddrWS string, storage storage.UserStorage, stopControl *stopcontrol.StopControl, version string, logger gethlog.Logger, config *common.Config) *Services {
-	newGatewayCache, err := cache.NewCache(rpcResponseCacheSize, logger)
-	if err != nil {
-		logger.Error(fmt.Errorf("could not create cache. Cause: %w", err).Error())
-		panic(err)
+	var newGatewayCache cache.Cache
+	var err error
+
+	if !config.DisableCaching {
+		newGatewayCache, err = cache.NewCache(rpcResponseCacheSize, logger)
+		if err != nil {
+			logger.Error(fmt.Errorf("could not create cache. Cause: %w", err).Error())
+			panic(err)
+		}
+	} else {
+		// Create a no-op cache implementation when caching is disabled
+		newGatewayCache = cache.NewNoOpCache()
 	}
 
 	rateLimiter := ratelimiter.NewRateLimiter(config.RateLimitUserComputeTime, config.RateLimitWindow, uint32(config.RateLimitMaxConcurrentRequests), logger)


### PR DESCRIPTION
### Why this change is needed

In tests we would sometimes like to run the gateway without caching so that every request goes to the validator/sequencer directly.

### What changes were made as part of this PR

- add a flag to disable caching & add it to the config
- add a NonOpCache and use it when caching is disabled

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


