### PR TITLE
#4451 - L1 head used for compression can be stale

### DIFF
--- a/go/enclave/components/rollup_producer.go
+++ b/go/enclave/components/rollup_producer.go
@@ -3,7 +3,6 @@ package components
 import (
 	"context"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 
@@ -46,7 +45,7 @@ func (re *rollupProducerImpl) CreateInternalRollup(ctx context.Context, fromBatc
 		return nil, fmt.Errorf("no batches for rollup")
 	}
 
-	block, err := re.storage.FetchCanonicaBlockByHeight(ctx, big.NewInt(int64(upToL1Height)))
+	block, err := re.storage.FetchHeadBlock(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why this change is needed

L1 head used for compression can be stale; If the block is not in the canonical chain on the l1, the rollup should not be accepted by the management contract as nodes will not be able to decompress it. However if a block is too old, then its never going to be available in the EVM; This ensures we always use latest block in order to make rollups reconstructible.

### What changes were made as part of this PR

Changed from using a block at a height to always using head cannon block

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


