### PR TITLE
improve error handling

### DIFF
--- a/go/common/crosschain.go
+++ b/go/common/crosschain.go
@@ -30,7 +30,7 @@ func (hashes CrossChainRootHashes) ToHexString() string {
 	return strings.Join(hexStrings, ",")
 }
 
-func (bundle ExtCrossChainBundle) HashPacked() common.Hash {
+func (bundle ExtCrossChainBundle) HashPacked() (common.Hash, error) {
 	uint256type, _ := abi.NewType("uint256", "", nil)
 	bytes32type, _ := abi.NewType("bytes32", "", nil)
 	bytesТype, _ := abi.NewType("bytes[]", "", nil)
@@ -52,9 +52,9 @@ func (bundle ExtCrossChainBundle) HashPacked() common.Hash {
 
 	bytes, err := args.Pack(bundle.LastBatchHash, bundle.L1BlockHash, bundle.L1BlockNum, bundle.CrossChainRootHashes)
 	if err != nil {
-		panic(err)
+		return common.Hash{}, err
 	}
 
 	hash := crypto.Keccak256Hash(bytes)
-	return hash
+	return hash, nil
 }

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -384,7 +384,8 @@ func (rc *RollupCompression) calculateL1HeightsFromDeltas(calldataRollupHeader *
 			}
 			value := l1Delta.Int64() + int64(prevHeight)
 			if value < 0 {
-				rc.logger.Crit("Should not have a negative height")
+				rc.logger.Error("Should not have a negative height")
+				return nil, errors.New("negative height")
 			}
 			l1Heights = append(l1Heights, uint64(value))
 			prevHeight = uint64(value)

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -173,7 +173,10 @@ func (rc *rollupConsumerImpl) extractAndVerifyRollups(processed *common.Processe
 	txsSeen := make(map[gethcommon.Hash]bool)
 
 	for i, tx := range rollupTxs {
-		t := rc.MgmtContractLib.DecodeTx(tx.Transaction)
+		t, err := rc.MgmtContractLib.DecodeTx(tx.Transaction)
+		if err != nil {
+			rc.logger.Warn(fmt.Sprintf("could not decode tx at index %d. Cause: %s", i, err))
+		}
 		if t == nil {
 			continue
 		}

--- a/go/enclave/components/shared_secret_process.go
+++ b/go/enclave/components/shared_secret_process.go
@@ -41,7 +41,11 @@ func (ssp *SharedSecretProcessor) ProcessNetworkSecretMsgs(ctx context.Context, 
 
 	// process initialize secret events
 	for _, txData := range processed.GetEvents(common.InitialiseSecretTx) {
-		t := ssp.mgmtContractLib.DecodeTx(txData.Transaction)
+		t, err := ssp.mgmtContractLib.DecodeTx(txData.Transaction)
+		if err != nil {
+			ssp.logger.Warn("Could not decode transaction", log.ErrKey, err)
+			continue
+		}
 		initSecretTx, ok := t.(*common.L1InitializeSecretTx)
 		if !ok {
 			continue
@@ -60,7 +64,11 @@ func (ssp *SharedSecretProcessor) ProcessNetworkSecretMsgs(ctx context.Context, 
 
 	// process secret requests
 	for _, txData := range processed.GetEvents(common.SecretRequestTx) {
-		t := ssp.mgmtContractLib.DecodeTx(txData.Transaction)
+		t, err := ssp.mgmtContractLib.DecodeTx(txData.Transaction)
+		if err != nil {
+			ssp.logger.Warn("Could not decode transaction", log.ErrKey, err)
+			continue
+		}
 		scrtReqTx, ok := t.(*common.L1RequestSecretTx)
 		if !ok {
 			continue

--- a/go/enclave/crosschain/block_message_extractor.go
+++ b/go/enclave/crosschain/block_message_extractor.go
@@ -56,7 +56,7 @@ func (m *blockMessageExtractor) StoreCrossChainValueTransfers(ctx context.Contex
 
 	err := m.storage.StoreValueTransfers(ctx, block.Hash(), transfers)
 	if err != nil {
-		m.logger.Crit("Unable to store the transfers", log.ErrKey, err)
+		m.logger.Error("Unable to store the transfers", log.ErrKey, err)
 		return err
 	}
 
@@ -88,7 +88,7 @@ func (m *blockMessageExtractor) StoreCrossChainMessages(ctx context.Context, blo
 		m.logger.Info(fmt.Sprintf("Storing %d messages for block", len(messages)), log.BlockHashKey, block.Hash())
 		err := m.storage.StoreL1Messages(ctx, block.Hash(), messages)
 		if err != nil {
-			m.logger.Crit("Unable to store the messages", log.ErrKey, err)
+			m.logger.Error("Unable to store the messages", log.ErrKey, err)
 			return err
 		}
 	}

--- a/go/enclave/crosschain/interfaces.go
+++ b/go/enclave/crosschain/interfaces.go
@@ -42,11 +42,11 @@ type Manager interface {
 
 	ExtractOutboundTransfers(ctx context.Context, receipts common.L2Receipts) (common.ValueTransferEvents, error)
 
-	CreateSyntheticTransactions(ctx context.Context, messages common.CrossChainMessages, transfers common.ValueTransferEvents, stateDB *state.StateDB) common.L2Transactions
+	CreateSyntheticTransactions(ctx context.Context, messages common.CrossChainMessages, transfers common.ValueTransferEvents, stateDB *state.StateDB) (common.L2Transactions, error)
 
 	ExecuteValueTransfers(ctx context.Context, transfers common.ValueTransferEvents, stateDB *state.StateDB)
 
-	RetrieveInboundMessages(ctx context.Context, fromBlock *types.Header, toBlock *types.Header) (common.CrossChainMessages, common.ValueTransferEvents)
+	RetrieveInboundMessages(ctx context.Context, fromBlock *types.Header, toBlock *types.Header) (common.CrossChainMessages, common.ValueTransferEvents, error)
 
 	system.SystemContractsInitializable
 }

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -308,7 +308,12 @@ func (e *enclaveAdminService) ExportCrossChainData(ctx context.Context, fromSeqN
 		return nil, err
 	}
 
-	sig, err := e.enclaveKeyService.Sign(bundle.HashPacked())
+	bytes, err := bundle.HashPacked()
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := e.enclaveKeyService.Sign(bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/go/enclave/rpc/vk_utils.go
+++ b/go/enclave/rpc/vk_utils.go
@@ -104,7 +104,7 @@ func HandleEncryptedRPC(ctx context.Context,
 	case rpc.ERPCGetPersonalTransactions:
 		return withVKEncryption(ctx, encManager, decodedRequest, vk, GetPersonalTransactionsValidate, GetPersonalTransactionsExecute)
 	default:
-		panic(fmt.Sprintf("unsupported method %s", decodedRequest.Method))
+		return nil, fmt.Errorf("unsupported method %s", decodedRequest.Method)
 	}
 }
 

--- a/go/enclave/system/contracts.go
+++ b/go/enclave/system/contracts.go
@@ -3,6 +3,8 @@ package system
 import (
 	"fmt"
 
+	"github.com/ten-protocol/go-ten/go/common/log"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 
@@ -32,7 +34,7 @@ func SystemDeployerInitTransaction(logger gethlog.Logger, eoaOwner gethcommon.Ad
 	abi, _ := SystemDeployer.SystemDeployerMetaData.GetAbi()
 	args, err := abi.Constructor.Inputs.Pack(eoaOwner)
 	if err != nil {
-		panic(err) // This error is fatal. If the system contracts can't be initialized the network cannot bootstrap.
+		logger.Crit("This error is fatal. If the system contracts can't be initialized the network cannot bootstrap.", log.ErrKey, err)
 	}
 
 	bytecode := gethcommon.FromHex(SystemDeployer.SystemDeployerMetaData.Bin)

--- a/go/ethadapter/erc20contractlib/erc20_contract_lib.go
+++ b/go/ethadapter/erc20contractlib/erc20_contract_lib.go
@@ -79,7 +79,7 @@ func (c *erc20ContractLibImpl) DecodeTx(tx *types.Transaction) (common.L1TenTran
 	// only process transfers made to the management contract
 	toAddr, ok := to.(gethcommon.Address)
 	if !ok || toAddr.Hex() != c.mgmtContractAddr.Hex() {
-		return nil, fmt.Errorf("transfer not made to the management contract")
+		return nil, nil
 	}
 
 	amount, found := contractCallData[AmountCallData]

--- a/go/ethadapter/erc20contractlib/erc20_contract_lib.go
+++ b/go/ethadapter/erc20contractlib/erc20_contract_lib.go
@@ -1,6 +1,7 @@
 package erc20contractlib
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -17,10 +18,10 @@ const methodBytesLen = 4
 type ERC20ContractLib interface {
 	// DecodeTx receives a *types.Transaction and converts it to an common.L1Transaction
 	// returns nil if the transaction is not convertible
-	DecodeTx(tx *types.Transaction) common.L1TenTransaction
+	DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error)
 
 	// CreateDepositTx receives an common.L1Transaction and converts it to an eth transaction
-	CreateDepositTx(tx *common.L1DepositTx) types.TxData
+	CreateDepositTx(tx *common.L1DepositTx) (types.TxData, error)
 }
 
 // erc20ContractLibImpl takes a mgmtContractAddr and processes multiple erc20ContractAddrs
@@ -44,52 +45,52 @@ func NewERC20ContractLib(mgmtContractAddr *gethcommon.Address, contractAddrs ...
 	}
 }
 
-func (c *erc20ContractLibImpl) CreateDepositTx(tx *common.L1DepositTx) types.TxData {
+func (c *erc20ContractLibImpl) CreateDepositTx(tx *common.L1DepositTx) (types.TxData, error) {
 	data, err := c.contractABI.Pack("transfer", &tx.To, tx.Amount)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to pack transfer data: %w", err)
 	}
 
 	return &types.LegacyTx{
 		To:   tx.TokenContract,
 		Data: data,
-	}
+	}, nil
 }
 
-func (c *erc20ContractLibImpl) DecodeTx(tx *types.Transaction) common.L1TenTransaction {
+func (c *erc20ContractLibImpl) DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error) {
 	if !c.isRelevant(tx) {
-		return nil
+		return nil, nil
 	}
 	method, err := c.contractABI.MethodById(tx.Data()[:methodBytesLen])
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to extract method from tx data: %w", err)
 	}
 
 	contractCallData := map[string]interface{}{}
 	if err := method.Inputs.UnpackIntoMap(contractCallData, tx.Data()[methodBytesLen:]); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to unpack contract call data: %w", err)
 	}
 
 	to, found := contractCallData[ToCallData]
 	if !found {
-		panic("to address not found for transfer")
+		return nil, fmt.Errorf("to not found for transfer")
 	}
 
 	// only process transfers made to the management contract
 	toAddr, ok := to.(gethcommon.Address)
 	if !ok || toAddr.Hex() != c.mgmtContractAddr.Hex() {
-		return nil
+		return nil, fmt.Errorf("transfer not made to the management contract")
 	}
 
 	amount, found := contractCallData[AmountCallData]
 	if !found {
-		panic("amount not found for transfer")
+		return nil, fmt.Errorf("amount not found for transfer")
 	}
 
 	signer := types.NewLondonSigner(tx.ChainId())
 	sender, err := signer.Sender(tx)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to extract sender from tx: %w", err)
 	}
 
 	return &common.L1DepositTx{
@@ -97,7 +98,7 @@ func (c *erc20ContractLibImpl) DecodeTx(tx *types.Transaction) common.L1TenTrans
 		To:            &toAddr,
 		TokenContract: tx.To(),
 		Sender:        &sender,
-	}
+	}, nil
 }
 
 func (c *erc20ContractLibImpl) isRelevant(tx *types.Transaction) bool {

--- a/go/ethadapter/mgmtcontractlib/mgmt_contract_lib.go
+++ b/go/ethadapter/mgmtcontractlib/mgmt_contract_lib.go
@@ -27,12 +27,12 @@ type MgmtContractLib interface {
 	IsMock() bool
 	BlobHasher() ethadapter.BlobHasher
 	PopulateAddRollup(t *common.L1RollupTx, blobs []*kzg4844.Blob) (types.TxData, error)
-	CreateRequestSecret(tx *common.L1RequestSecretTx) types.TxData
-	CreateRespondSecret(tx *common.L1RespondSecretTx, verifyAttester bool) types.TxData
-	CreateInitializeSecret(tx *common.L1InitializeSecretTx) types.TxData
+	CreateRequestSecret(tx *common.L1RequestSecretTx) (types.TxData, error)
+	CreateRespondSecret(tx *common.L1RespondSecretTx, verifyAttester bool) (types.TxData, error)
+	CreateInitializeSecret(tx *common.L1InitializeSecretTx) (types.TxData, error)
 
 	// DecodeTx receives a *types.Transaction and converts it to a common.L1Transaction
-	DecodeTx(tx *types.Transaction) common.L1TenTransaction
+	DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error)
 	GetContractAddr() *gethcommon.Address
 
 	// The methods below are used to create call messages for mgmt contract data and unpack the responses
@@ -80,13 +80,13 @@ func (c *contractLibImpl) GetContractAddr() *gethcommon.Address {
 	return c.addr
 }
 
-func (c *contractLibImpl) DecodeTx(tx *types.Transaction) common.L1TenTransaction {
+func (c *contractLibImpl) DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error) {
 	if tx.To() == nil || tx.To().Hex() != c.addr.Hex() || len(tx.Data()) == 0 {
-		return nil
+		return nil, nil
 	}
 	method, err := c.contractABI.MethodById(tx.Data()[:methodBytesLen])
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not decode tx. Cause: %w", err)
 	}
 
 	contractCallData := map[string]interface{}{}
@@ -95,9 +95,9 @@ func (c *contractLibImpl) DecodeTx(tx *types.Transaction) common.L1TenTransactio
 		if tx.Type() == types.BlobTxType {
 			return &common.L1RollupHashes{
 				BlobHashes: tx.BlobHashes(),
-			}
+			}, nil
 		} else {
-			return nil
+			return nil, nil
 		}
 	case RespondSecretMethod:
 		return c.unpackRespondSecretTx(tx, method, contractCallData)
@@ -112,19 +112,19 @@ func (c *contractLibImpl) DecodeTx(tx *types.Transaction) common.L1TenTransactio
 		tx, err := c.unpackSetImportantContractsTx(tx, method, contractCallData)
 		if err != nil {
 			c.logger.Warn("could not unpack set important contracts tx", log.ErrKey, err)
-			return nil
+			return nil, err
 		}
-		return tx
+		return tx, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // PopulateAddRollup creates a BlobTx, encoding the rollup data into blobs.
 func (c *contractLibImpl) PopulateAddRollup(t *common.L1RollupTx, blobs []*kzg4844.Blob) (types.TxData, error) {
 	decodedRollup, err := common.DecodeRollup(t.Rollup)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not decode rollup. Cause: %w", err)
 	}
 
 	metaRollup := ManagementContract.StructsMetaRollup{
@@ -143,7 +143,7 @@ func (c *contractLibImpl) PopulateAddRollup(t *common.L1RollupTx, blobs []*kzg48
 		metaRollup,
 	)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not pack the call data. Cause: %w", err)
 	}
 
 	var blobHashes []gethcommon.Hash
@@ -162,19 +162,19 @@ func (c *contractLibImpl) PopulateAddRollup(t *common.L1RollupTx, blobs []*kzg48
 	}, nil
 }
 
-func (c *contractLibImpl) CreateRequestSecret(tx *common.L1RequestSecretTx) types.TxData {
+func (c *contractLibImpl) CreateRequestSecret(tx *common.L1RequestSecretTx) (types.TxData, error) {
 	data, err := c.contractABI.Pack(RequestSecretMethod, base64EncodeToString(tx.Attestation))
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not pack the call data. Cause: %w", err)
 	}
 
 	return &types.LegacyTx{
 		To:   c.addr,
 		Data: data,
-	}
+	}, nil
 }
 
-func (c *contractLibImpl) CreateRespondSecret(tx *common.L1RespondSecretTx, verifyAttester bool) types.TxData {
+func (c *contractLibImpl) CreateRespondSecret(tx *common.L1RespondSecretTx, verifyAttester bool) (types.TxData, error) {
 	data, err := c.contractABI.Pack(
 		RespondSecretMethod,
 		tx.AttesterID,
@@ -184,15 +184,15 @@ func (c *contractLibImpl) CreateRespondSecret(tx *common.L1RespondSecretTx, veri
 		verifyAttester,
 	)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not pack the call data. Cause: %w", err)
 	}
 	return &types.LegacyTx{
 		To:   c.addr,
 		Data: data,
-	}
+	}, nil
 }
 
-func (c *contractLibImpl) CreateInitializeSecret(tx *common.L1InitializeSecretTx) types.TxData {
+func (c *contractLibImpl) CreateInitializeSecret(tx *common.L1InitializeSecretTx) (types.TxData, error) {
 	data, err := c.contractABI.Pack(
 		InitializeSecretMethod,
 		tx.EnclaveID,
@@ -200,12 +200,12 @@ func (c *contractLibImpl) CreateInitializeSecret(tx *common.L1InitializeSecretTx
 		base64EncodeToString(tx.Attestation),
 	)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not pack the call data. Cause: %w", err)
 	}
 	return &types.LegacyTx{
 		To:   c.addr,
 		Data: data,
-	}
+	}, nil
 }
 
 func (c *contractLibImpl) GetHostAddressesMsg() (ethereum.CallMsg, error) {
@@ -320,84 +320,84 @@ func (c *contractLibImpl) DecodeImportantAddressResponse(callResponse []byte) (g
 	return address, nil
 }
 
-func (c *contractLibImpl) unpackInitSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) *common.L1InitializeSecretTx {
+func (c *contractLibImpl) unpackInitSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) (*common.L1InitializeSecretTx, error) {
 	err := method.Inputs.UnpackIntoMap(contractCallData, tx.Data()[methodBytesLen:])
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not unpack transaction. Cause: %w", err)
 	}
 	callData, found := contractCallData["_genesisAttestation"]
 	if !found {
-		panic("call data not found for requestReport")
+		return nil, fmt.Errorf("call data not found for _genesisAttestation")
 	}
 
-	att := Base64DecodeFromString(callData.(string))
+	att, err := Base64DecodeFromString(callData.(string))
 	if err != nil {
-		c.logger.Crit("could not decode genesis attestation request.", log.ErrKey, err)
+		return nil, err
 	}
 
 	// todo (#1275) - add the other fields
 	return &common.L1InitializeSecretTx{
 		Attestation: att,
-	}
+	}, nil
 }
 
-func (c *contractLibImpl) unpackRequestSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) *common.L1RequestSecretTx {
+func (c *contractLibImpl) unpackRequestSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) (*common.L1RequestSecretTx, error) {
 	err := method.Inputs.UnpackIntoMap(contractCallData, tx.Data()[methodBytesLen:])
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("could not unpack transaction. Cause: %w", err)
 	}
 	callData, found := contractCallData["requestReport"]
 	if !found {
-		panic("call data not found for requestReport")
+		return nil, fmt.Errorf("call data not found for requestReport")
 	}
 
-	att := Base64DecodeFromString(callData.(string))
+	att, err := Base64DecodeFromString(callData.(string))
 	if err != nil {
-		c.logger.Crit("could not decode attestation request.", log.ErrKey, err)
+		return nil, fmt.Errorf("could not decode attestation request. Cause: %w", err)
 	}
 	return &common.L1RequestSecretTx{
 		Attestation: att,
-	}
+	}, nil
 }
 
