### PR TITLE
Prevent multiple blobs/ rollups in the same tx 

### DIFF
--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -153,7 +153,9 @@ type RollupProducer interface {
 }
 
 type RollupConsumer interface {
-	// ProcessBlobsInBlock - extracts the blob hashes from the block's transactions and builds the blob hashes from the blobs,
+	// ProcessRollups - extracts the blob hashes from the block's transactions and builds the blob hashes from the blobs,
 	// compares this with the hashes seen in the block.
-	ProcessBlobsInBlock(ctx context.Context, processed *common.ProcessedL1Data) error
+	ProcessRollups(ctx context.Context, rollups []*common.ExtRollup) error
+	// GetRollupsFromL1Data -
+	GetRollupsFromL1Data(processed *common.ProcessedL1Data) ([]*common.ExtRollup, error)
 }

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -50,7 +50,7 @@ func NewRollupConsumer(
 
 // ProcessRollups - processes the rollups found in the block, verifies the rollups and stores them
 func (rc *rollupConsumerImpl) ProcessRollups(ctx context.Context, rollups []*common.ExtRollup) error {
-	defer core.LogMethodDuration(rc.logger, measure.NewStopwatch(), "Rollup consumer processed blobs", log.RollupHashKey, rollups[0].Hash())
+	defer core.LogMethodDuration(rc.logger, measure.NewStopwatch(), "Rollup consumer processed blobs")
 
 	for _, rollup := range rollups {
 		l1CompressionBlock, err := rc.storage.FetchBlock(ctx, rollup.Header.CompressionL1Head)


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/4483

### What changes were made as part of this PR

* If multiple rollups are found in the same block, check they have unique tx hashes before storing the block/ rollup
* change the logger warning to trace as it will only reach that point if we have multiple rollups with unique txs in the block (ie in mem test) 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


