### PR TITLE
Tests: fix rpc urls to match testnet gateways

### DIFF
--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -25,8 +25,8 @@ func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		[]string{"http://erpc.sepolia-testnet.ten.xyz:80"},
 		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"https://rpc.sepolia.org/",
-		"https://testnet.ten.xyz",
-		"wss://testnet.ten.xyz:81",
+		"https://rpc.testnet.ten.xyz",
+		"wss://rpc.testnet.ten.xyz:81",
 	)
 	return newTestnetEnv(connector, opts...)
 }
@@ -37,8 +37,8 @@ func UATTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		[]string{"http://erpc.uat-testnet.ten.xyz:80"},
 		"http://uat-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://uat-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
-		"https://uat-testnet.ten.xyz",
-		"wss://uat-testnet.ten.xyz:81",
+		"https://rpc.uat-testnet.ten.xyz",
+		"wss://rpc.uat-testnet.ten.xyz:81",
 	)
 	return newTestnetEnv(connector, opts...)
 }
@@ -49,8 +49,8 @@ func DevTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		[]string{"http://erpc.dev-testnet.ten.xyz:80"},
 		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
-		"https://dev-testnet.ten.xyz",
-		"wss://dev-testnet.ten.xyz:81",
+		"https://rpc.dev-testnet.ten.xyz",
+		"wss://rpc.dev-testnet.ten.xyz:81",
 	)
 	return newTestnetEnv(connector, opts...)
 }

--- a/integration/networktest/tests/gateway/gateway_test.go
+++ b/integration/networktest/tests/gateway/gateway_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ten-protocol/go-ten/integration/networktest/actions"
 	"github.com/ten-protocol/go-ten/integration/networktest/env"
 	"github.com/ten-protocol/go-ten/integration/networktest/userwallet"
-	"github.com/ten-protocol/go-ten/integration/simulation/devnetwork"
 )
 
 var _transferAmount = big.NewInt(100_000_000)
@@ -27,7 +26,7 @@ func TestGatewayHappyPath(t *testing.T) {
 	networktest.Run(
 		"gateway-happy-path",
 		t,
-		env.LocalDevNetwork(devnetwork.WithGateway()),
+		env.UATTestnet(),
 		actions.Series(
 			&actions.CreateTestUser{UserID: 0, UseGateway: true},
 			&actions.CreateTestUser{UserID: 1, UseGateway: true},


### PR DESCRIPTION
### Why this change is needed

Network tests failing against testnet gateways because URLs are wrong

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