-func (c *contractLibImpl) unpackRespondSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) *common.L1RespondSecretTx {
+func (c *contractLibImpl) unpackRespondSecretTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) (*common.L1RespondSecretTx, error) {
 	err := method.Inputs.UnpackIntoMap(contractCallData, tx.Data()[methodBytesLen:])
 	if err != nil {
-		c.logger.Crit("could not unpack transaction.", log.ErrKey, err)
+		return nil, fmt.Errorf("could not unpack transaction. Cause: %w", err)
 	}
 
 	requesterData, found := contractCallData["requesterID"]
 	if !found {
-		c.logger.Crit("call data not found for requesterID")
+		return nil, fmt.Errorf("call data not found for requesterID")
 	}
 	requesterAddr, ok := requesterData.(gethcommon.Address)
 	if !ok {
-		c.logger.Crit("could not decode requester data")
+		return nil, fmt.Errorf("could not decode requester data")
 	}
 
 	attesterData, found := contractCallData["attesterID"]
 	if !found {
-		c.logger.Crit("call data not found for attesterID")
+		return nil, fmt.Errorf("call data not found for attesterID")
 	}
 	attesterAddr, ok := attesterData.(gethcommon.Address)
 	if !ok {
-		c.logger.Crit("could not decode attester data")
+		return nil, fmt.Errorf("could not decode attester data")
 	}
 
 	responseSecretData, found := contractCallData["responseSecret"]
 	if !found {
-		c.logger.Crit("call data not found for responseSecret")
+		return nil, fmt.Errorf("call data not found for responseSecret")
 	}
 	responseSecretBytes, ok := responseSecretData.([]uint8)
 	if !ok {
-		c.logger.Crit("could not decode responseSecret data")
+		return nil, fmt.Errorf("could not decode responseSecret data")
 	}
 
 	return &common.L1RespondSecretTx{
 		AttesterID:  attesterAddr,
 		RequesterID: requesterAddr,
 		Secret:      responseSecretBytes[:],
-	}
+	}, nil
 }
 
 func (c *contractLibImpl) unpackSetImportantContractsTx(tx *types.Transaction, method *abi.Method, contractCallData map[string]interface{}) (*common.L1SetImportantContractsTx, error) {
@@ -436,10 +436,6 @@ func base64EncodeToString(bytes []byte) string {
 }
 
 // Base64DecodeFromString decodes a string to a byte array
-func Base64DecodeFromString(in string) []byte {
-	bytesStr, err := base64.StdEncoding.DecodeString(in)
-	if err != nil {
-		panic(err)
-	}
-	return bytesStr
+func Base64DecodeFromString(in string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(in)
 }

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -284,7 +284,8 @@ func (r *DataService) processSequencerLogs(l types.Log, txData *common.L1TxData,
 // processManagementContractTx handles decoded transaction types
 func (r *DataService) processManagementContractTx(txData *common.L1TxData, processed *common.ProcessedL1Data) {
 	b := processed.BlockHeader
-	if decodedTx := r.mgmtContractLib.DecodeTx(txData.Transaction); decodedTx != nil {
+	decodedTx, _ := r.mgmtContractLib.DecodeTx(txData.Transaction)
+	if decodedTx != nil {
 		switch t := decodedTx.(type) {
 		case *common.L1InitializeSecretTx:
 			processed.AddEvent(common.InitialiseSecretTx, txData)

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -88,7 +88,7 @@ func (c *Client) EncryptedRPC(ctx context.Context, encryptedReq common.Encrypted
 		return nil, syserr.NewInternalError(fmt.Errorf("%s", response.SystemError.ErrorString))
 	}
 
-	return responses.ToEnclaveResponse(response.EncodedEnclaveResponse), nil
+	return responses.ToEnclaveResponse(response.EncodedEnclaveResponse)
 }
 
 func (c *Client) ExportCrossChainData(ctx context.Context, from uint64, to uint64) (*common.ExtCrossChainBundle, common.SystemError) {

--- a/go/responses/responses.go
+++ b/go/responses/responses.go
@@ -40,16 +40,6 @@ func (er *EnclaveResponse) Error() error {
 	return nil
 }
 
-// AsPlaintextResponse - creates the plaintext part of the enclave response
-// It would be visible that there is an enclave response,
-// but the bytes in it will still be encrypted
-// todo - rename
-func AsPlaintextResponse(encResp EncryptedUserResponse) *EnclaveResponse {
-	return &EnclaveResponse{
-		EncUserResponse: encResp,
-	}
-}
-
 // AsEmptyResponse - Creates an empty enclave response. Useful for when no error
 // encountered but also no result found.
 func AsEmptyResponse() *EnclaveResponse {
@@ -95,7 +85,9 @@ func AsEncryptedResponse[T any](data *T, encryptHandler Encryptor) *EnclaveRespo
 		return AsPlaintextError(err)
 	}
 
-	return AsPlaintextResponse(encrypted)
+	return &EnclaveResponse{
+		EncUserResponse: encrypted,
+	}
 }
 
 // AsEncryptedError - Encodes and encrypts an error to be returned for a concrete user.
@@ -114,17 +106,19 @@ func AsEncryptedError(err error, encrypt Encryptor) *EnclaveResponse {
 		return AsPlaintextError(err)
 	}
 
-	return AsPlaintextResponse(encrypted)
+	return &EnclaveResponse{
+		EncUserResponse: encrypted,
+	}
 }
 
 // ToEnclaveResponse - Converts an encoded plaintext into an enclave response
-func ToEnclaveResponse(encoded []byte) *EnclaveResponse {
+func ToEnclaveResponse(encoded []byte) (*EnclaveResponse, error) {
 	resp := EnclaveResponse{}
 	err := json.Unmarshal(encoded, &resp)
 	if err != nil {
-		panic(err) // Todo change when stable.
+		return nil, err
 	}
-	return &resp
+	return &resp, nil
 }
 
 // ToInternalError - Converts an error to an InternalError

--- a/integration/ethereummock/erc20_contract_lib.go
+++ b/integration/ethereummock/erc20_contract_lib.go
@@ -11,26 +11,26 @@ import (
 
 type contractLib struct{}
 
-func (c *contractLib) CreateDepositTx(tx *common.L1DepositTx) types.TxData {
-	return encodeTx(tx, depositTxAddr)
+func (c *contractLib) CreateDepositTx(tx *common.L1DepositTx) (types.TxData, error) {
+	return encodeTx(tx, depositTxAddr), nil
 }
 
 // DecodeTx returns only deposit transactions to the management contract
-func (c *contractLib) DecodeTx(tx *types.Transaction) common.L1TenTransaction {
+func (c *contractLib) DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error) {
 	if bytes.Equal(tx.To().Bytes(), depositTxAddr.Bytes()) {
 		depositTx, ok := decodeTx(tx).(*common.L1DepositTx)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 
 		// Mock deposits towards the L1 bridge target nil as the management contract address
 		// is not set.
 		if bytes.Equal(depositTx.To.Bytes(), gethcommon.BigToAddress(gethcommon.Big0).Bytes()) {
-			return depositTx
+			return depositTx, nil
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 // NewERC20ContractLibMock is an implementation of the erc20contractlib.ERC20ContractLib

--- a/integration/ethereummock/mgmt_contract_lib.go
+++ b/integration/ethereummock/mgmt_contract_lib.go
@@ -70,19 +70,19 @@ func (m *mockContractLib) GetContractAddr() *gethcommon.Address {
 	return &rollupTxAddr
 }
 
-func (m *mockContractLib) DecodeTx(tx *types.Transaction) common.L1TenTransaction {
+func (m *mockContractLib) DecodeTx(tx *types.Transaction) (common.L1TenTransaction, error) {
 	// Do not decode erc20 transactions, this is the responsibility
 	// of the erc20 contract lib.
 	if tx.To().Hex() == depositTxAddr.Hex() {
-		return nil
+		return nil, nil
 	}
 
 	if tx.To().Hex() == rollupTxAddr.Hex() {
 		return &common.L1RollupHashes{
 			BlobHashes: tx.BlobHashes(),
-		}
+		}, nil
 	}
-	return decodeTx(tx)
+	return decodeTx(tx), nil
 }
 
 // TODO: Ziga - fix this mock implementation later if needed
@@ -111,16 +111,16 @@ func (m *mockContractLib) PopulateAddRollup(t *common.L1RollupTx, blobs []*kzg48
 	}, nil
 }
 
-func (m *mockContractLib) CreateRequestSecret(tx *common.L1RequestSecretTx) types.TxData {
-	return encodeTx(tx, requestSecretTxAddr)
+func (m *mockContractLib) CreateRequestSecret(tx *common.L1RequestSecretTx) (types.TxData, error) {
+	return encodeTx(tx, requestSecretTxAddr), nil
 }
 
-func (m *mockContractLib) CreateRespondSecret(tx *common.L1RespondSecretTx, _ bool) types.TxData {
-	return encodeTx(tx, storeSecretTxAddr)
+func (m *mockContractLib) CreateRespondSecret(tx *common.L1RespondSecretTx, _ bool) (types.TxData, error) {
+	return encodeTx(tx, storeSecretTxAddr), nil
 }
 
-func (m *mockContractLib) CreateInitializeSecret(tx *common.L1InitializeSecretTx) types.TxData {
-	return encodeTx(tx, initializeSecretTxAddr)
+func (m *mockContractLib) CreateInitializeSecret(tx *common.L1InitializeSecretTx) (types.TxData, error) {
+	return encodeTx(tx, initializeSecretTxAddr), nil
 }
 
 func (m *mockContractLib) GetHostAddressesMsg() (ethereum.CallMsg, error) {

--- a/integration/ethereummock/mock_l1_network.go
+++ b/integration/ethereummock/mock_l1_network.go
@@ -85,9 +85,15 @@ func printBlock(b *types.Block, m *Node) string {
 	// This is just for printing
 	var txs []string
 	for _, tx := range b.Transactions() {
-		t := m.erc20ContractLib.DecodeTx(tx)
+		t, err := m.erc20ContractLib.DecodeTx(tx)
+		if err != nil {
+			panic(err)
+		}
 		if t == nil {
-			t = m.mgmtContractLib.DecodeTx(tx)
+			t, err = m.mgmtContractLib.DecodeTx(tx)
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		if t == nil {

--- a/integration/ethereummock/node.go
+++ b/integration/ethereummock/node.go
@@ -167,7 +167,11 @@ func (m *Node) Nonce(gethcommon.Address) (uint64, error) {
 
 func (m *Node) getRollupFromBlock(block *types.Block) *common.ExtRollup {
 	for _, tx := range block.Transactions() {
-		decodedTx := m.mgmtContractLib.DecodeTx(tx)
+		decodedTx, err := m.mgmtContractLib.DecodeTx(tx)
+		if err != nil {
+			m.logger.Warn(fmt.Sprintf("could not decode tx. Cause: %s", err))
+			continue
+		}
 		if decodedTx == nil {
 			continue
 		}

--- a/integration/simulation/output_stats.go
+++ b/integration/simulation/output_stats.go
@@ -91,9 +91,16 @@ func (o *OutputStats) countBlockChain() {
 
 func (o *OutputStats) incrementStats(block *types.Block, _ ethadapter.EthClient) {
 	for _, tx := range block.Transactions() {
-		t := o.simulation.Params.MgmtContractLib.DecodeTx(tx)
+		t, err := o.simulation.Params.MgmtContractLib.DecodeTx(tx)
+		if err != nil {
+			panic(err)
+		}
 		if t == nil {
-			t = o.simulation.Params.ERC20ContractLib.DecodeTx(tx)
+			var err error
+			t, err = o.simulation.Params.ERC20ContractLib.DecodeTx(tx)
+			if err != nil {
+				testlog.Logger().Crit("could not decode tx.", log.ErrKey, err)
+			}
 		}
 
 		if t == nil {

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -144,7 +144,10 @@ func (s *Simulation) waitForTenGenesisOnL1() {
 					panic(err)
 				}
 				for _, tx := range b.Transactions() {
-					t := s.Params.MgmtContractLib.DecodeTx(tx)
+					t, err := s.Params.MgmtContractLib.DecodeTx(tx)
+					if err != nil {
+						panic(err)
+					}
 					if t == nil {
 						continue
 					}
@@ -444,7 +447,10 @@ func (s *Simulation) prefundL1Accounts() {
 			TokenContract: s.Params.Wallets.Tokens[testcommon.HOC].L1ContractAddress,
 			Sender:        &ownerAddr,
 		}
-		tx := s.Params.ERC20ContractLib.CreateDepositTx(txData)
+		tx, err := s.Params.ERC20ContractLib.CreateDepositTx(txData)
+		if err != nil {
+			testlog.Logger().Crit("failed to create deposit tx", log.ErrKey, err)
+		}
 		estimatedTx, err := ethadapter.SetTxGasPrice(s.ctx, ethClient, tx, tokenOwner.Address(), tokenOwner.GetNonceAndIncrement(), 0)
 		if err != nil {
 			// ignore txs that are not able to be estimated/execute

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -334,7 +334,11 @@ func (ti *TransactionInjector) awaitAndFinalizeWithdrawal(tx *types.Transaction,
 
 	var proof clientapi.CrossChainProof
 	for {
-		proof, err = ti.rpcHandles.TenWalletRndClient(fromWallet).GetCrossChainProof(ti.ctx, "v", vTransfers.ForMerkleTree()[0][1].(gethcommon.Hash))
+		mtree, err := vTransfers.ForMerkleTree()
+		if err != nil {
+			panic(err)
+		}
+		proof, err = ti.rpcHandles.TenWalletRndClient(fromWallet).GetCrossChainProof(ti.ctx, "v", mtree[0][1].(gethcommon.Hash))
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				ti.logger.Info("Proof not found, retrying...", log.ErrKey, err)

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -264,9 +264,16 @@ func ExtractDataFromEthereumChain(startBlock *types.Header, endBlock *types.Head
 			panic(err)
 		}
 		for _, tx := range block.Transactions() {
-			t := s.Params.ERC20ContractLib.DecodeTx(tx)
+			t, err := s.Params.ERC20ContractLib.DecodeTx(tx)
+			if err != nil {
+				panic(err)
+			}
+
 			if t == nil {
-				t = s.Params.MgmtContractLib.DecodeTx(tx)
+				t, err = s.Params.MgmtContractLib.DecodeTx(tx)
+				if err != nil {
+					panic(err)
+				}
 			}
 
 			if t == nil {

--- a/integration/smartcontract/smartcontracts_test.go
+++ b/integration/smartcontract/smartcontracts_test.go
@@ -170,11 +170,14 @@ func nonAttestedNodesCannotCreateRollup(t *testing.T, mgmtContractLib *debugMgmt
 // secretCannotBeInitializedTwice issues the InitializeNetworkSecret twice, failing the second time
 func secretCannotBeInitializedTwice(t *testing.T, mgmtContractLib *debugMgmtContractLib, w *debugWallet, client ethadapter.EthClient) {
 	aggregatorID := datagenerator.RandomAddress()
-	txData := mgmtContractLib.CreateInitializeSecret(
+	txData, err := mgmtContractLib.CreateInitializeSecret(
 		&common.L1InitializeSecretTx{
 			EnclaveID: &aggregatorID,
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, receipt, err := w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
@@ -196,11 +199,14 @@ func secretCannotBeInitializedTwice(t *testing.T, mgmtContractLib *debugMgmtCont
 
 	// do the same again
 	aggregatorID = datagenerator.RandomAddress()
-	txData = mgmtContractLib.CreateInitializeSecret(
+	txData, err = mgmtContractLib.CreateInitializeSecret(
 		&common.L1InitializeSecretTx{
 			EnclaveID: &aggregatorID,
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, _, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err == nil || !assert.Contains(t, err.Error(), "execution reverted") {
@@ -256,11 +262,14 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 	aggAID := crypto.PubkeyToAddress(aggAPrivateKey.PublicKey)
 
 	// aggregator A starts the network secret
-	txData := mgmtContractLib.CreateInitializeSecret(
+	txData, err := mgmtContractLib.CreateInitializeSecret(
 		&common.L1InitializeSecretTx{
 			EnclaveID: &aggAID,
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, receipt, err := w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
@@ -277,11 +286,14 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 	}
 	aggBID := crypto.PubkeyToAddress(aggBPrivateKey.PublicKey)
 
-	txData = mgmtContractLib.CreateRequestSecret(
+	txData, err = mgmtContractLib.CreateRequestSecret(
 		&common.L1RequestSecretTx{
 			Attestation: datagenerator.RandomBytes(10),
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, receipt, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
@@ -300,7 +312,7 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 
 	fakeSecret := []byte{123}
 
-	txData = mgmtContractLib.CreateRespondSecret(
+	txData, err = mgmtContractLib.CreateRespondSecret(
 		Sign(&common.L1RespondSecretTx{
 			Secret:      fakeSecret,
 			RequesterID: aggBID,
@@ -308,6 +320,9 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 		}, aggCPrivateKey),
 		true,
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, _, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err == nil || !assert.Contains(t, err.Error(), "execution reverted") {
@@ -315,7 +330,7 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 	}
 
 	// agg c responds to the secret AGAIN, but trying to mimick aggregator A
-	txData = mgmtContractLib.CreateRespondSecret(
+	txData, err = mgmtContractLib.CreateRespondSecret(
 		Sign(&common.L1RespondSecretTx{
 			Secret:      fakeSecret,
 			RequesterID: aggBID,
@@ -323,6 +338,9 @@ func nonAttestedNodesCannotAttest(t *testing.T, mgmtContractLib *debugMgmtContra
 		}, aggCPrivateKey),
 		true,
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, _, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err == nil || !assert.Contains(t, err.Error(), "execution reverted") {
@@ -341,12 +359,15 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 	aggAID := crypto.PubkeyToAddress(aggAPrivateKey.PublicKey)
 
 	// the aggregator starts the network
-	txData := mgmtContractLib.CreateInitializeSecret(
+	txData, err := mgmtContractLib.CreateInitializeSecret(
 		&common.L1InitializeSecretTx{
 			EnclaveID:     &aggAID,
 			InitialSecret: secretBytes,
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, receipt, err := w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
@@ -370,11 +391,15 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 	}
 	aggBID := crypto.PubkeyToAddress(aggBPrivateKey.PublicKey)
 
-	txData = mgmtContractLib.CreateRequestSecret(
+	txData, err = mgmtContractLib.CreateRequestSecret(
 		&common.L1RequestSecretTx{
 			Attestation: datagenerator.RandomBytes(10),
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
+
 	_, receipt, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
 		t.Error(err)
@@ -390,11 +415,14 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 	}
 	aggCID := crypto.PubkeyToAddress(aggCPrivateKey.PublicKey)
 
-	txData = mgmtContractLib.CreateRequestSecret(
+	txData, err = mgmtContractLib.CreateRequestSecret(
 		&common.L1RequestSecretTx{
 			Attestation: datagenerator.RandomBytes(10),
 		},
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	_, receipt, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
@@ -405,7 +433,7 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 	}
 
 	// Agg A responds to Agg C request
-	txData = mgmtContractLib.CreateRespondSecret(
+	txData, err = mgmtContractLib.CreateRespondSecret(
 		Sign(&common.L1RespondSecretTx{
 			Secret:      secretBytes,
 			RequesterID: aggCID,
@@ -413,6 +441,10 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 		}, aggAPrivateKey),
 		true,
 	)
+	if err != nil {
+		t.Error(err)
+	}
+
 	_, receipt, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
 		t.Error(err)
@@ -432,7 +464,7 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 	}
 
 	// agg C attests agg B
-	txData = mgmtContractLib.CreateRespondSecret(
+	txData, err = mgmtContractLib.CreateRespondSecret(
 		Sign(&common.L1RespondSecretTx{
 			Secret:      secretBytes,
 			RequesterID: aggBID,
@@ -440,6 +472,10 @@ func newlyAttestedNodesCanAttest(t *testing.T, mgmtContractLib *debugMgmtContrac
 		}, aggCPrivateKey),
 		true,
 	)
+	if err != nil {
+		t.Error(err)
+	}
+
 	_, receipt, err = w.AwaitedSignAndSendTransaction(client, txData)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
### Why this change is needed

We were panicking in some improbable scenarios. Mostly leftovers from the early days when we didn't handle errors.

### What changes were made as part of this PR

Return errors instead of panic.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


