### PR TITLE
Update dev container to match new required go version.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
 	"features": {
 		"ghcr.io/dhoeric/features/act:1": {},
 		"ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/install-deps.sh
+++ b/.devcontainer/install-deps.sh
@@ -1,3 +1,11 @@
+#!/bin/bash
+
+# Download and install Go 1.22.11
+curl -OL https://go.dev/dl/go1.22.11.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.22.11.linux-amd64.tar.gz
+rm go1.22.11.linux-amd64.tar.gz
+
 go install github.com/ethereum/go-ethereum/cmd/abigen@v1.13.15;
 nvm install 18;
 cd contracts;


### PR DESCRIPTION
### Why this change is needed

As we updated ego and raised the go version, the dev container became stale at 1.21

### What changes were made as part of this PR

Upped the version; However the official one is 1.22.10 in the dev container docker image, thus added a manual part that downloads 1.22.11 (claude did it, seems to work, hurray) 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


