### PR TITLE
Revert testnet sequencer key change

### DIFF
--- a/go/config/defaults/testnet-launcher/2-sequencer.yaml
+++ b/go/config/defaults/testnet-launcher/2-sequencer.yaml
@@ -2,8 +2,8 @@ node:
    name: sequencer
    nodeType: sequencer
    isGenesis: true
-   id: 0x0654D8B60033144D567f25bF41baC1FB0D60F23B
-   privateKey: 8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
+   id: 0x9e36779646F7011A3c6D3713b49aEB254258F5d6
+   privateKey: e28d878c21a124b5789d244c40a0863613affcc7d918befbb3f94ec0735cdd80
    hostAddress: sequencer-host:15000
 host:
    p2p:

--- a/go/config/defaults/testnet-launcher/2-sequencer.yaml
+++ b/go/config/defaults/testnet-launcher/2-sequencer.yaml
@@ -2,8 +2,8 @@ node:
    name: sequencer
    nodeType: sequencer
    isGenesis: true
-   id: 0x9e36779646F7011A3c6D3713b49aEB254258F5d6
-   privateKey: e28d878c21a124b5789d244c40a0863613affcc7d918befbb3f94ec0735cdd80
+   id: 0x0654D8B60033144D567f25bF41baC1FB0D60F23B
+   privateKey: 8ead642ca80dadb0f346a66cd6aa13e08a8ac7b5c6f7578d4bac96f5db01ac99
    hostAddress: sequencer-host:15000
 host:
    p2p:

--- a/go/enclave/crosschain/processors.go
+++ b/go/enclave/crosschain/processors.go
@@ -1,6 +1,7 @@
 package crosschain
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ten-protocol/go-ten/go/common"
@@ -36,5 +37,8 @@ func (c *Processors) Enabled() bool {
 
 func (c *Processors) GetL2MessageBusAddress() (gethcommon.Address, common.SystemError) {
 	address := c.Local.GetBusAddress()
+	if address == nil {
+		return gethcommon.Address{}, fmt.Errorf("message bus address not initialised")
+	}
 	return *address, nil
 }


### PR DESCRIPTION
### Why this change is needed

Revert testnet sequencer key to older version for cleanliness

### What changes were made as part of this PR

* Revert last nights commit

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


