### PR TITLE
Fix duplicate key error on host batch insertion

### DIFF
--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -37,7 +37,7 @@ func AddBatch(dbtx *dbTransaction, statements *SQLStatements, batch *common.ExtB
 		extBatch,                     // ext_batch
 	)
 	if err != nil {
-		if IsUniqueKeyConstraintError(err) {
+		if RowExistsError(err) {
 			return errutil.ErrAlreadyExists
 		}
 		return fmt.Errorf("host failed to insert batch: %w", err)
@@ -498,6 +498,6 @@ func fetchBatchTxs(db *sql.DB, whereQuery string, batchHash []byte) (*common.Tra
 	}, nil
 }
 
-func IsUniqueKeyConstraintError(err error) bool {
+func RowExistsError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key")
 }

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -37,7 +37,7 @@ func AddBatch(dbtx *dbTransaction, statements *SQLStatements, batch *common.ExtB
 		extBatch,                     // ext_batch
 	)
 	if err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key") {
+		if IsUniqueKeyConstraintError(err) {
 			return errutil.ErrAlreadyExists
 		}
 		return fmt.Errorf("host failed to insert batch: %w", err)
@@ -496,4 +496,8 @@ func fetchBatchTxs(db *sql.DB, whereQuery string, batchHash []byte) (*common.Tra
 		TransactionsData: transactions,
 		Total:            uint64(len(transactions)),
 	}, nil
+}
+
+func IsUniqueKeyConstraintError(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key")
 }

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -37,7 +37,7 @@ func AddBatch(dbtx *dbTransaction, statements *SQLStatements, batch *common.ExtB
 		extBatch,                     // ext_batch
 	)
 	if err != nil {
-		if RowExistsError(err) {
+		if IsRowExistsError(err) {
 			return errutil.ErrAlreadyExists
 		}
 		return fmt.Errorf("host failed to insert batch: %w", err)
@@ -498,6 +498,6 @@ func fetchBatchTxs(db *sql.DB, whereQuery string, batchHash []byte) (*common.Tra
 	}, nil
 }
 
-func RowExistsError(err error) bool {
+func IsRowExistsError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key")
 }

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -37,7 +37,7 @@ func AddBatch(dbtx *dbTransaction, statements *SQLStatements, batch *common.ExtB
 		extBatch,                     // ext_batch
 	)
 	if err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "unique") {
+		if strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key") {
 			return errutil.ErrAlreadyExists
 		}
 		return fmt.Errorf("host failed to insert batch: %w", err)

--- a/go/host/storage/hostdb/batch_test.go
+++ b/go/host/storage/hostdb/batch_test.go
@@ -2,12 +2,13 @@ package hostdb
 
 import (
 	"errors"
+	"math/big"
+	"testing"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/ten-protocol/go-ten/go/common/errutil"
-	"math/big"
-	"testing"
 
 	"github.com/ten-protocol/go-ten/go/common"
 )

--- a/go/host/storage/hostdb/batch_test.go
+++ b/go/host/storage/hostdb/batch_test.go
@@ -2,14 +2,12 @@ package hostdb
 
 import (
 	"errors"
-	"math/big"
-	"testing"
-	"time"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/ten-protocol/go-ten/go/common/errutil"
+	"math/big"
+	"testing"
 
 	"github.com/ten-protocol/go-ten/go/common"
 )
