### PR TITLE
fix mock l1

### DIFF
--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -450,22 +450,11 @@ func (m *Node) setHead(b *types.Header) *types.Header {
 }
 
 func (m *Node) setFork(blocks []*types.Header) *types.Header {
-	m.subMu.Lock()
-	defer m.subMu.Unlock()
 	head := blocks[len(blocks)-1]
 	if atomic.LoadInt32(m.interrupt) == 1 {
 		return head
 	}
-
-	// notify the client subs
-	for _, s := range m.subs {
-		sub := s
-		go sub.publishAll(blocks)
-	}
-
-	m.canonicalCh <- head
-
-	return head
+	return m.setHead(head)
 }
 
 // P2PReceiveBlock is called by counterparties when there is a block to broadcast


### PR DESCRIPTION
### Why this change is needed

This manifested as split brains on the mock l1

### What changes were made as part of this PR

Properly set the l1 head during forks

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


