### PR TITLE
flakyness fix

### DIFF
--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -414,7 +414,7 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 	if calldataRollupHeader.FirstBatchSequence.Uint64() != common.L2GenesisSeqNo {
 		_, err := rc.storage.FetchBatchHeader(ctx, parentHash)
 		if err != nil {
-			rc.logger.Error("Could not find batch mentioned in the rollup. This should not happen.", log.ErrKey, err)
+			rc.logger.Error("Rollup cannot be processed because the parent of the first canonical batch is missing.", log.ErrKey, err)
 			return ErrReorgedRollup
 		}
 	}

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ten-protocol/go-ten/go/enclave/storage"
 )
 
+var ErrReorgedRollup = errors.New("reorged rollup")
+
 /*
 RollupCompression - responsible for the compression logic
 
@@ -413,7 +415,7 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 		_, err := rc.storage.FetchBatchHeader(ctx, parentHash)
 		if err != nil {
 			rc.logger.Error("Could not find batch mentioned in the rollup. This should not happen.", log.ErrKey, err)
-			return err
+			return ErrReorgedRollup
 		}
 	}
 

--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -683,9 +683,19 @@ func (g *Guardian) periodicRollupProduction() {
 					g.logger.Error("Unable to create rollup", log.BatchSeqNoKey, fromBatch, log.ErrKey, err)
 					continue
 				}
-				// this method waits until the receipt is received
-				g.sl.L1Publisher().PublishBlob(producedRollup, blobs)
-				lastSuccessfulRollup = time.Now()
+				canonBlock, err := g.sl.L1Data().FetchBlockByHeight(producedRollup.Header.CompressionL1Number)
+				if err != nil {
+					g.logger.Error("Could not fetch block for compression", log.ErrKey, err)
+					continue
+				}
+				// only publish if the block used for compression is canonical
+				if canonBlock.Hash() == producedRollup.Header.CompressionL1Head {
+					// this method waits until the receipt is received
+					g.sl.L1Publisher().PublishBlob(producedRollup, blobs)
+					lastSuccessfulRollup = time.Now()
+				} else {
+					g.logger.Info("Skipping rollup publication because compression block is not canonical", "block", canonBlock.Hash())
+				}
 			}
 
 		case <-g.hostInterrupter.Done():

--- a/integration/simulation/simulation_in_mem_test.go
+++ b/integration/simulation/simulation_in_mem_test.go
@@ -35,7 +35,7 @@ func TestInMemoryMonteCarloSimulation(t *testing.T) {
 		IsInMem:                    true,
 		L1TenData:                  &params.L1TenData{},
 		ReceiptTimeout:             6 * time.Second,
-		StoppingDelay:              8 * time.Second,
+		StoppingDelay:              10 * time.Second,
 		NodeWithInboundP2PDisabled: 2,
 		L1BeaconPort:               integration.TestPorts.TestInMemoryMonteCarloSimulationPort + integration.DefaultPrysmGatewayPortOffset,
 	}


### PR DESCRIPTION
### Why this change is needed

Flakyness fixes

### What changes were made as part of this PR

- in the sim, wait for the nodes to be ready using polling
- only publish a rollup if the compression block has not been reorged

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


