### PR TITLE
Host: fix failing p2p check for sequencers

### DIFF
--- a/go/host/p2p/p2p.go
+++ b/go/host/p2p/p2p.go
@@ -269,7 +269,8 @@ func (p *Service) RegisterForBroadcasts() error {
 // if there's more than 100 failures on a given fail type
 // if there's a known peer for which a message hasn't been received
 func (p *Service) verifyHealth() error {
-	if p.isIncomingP2PDisabled {
+	if p.isIncomingP2PDisabled || p.isSequencer {
+		// sequencer is not expected to periodically receive p2p messages so this health check is ignored
 		return nil
 	}
 	var noMsgReceivedPeers []string


### PR DESCRIPTION
### Why this change is needed

Health check fails for health sequencers in all environments, because the p2p health check is failing unnecessarily. Sequencers don't receive batches so have no expected p2p traffic currently.

```
> curl http://obscuronode-0-uat-testnet.uksouth.cloudapp.azure.com:80  -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"ten_health","params":[],"id":1}'

{"jsonrpc":"2.0","id":1,"result":{"OverallHealth":false,"Errors":["[p2p] not healthy - no message received from peers"],"Enclaves":[{"StatusCode":0,"L1Head":"0x5a86a913366b01ea9304b5b38a9d155ea1c7e1d2cdf946da509ee4e1765395c8","L2Head":370086,"EnclaveID":"0x09abfd84a5a0fbbed92d8933293c0621a91dadd5"},{"StatusCode":0,"L1Head":"0x5a86a913366b01ea9304b5b38a9d155ea1c7e1d2cdf946da509ee4e1765395c8","L2Head":370086,"EnclaveID":"0xfa14ffad8557253a245a7e28cb696e7bf1455ce6"}]}}
```

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


