### PR TITLE
Guardian: avoid spamming errors after enclave removed from HA pool

### DIFF
--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -151,6 +151,10 @@ func (e *Service) NotifyUnavailable(enclaveID *common.EnclaveID) {
 		e.logger.Warn("Could not find enclave to evict.", log.EnclaveIDKey, enclaveID)
 		return
 	}
+	err := e.enclaveGuardians[failedEnclaveIdx].Stop()
+	if err != nil {
+		e.logger.Info("Failed to stop enclave guardian.", log.EnclaveIDKey, enclaveID, log.ErrKey, err)
+	}
 
 	// remove the failed enclave from the list of enclaves
 	e.enclaveGuardians = append(e.enclaveGuardians[:failedEnclaveIdx], e.enclaveGuardians[failedEnclaveIdx+1:]...)


### PR DESCRIPTION
### Why this change is needed

We weren't stopping the guardian when evicting it from the HA pool and it kept spamming the enclaves service to evict it again.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


