### PR TITLE
fix personal txs query

### DIFF
--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -380,7 +380,7 @@ func BatchWasExecuted(ctx context.Context, db *sql.DB, hash common.L2BatchHash) 
 }
 
 func GetTransactionsPerAddress(ctx context.Context, db *sql.DB, address *gethcommon.Address, pagination *common.QueryPagination) ([]*core.InternalReceipt, error) {
-	receipts, err := loadReceiptList(ctx, db, address, " AND tx_sender.address = ? ", []any{address.Bytes()}, " ORDER BY b.height DESC LIMIT ? OFFSET ?", []any{pagination.Size, pagination.Offset})
+	receipts, err := loadReceiptList(ctx, db, address, " ", []any{}, " ORDER BY b.sequence DESC LIMIT ? OFFSET ?", []any{pagination.Size, pagination.Offset})
 	if err != nil {
 		return nil, err
 	}

--- a/go/enclave/storage/enclavedb/events.go
+++ b/go/enclave/storage/enclavedb/events.go
@@ -240,6 +240,7 @@ func loadReceiptList(ctx context.Context, db *sql.DB, requestingAccount *gethcom
 
 	query := "select b.hash, b.height, curr_tx.hash, curr_tx.idx, rec.post_state, rec.status, rec.cumulative_gas_used, rec.effective_gas_price, rec.created_contract_address, tx_sender.address, tx_contr.address, curr_tx.type "
 	query += baseReceiptJoin
+	query += " WHERE 1=1 "
 
 	// visibility
 	query += " AND tx_sender.address = ? "


### PR DESCRIPTION
### Why this change is needed

There was a bug in the "personal transactions" query.
The requester condition was part of the join instead of part of "where"

### What changes were made as part of this PR

- fix the query

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