@@ -17,8 +15,8 @@ import (
 // An arbitrary number to put in the header, to check that the header is retrieved correctly from the DB.
 
 func TestCanStoreAndRetrieveBatchHeader(t *testing.T) {
-	db, _ := createSQLiteDB(t)
-	batch := createBatch(batchNumber, []common.L2TxHash{})
+	db, _ := CreateSQLiteDB(t)
+	batch := CreateBatch(batchNumber, []common.L2TxHash{})
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batch)
 	if err != nil {
@@ -35,7 +33,7 @@ func TestCanStoreAndRetrieveBatchHeader(t *testing.T) {
 }
 
 func TestUnknownBatchHeaderReturnsNotFound(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	header := types.Header{}
 
 	_, err := GetBatchHeader(db, header.Hash())
@@ -45,15 +43,15 @@ func TestUnknownBatchHeaderReturnsNotFound(t *testing.T) {
 }
 
 func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
-	db, _ := createSQLiteDB(t)
-	batchOne := createBatch(batchNumber, []common.L2TxHash{})
+	db, _ := CreateSQLiteDB(t)
+	batchOne := CreateBatch(batchNumber, []common.L2TxHash{})
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
 		t.Errorf("could not store batch. Cause: %s", err)
 	}
 
-	batchTwo := createBatch(batchNumber+1, []common.L2TxHash{})
+	batchTwo := CreateBatch(batchNumber+1, []common.L2TxHash{})
 	if err != nil {
 		t.Errorf("could not create batch. Cause: %s", err)
 	}
@@ -75,15 +73,15 @@ func TestHigherNumberBatchBecomesBatchHeader(t *testing.T) { //nolint:dupl
 }
 
 func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	dbtx, _ := db.NewDBTransaction()
-	batchOne := createBatch(batchNumber, []common.L2TxHash{})
+	batchOne := CreateBatch(batchNumber, []common.L2TxHash{})
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
 		t.Errorf("could not store batch. Cause: %s", err)
 	}
 
-	batchTwo := createBatch(batchNumber-1, []common.L2TxHash{})
+	batchTwo := CreateBatch(batchNumber-1, []common.L2TxHash{})
 	if err != nil {
 		t.Errorf("could not create batch. Cause: %s", err)
 	}
@@ -104,7 +102,7 @@ func TestLowerNumberBatchDoesNotBecomeBatchHeader(t *testing.T) { //nolint:dupl
 }
 
 func TestHeadBatchHeaderIsNotSetInitially(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	_, err := GetHeadBatchHeader(db)
 	if !errors.Is(err, errutil.ErrNotFound) {
 		t.Errorf("head batch was set, but no batchs had been written")
@@ -112,8 +110,8 @@ func TestHeadBatchHeaderIsNotSetInitially(t *testing.T) {
 }
 
 func TestCanRetrieveBatchHashByNumber(t *testing.T) {
-	db, _ := createSQLiteDB(t)
-	batch := createBatch(batchNumber, []common.L2TxHash{})
+	db, _ := CreateSQLiteDB(t)
+	batch := CreateBatch(batchNumber, []common.L2TxHash{})
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batch)
 	if err != nil {
@@ -131,7 +129,7 @@ func TestCanRetrieveBatchHashByNumber(t *testing.T) {
 }
 
 func TestUnknownBatchNumberReturnsNotFound(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	header := types.Header{Number: big.NewInt(10)}
 
 	_, err := GetBatchHashByNumber(db, header.Number)
@@ -141,9 +139,9 @@ func TestUnknownBatchNumberReturnsNotFound(t *testing.T) {
 }
 
 func TestCanRetrieveBatchNumberByTxHash(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHash := gethcommon.BytesToHash([]byte("magicString"))
-	batch := createBatch(batchNumber, []common.L2TxHash{txHash})
+	batch := CreateBatch(batchNumber, []common.L2TxHash{txHash})
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batch)
 	if err != nil {
@@ -168,7 +166,7 @@ func TestCanRetrieveBatchNumberByTxHash(t *testing.T) {
 }
 
 func TestUnknownBatchTxHashReturnsNotFound(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 
 	_, err := GetBatchNumber(db, gethcommon.BytesToHash([]byte("magicString")))
 	if !errors.Is(err, errutil.ErrNotFound) {
@@ -177,9 +175,9 @@ func TestUnknownBatchTxHashReturnsNotFound(t *testing.T) {
 }
 
 func TestCanRetrieveBatchTransactions(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashes := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batch := createBatch(batchNumber, txHashes)
+	batch := CreateBatch(batchNumber, txHashes)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batch)
 	if err != nil {
@@ -202,7 +200,7 @@ func TestCanRetrieveBatchTransactions(t *testing.T) {
 }
 
 func TestTransactionsForUnknownBatchReturnsNotFound(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 
 	_, err := GetBatchNumber(db, gethcommon.BytesToHash([]byte("magicString")))
 	if !errors.Is(err, errutil.ErrNotFound) {
@@ -211,9 +209,9 @@ func TestTransactionsForUnknownBatchReturnsNotFound(t *testing.T) {
 }
 
 func TestGetLatestBatch(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -221,7 +219,7 @@ func TestGetLatestBatch(t *testing.T) {
 	}
 
 	txHashesTwo := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -240,9 +238,9 @@ func TestGetLatestBatch(t *testing.T) {
 }
 
 func TestGetBatchByHeight(t *testing.T) {
-	db, _ := createSQLiteDB(t)
-	batch1 := createBatch(batchNumber, []common.L2TxHash{})
-	batch2 := createBatch(batchNumber+5, []common.L2TxHash{})
+	db, _ := CreateSQLiteDB(t)
+	batch1 := CreateBatch(batchNumber, []common.L2TxHash{})
+	batch2 := CreateBatch(batchNumber+5, []common.L2TxHash{})
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batch1)
 	if err != nil {
@@ -263,9 +261,9 @@ func TestGetBatchByHeight(t *testing.T) {
 }
 
 func TestGetBatchListing(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -273,7 +271,7 @@ func TestGetBatchListing(t *testing.T) {
 	}
 
 	txHashesTwo := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -281,7 +279,7 @@ func TestGetBatchListing(t *testing.T) {
 	}
 
 	txHashesThree := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringFive")), gethcommon.BytesToHash([]byte("magicStringSix"))}
-	batchThree := createBatch(batchNumber+2, txHashesThree)
+	batchThree := CreateBatch(batchNumber+2, txHashesThree)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchThree)
 	if err != nil {
@@ -329,9 +327,9 @@ func TestGetBatchListing(t *testing.T) {
 }
 
 func TestGetBatchListingDeprecated(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -339,7 +337,7 @@ func TestGetBatchListingDeprecated(t *testing.T) {
 	}
 
 	txHashesTwo := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -347,7 +345,7 @@ func TestGetBatchListingDeprecated(t *testing.T) {
 	}
 
 	txHashesThree := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringFive")), gethcommon.BytesToHash([]byte("magicStringSix"))}
-	batchThree := createBatch(batchNumber+2, txHashesThree)
+	batchThree := CreateBatch(batchNumber+2, txHashesThree)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchThree)
 	if err != nil {
@@ -411,9 +409,9 @@ func TestGetBatchListingDeprecated(t *testing.T) {
 }
 
 func TestGetBatchTransactions(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -421,7 +419,7 @@ func TestGetBatchTransactions(t *testing.T) {
 	}
 
 	txHashesTwo := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour")), gethcommon.BytesToHash([]byte("magicStringFive"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -445,18 +443,4 @@ func TestGetBatchTransactions(t *testing.T) {
 	if txListing2.Total != uint64(len(txHashesTwo)) {
 		t.Errorf("batch transactions were not retrieved correctly")
 	}
-}
-
-func createBatch(batchNum int64, txHashes []common.L2BatchHash) common.ExtBatch {
-	header := common.BatchHeader{
-		SequencerOrderNo: big.NewInt(batchNum),
-		Number:           big.NewInt(batchNum),
-		Time:             uint64(time.Now().Unix()),
-	}
-	batch := common.ExtBatch{
-		Header:   &header,
-		TxHashes: txHashes,
-	}
-
-	return batch
 }

--- a/go/host/storage/hostdb/block_test.go
+++ b/go/host/storage/hostdb/block_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCanStoreAndRetrieveBlock(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	block1 := createBlock(batchNumber)
 	block2 := createBlock(batchNumber + 1)
 
@@ -62,7 +62,7 @@ func TestCanStoreAndRetrieveBlock(t *testing.T) {
 }
 
 func TestAddBlockWithForeignKeyConstraint(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	dbtx, _ := db.NewDBTransaction()
 	statements := db.GetSQLStatement()
 	metadata := createRollupMetadata(batchNumber - 10)

--- a/go/host/storage/hostdb/rollup_test.go
+++ b/go/host/storage/hostdb/rollup_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCanStoreAndRetrieveRollup(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -53,7 +53,7 @@ func TestCanStoreAndRetrieveRollup(t *testing.T) {
 }
 
 func TestGetRollupByBlockHash(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -83,7 +83,7 @@ func TestGetRollupByBlockHash(t *testing.T) {
 }
 
 func TestGetLatestRollup(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -128,7 +128,7 @@ func TestGetLatestRollup(t *testing.T) {
 }
 
 func TestGetRollupBySeqNo(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -183,7 +183,7 @@ func TestGetRollupBySeqNo(t *testing.T) {
 }
 
 func TestGetRollupListing(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -286,7 +286,7 @@ func TestGetRollupListing(t *testing.T) {
 }
 
 func TestGetRollupByHash(t *testing.T) {
-	db, err := createSQLiteDB(t)
+	db, err := CreateSQLiteDB(t)
 	if err != nil {
 		t.Fatalf("unable to initialise test db: %s", err)
 	}
@@ -333,9 +333,9 @@ func TestGetRollupByHash(t *testing.T) {
 }
 
 func TestGetRollupBatches(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	block := types.NewBlock(&types.Header{}, nil, nil, nil)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBlock(dbtx.Tx, db.GetSQLStatement(), block.Header())
@@ -350,7 +350,7 @@ func TestGetRollupBatches(t *testing.T) {
 	}
 
 	txHashesTwo := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -358,7 +358,7 @@ func TestGetRollupBatches(t *testing.T) {
 	}
 
 	txHashesThree := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringFive")), gethcommon.BytesToHash([]byte("magicStringSix"))}
-	batchThree := createBatch(batchNumber+2, txHashesThree)
+	batchThree := CreateBatch(batchNumber+2, txHashesThree)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchThree)
 	if err != nil {
@@ -366,7 +366,7 @@ func TestGetRollupBatches(t *testing.T) {
 	}
 
 	txHashesFour := []gethcommon.Hash{gethcommon.BytesToHash([]byte("magicStringSeven")), gethcommon.BytesToHash([]byte("magicStringEight"))}
-	batchFour := createBatch(batchNumber+3, txHashesFour)
+	batchFour := CreateBatch(batchNumber+3, txHashesFour)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchFour)
 	if err != nil {

--- a/go/host/storage/hostdb/transaction_test.go
+++ b/go/host/storage/hostdb/transaction_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestGetTransactionListing(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHash12 := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHash12)
+	batchOne := CreateBatch(batchNumber, txHash12)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -20,7 +20,7 @@ func TestGetTransactionListing(t *testing.T) {
 	}
 
 	txHash34 := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHash34)
+	batchTwo := CreateBatch(batchNumber+1, txHash34)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -28,7 +28,7 @@ func TestGetTransactionListing(t *testing.T) {
 	}
 
 	txHash56 := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringFive")), gethcommon.BytesToHash([]byte("magicStringSix"))}
-	batchThree := createBatch(batchNumber+2, txHash56)
+	batchThree := CreateBatch(batchNumber+2, txHash56)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchThree)
 	if err != nil {
@@ -86,11 +86,11 @@ func TestGetTransactionListing(t *testing.T) {
 }
 
 func TestGetTransaction(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHash1 := gethcommon.BytesToHash([]byte("magicStringOne"))
 	txHash2 := gethcommon.BytesToHash([]byte("magicStringOne"))
 	txHashes := []common.L2TxHash{txHash1, txHash2}
-	batchOne := createBatch(batchNumber, txHashes)
+	batchOne := CreateBatch(batchNumber, txHashes)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -112,9 +112,9 @@ func TestGetTransaction(t *testing.T) {
 }
 
 func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}
-	batchOne := createBatch(batchNumber, txHashesOne)
+	batchOne := CreateBatch(batchNumber, txHashesOne)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {
@@ -122,7 +122,7 @@ func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
 	}
 
 	txHashesTwo := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringThree")), gethcommon.BytesToHash([]byte("magicStringFour"))}
-	batchTwo := createBatch(batchNumber+1, txHashesTwo)
+	batchTwo := CreateBatch(batchNumber+1, txHashesTwo)
 
 	err = AddBatch(dbtx, db.GetSQLStatement(), &batchTwo)
 	if err != nil {
@@ -141,13 +141,13 @@ func TestCanRetrieveTotalNumberOfTransactions(t *testing.T) {
 }
 
 func TestTotalTxsQuery(t *testing.T) {
-	db, _ := createSQLiteDB(t)
+	db, _ := CreateSQLiteDB(t)
 	var txHashes []common.L2TxHash
 	for i := 0; i < 100; i++ {
 		txHash := gethcommon.BytesToHash([]byte(fmt.Sprintf("magicString%d", i+1)))
 		txHashes = append(txHashes, txHash)
 	}
-	batchOne := createBatch(batchNumber, txHashes)
+	batchOne := CreateBatch(batchNumber, txHashes)
 	dbtx, _ := db.NewDBTransaction()
 	err := AddBatch(dbtx, db.GetSQLStatement(), &batchOne)
 	if err != nil {

--- a/go/host/storage/hostdb/utils.go
+++ b/go/host/storage/hostdb/utils.go
@@ -3,10 +3,11 @@ package hostdb
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/ten-protocol/go-ten/go/common"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ten-protocol/go-ten/go/common"
 
 	"github.com/ten-protocol/go-ten/go/host/storage/init/sqlite"
 )

--- a/go/host/storage/hostdb/utils.go
+++ b/go/host/storage/hostdb/utils.go
@@ -3,7 +3,10 @@ package hostdb
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/ten-protocol/go-ten/go/common"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ten-protocol/go-ten/go/host/storage/init/sqlite"
 )
@@ -11,12 +14,26 @@ import (
 // An arbitrary number to put in the header
 const batchNumber = 777
 
-func createSQLiteDB(t *testing.T) (HostDB, error) {
+func CreateSQLiteDB(t *testing.T) (HostDB, error) {
 	hostDB, err := sqlite.CreateTemporarySQLiteHostDB("", "mode=memory")
 	if err != nil {
 		t.Fatalf("unable to create temp sql db: %s", err)
 	}
 	return NewHostDB(hostDB, SQLiteSQLStatements())
+}
+
+func CreateBatch(batchNum int64, txHashes []common.L2BatchHash) common.ExtBatch {
+	header := common.BatchHeader{
+		SequencerOrderNo: big.NewInt(batchNum),
+		Number:           big.NewInt(batchNum),
+		Time:             uint64(time.Now().Unix()),
+	}
+	batch := common.ExtBatch{
+		Header:   &header,
+		TxHashes: txHashes,
+	}
+
+	return batch
 }
 
 func bytesToHexString(bytes []byte) string {

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -48,7 +48,7 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 	}
 
 	if err := dbtx.Write(); err != nil {
-		if hostdb.IsUniqueKeyConstraintError(err) {
+		if hostdb.RowExistsError(err) {
 			return nil
 		}
 		return fmt.Errorf("could not commit batch tx. Cause: %w", err)

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -26,10 +26,10 @@ type storageImpl struct {
 }
 
 func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
-	// Check if the Batch is already stored
 	_, err := hostdb.GetBatchHeader(s.db, batch.Hash())
 	if err == nil {
-		return errutil.ErrAlreadyExists
+		// batch already exists don't error
+		return nil
 	}
 
 	dbtx, err := s.db.NewDBTransaction()

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -48,7 +48,7 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 	}
 
 	if err := dbtx.Write(); err != nil {
-		if errors.Is(err, errutil.ErrAlreadyExists) {
+		if hostdb.IsUniqueKeyConstraintError(err) {
 			return nil
 		}
 		return fmt.Errorf("could not commit batch tx. Cause: %w", err)

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -42,12 +42,15 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 			return err1
 		}
 		if errors.Is(err, errutil.ErrAlreadyExists) {
-			return err
+			return nil
 		}
 		return fmt.Errorf("could not add batch to host. Cause: %w", err)
 	}
 
 	if err := dbtx.Write(); err != nil {
+		if errors.Is(err, errutil.ErrAlreadyExists) {
+			return nil
+		}
 		return fmt.Errorf("could not commit batch tx. Cause: %w", err)
 	}
 	return nil

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -48,7 +48,7 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 	}
 
 	if err := dbtx.Write(); err != nil {
-		if hostdb.RowExistsError(err) {
+		if hostdb.IsRowExistsError(err) {
 			return nil
 		}
 		return fmt.Errorf("could not commit batch tx. Cause: %w", err)

--- a/go/host/storage/storage_test.go
+++ b/go/host/storage/storage_test.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ten-protocol/go-ten/go/common"
+	"github.com/ten-protocol/go-ten/go/host/storage/hostdb"
+	"github.com/ten-protocol/go-ten/integration/common/testlog"
+	"testing"
+)
+
+func TestAddBatchWithDuplicateSequenceNumberStorageImpl(t *testing.T) {
+	db, _ := hostdb.CreateSQLiteDB(t)
+	logger := testlog.Logger()
+	s := NewStorage(db, logger)
+	batch1 := hostdb.CreateBatch(2, []common.L2TxHash{})
+	err := s.AddBatch(&batch1)
+	if err != nil {
+		t.Errorf("could not store first batch. Cause: %s", err)
+	}
+
+	batch2 := hostdb.CreateBatch(2, []common.L2TxHash{gethcommon.BytesToHash([]byte("different"))})
+	err = s.AddBatch(&batch2)
+	// verify no error is returned
+	if err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	}
+}

--- a/go/host/storage/storage_test.go
+++ b/go/host/storage/storage_test.go
@@ -1,11 +1,12 @@
 package storage
 
 import (
+	"testing"
+
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ten-protocol/go-ten/go/common"
 	"github.com/ten-protocol/go-ten/go/host/storage/hostdb"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
-	"testing"
 )
 
 func TestAddBatchWithDuplicateSequenceNumberStorageImpl(t *testing.T) {


### PR DESCRIPTION
### Why this change is needed

Getting a lot of batch duplicate key errors on the UAT validators due to bad error handling

### What changes were made as part of this PR

* return nil if the record exists and check for it in the `dbTx.Commit()` as well
* add storage unit test for the logic 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


