### PR TITLE
use double hash for userID logging

### DIFF
--- a/tools/walletextension/common/common.go
+++ b/tools/walletextension/common/common.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -80,4 +82,13 @@ func GenerateRandomKey() ([]byte, error) {
 		return nil, err
 	}
 	return key, nil
+}
+
+// HashForLogging creates a double-hashed hex string of the input bytes for secure logging
+func HashForLogging(input []byte) string {
+	// First hash
+	firstHash := sha256.Sum256(input)
+	// Second hash
+	secondHash := sha256.Sum256(firstHash[:])
+	return hex.EncodeToString(secondHash[:])
 }

--- a/tools/walletextension/services/wallet_extension.go
+++ b/tools/walletextension/services/wallet_extension.go
@@ -200,14 +200,14 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 
 	requestEndTime := time.Now()
 	duration := requestEndTime.Sub(requestStartTime)
-	audit(w, "Storing new userID: %s, duration: %d ", hexutils.BytesToHex(userID), duration.Milliseconds())
+	audit(w, "Storing new userID: %s, duration: %d ", common.HashForLogging(userID), duration.Milliseconds())
 	return userID, nil
 }
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
 func (w *Services) AddAddressToUser(userID []byte, address string, signature []byte, signatureType viewingkey.SignatureType) error {
 	w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
-	audit(w, "Adding address to user: %s, address: %s", hexutils.BytesToHex(userID), address)
+	audit(w, "Adding address to user: %s, address: %s", common.HashForLogging(userID), address)
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
 	// check if a message was signed by the correct address and if the signature is valid
@@ -235,7 +235,7 @@ func (w *Services) AddAddressToUser(userID []byte, address string, signature []b
 // UserHasAccount checks if provided account exist in the database for given userID
 func (w *Services) UserHasAccount(userID []byte, address string) (bool, error) {
 	w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
-	audit(w, "Checking if user has account: %s, address: %s", hexutils.BytesToHex(userID), address)
+	audit(w, "Checking if user has account: %s, address: %s", common.HashForLogging(userID), address)
 	addressBytes, err := hex.DecodeString(address[2:]) // remove 0x prefix from address
 	if err != nil {
 		w.Logger().Error(fmt.Errorf("error decoding string (%s), %w", address[2:], err).Error())


### PR DESCRIPTION
### Why this change is needed

At the moment we log userIDs to logs in plain text. This is a security issue as even we shouldn't be able to see that userIDs are.


https://github.com/ten-protocol/ten-internal/issues/4523

### What changes were made as part of this PR

- Double hash userIDs before logging them
Double hashing prevents us or anyone who can see the logs from getting userID and being able to see what is happening with this user. 
Using double hash still gives us some information about which user is performing which action so we are still able to debug things.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


