### PR TITLE
Backup sequencer: fix catchup issues

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -440,8 +440,8 @@ func (g *Guardian) catchupWithL1() error {
 func (g *Guardian) catchupWithL2() error {
 	// while we are behind the L2 head and still running:
 	for g.running.Load() && g.state.GetStatus() == L2Catchup {
-		if g.hostData.IsSequencer {
-			return errors.New("l2 catchup is not supported for sequencer")
+		if g.hostData.IsSequencer && g.isActiveSequencer {
+			return errors.New("l2 catchup is not supported for active sequencer")
 		}
 		// request the next batch by sequence number (based on what the enclave has been fed so far)
 		prevHead := g.state.GetEnclaveL2Head()

--- a/integration/simulation/devnetwork/dev_network.go
+++ b/integration/simulation/devnetwork/dev_network.go
@@ -157,7 +157,7 @@ func (s *InMemDevNetwork) Start() {
 	s.startNodes()
 
 	// sleep to allow the nodes to start
-	time.Sleep(15 * time.Second)
+	time.Sleep(30 * time.Second) // it takes a while for the secret exchanges etc. to sort themselves out
 
 	seqClient, err := obsclient.Dial(s.SequencerRPCAddress())
 	if err != nil {

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -75,7 +75,6 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 			return resp, err
 		})
 	})
-
 	if err != nil {
 		audit(w, "RPC call failed. method=%s args=%v error=%+v time=%d", method, args, err, time.Since(requestStartTime).Milliseconds())
 		return nil, err


### PR DESCRIPTION
### Why this change is needed

Backup sequencer was spending a lot of time unhealthy because it wasn't receiving batches directly from the seq host.

### What changes were made as part of this PR

Allow backup sequencer to be in L2 catchup mode.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


