### PR TITLE
Host: shortcut the next canonical block lookup

### DIFF
--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -159,13 +159,23 @@ func (r *DataService) latestCanonAncestor(remote gethcommon.Hash) (*common.Chain
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch L1 block with hash=%s - %w", remote, err)
 	}
-
 	currentHead, err := r.FetchBlock(ctx, r.head)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch current L1 head- %w", err)
+		return nil, fmt.Errorf("unable to fetch L1 block with hash=%s - %w", r.head, err)
 	}
 
-	fork, err := gethutil.LCA(ctx, currentHead, remoteHead, r)
+	searchBackFrom := currentHead
+	// if remote head is more than 5 blocks behind chain head, we find LCA with block at remote head height
+	// otherwise we find LCA with block at chain head height
+	// (this keeps things performant for catchup but avoids edgecases around small forks)
+	if big.NewInt(0).Sub(currentHead.Number, remoteHead.Number).Cmp(big.NewInt(5)) > 0 {
+		searchBackFrom, err = r.FetchBlockByHeight(remoteHead.Number)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch L1 block with height=%s - %w", remoteHead.Number, err)
+		}
+	}
+
+	fork, err := gethutil.LCA(ctx, searchBackFrom, remoteHead, r)
 	if err != nil {
 		return nil, fmt.Errorf("unable to calculate LCA - %w", err)
 	}

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -162,7 +162,7 @@ func (r *DataService) latestCanonAncestor(remote gethcommon.Hash) (*common.Chain
 
 	searchBackFrom, err := r.FetchBlockByHeight(remoteHead.Number)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch L1 block by height=%s - %w", remoteHead)
+		return nil, fmt.Errorf("unable to fetch L1 block by height=%s - %w", remoteHead.Number, err)
 	}
 
 	fork, err := gethutil.LCA(ctx, searchBackFrom, remoteHead, r)

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -159,20 +159,10 @@ func (r *DataService) latestCanonAncestor(remote gethcommon.Hash) (*common.Chain
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch L1 block with hash=%s - %w", remote, err)
 	}
-	currentHead, err := r.FetchBlock(ctx, r.head)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch L1 block with hash=%s - %w", r.head, err)
-	}
 
-	searchBackFrom := currentHead
-	// if remote head is more than 5 blocks behind chain head, we find LCA with block at remote head height
-	// otherwise we find LCA with block at chain head height
-	// (this keeps things performant for catchup but avoids edgecases around small forks)
-	if big.NewInt(0).Sub(currentHead.Number, remoteHead.Number).Cmp(big.NewInt(5)) > 0 {
-		searchBackFrom, err = r.FetchBlockByHeight(remoteHead.Number)
-		if err != nil {
-			return nil, fmt.Errorf("unable to fetch L1 block with height=%s - %w", remoteHead.Number, err)
-		}
+	searchBackFrom, err := r.FetchBlockByHeight(remoteHead.Number)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch L1 block by height=%s - %w", remoteHead)
 	}
 
 	fork, err := gethutil.LCA(ctx, searchBackFrom, remoteHead, r)


### PR DESCRIPTION
### Why this change is needed

We've got a bug when a new node has to do a long L1 catch-up where it's taking minutes searching backwards to find the next block to feed.

### What changes were made as part of this PR

Compare with the canonical block at the remote head height, don't need to build full fork path to head.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


