### PR TITLE
Fix flakiness.

### DIFF
--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -341,6 +341,10 @@ func (ti *TransactionInjector) awaitAndFinalizeWithdrawal(tx *types.Transaction,
 				time.Sleep(1 * time.Second)
 				continue
 			}
+			if strings.Contains(err.Error(), "database closed") {
+				ti.logger.Info("Database closed, test over", log.ErrKey, err)
+				return
+			}
 			panic(fmt.Errorf("unable to get proof for value transfer. cause: %w", err))
 		}
 		break


### PR DESCRIPTION
### Why this change is needed

There is a panic happening during valid database closed error being returned as the test is finishing. This fixes it.

### What changes were made as part of this PR

Added a return without doing anything meaningfull when this error is encountered, which stops the gorotuine.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


