### PR TITLE
disable caching with github env variable

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -100,6 +100,7 @@ jobs:
             "GATEWAY_KEY_EXCHANGE_URL"
             "GATEWAY_TLS_DOMAIN"
             "GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED"
+            "GATEWAY_DISABLE_CACHING"
           )
 
           for VAR_NAME in "${VAR_NAMES[@]}"; do
@@ -427,7 +428,8 @@ jobs:
             -insideEnclave=true \
             -enableTLS=true \
             -tlsDomain="${{ env.GATEWAY_TLS_DOMAIN }}" \
-            -encryptingCertificateEnabled="${{ env.GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED }}"
+            -encryptingCertificateEnabled="${{ env.GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED }}" \
+            -disableCaching="${{ env.GATEWAY_DISABLE_CACHING }}"
             
             docker exec "${{ env.VM_NAME }}" sh -c "
                 echo \"Checking volume mount...\";


### PR DESCRIPTION
### Why this change is needed

We want to be able to disable caching by setting github env. variable `GATEWAY_DISABLE_CACHING` to `true`.

### What changes were made as part of this PR

Changed github actions script

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


