### PR TITLE
make sure blocks are fully processed

### DIFF
--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -120,6 +120,11 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 	// signal to stop the enclave
 	stopControl := stopcontrol.New()
 
+	err = storage.DeleteDirtyBlocks(context.Background())
+	if err != nil {
+		logger.Crit("failed to clean dirty blocks", log.ErrKey, err)
+	}
+
 	// these services are directly exposed as the API of the Enclave
 	initAPI := NewEnclaveInitAPI(config, storage, logger, blockProcessor, enclaveKeyService, attestationProvider, sharedSecretService, daEncryptionService, rpcKeyService)
 	adminAPI := NewEnclaveAdminAPI(config, storage, logger, blockProcessor, batchRegistry, batchExecutor, gethEncodingService, stopControl, subscriptionManager, enclaveKeyService, mempool, chainConfig, mgmtContractLib, attestationProvider, sharedSecretService, daEncryptionService)

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -186,6 +186,11 @@ func (e *enclaveAdminService) SubmitL1Block(ctx context.Context, blockData *comm
 		return nil, e.rejectBlockErr(ctx, fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
 
+	err = e.storage.UpdateProcessed(ctx, blockHeader.Hash())
+	if err != nil {
+		return nil, e.rejectBlockErr(ctx, fmt.Errorf("could not submit L1 block. Cause: %w", err))
+	}
+
 	// in phase 1, only if the enclave is a sequencer, it can respond to shared secret requests
 	canShareSecret := e.isBackupSequencer(ctx) || e.isActiveSequencer(ctx) || e.sharedSecretService.IsGenesis()
 

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -29,14 +29,9 @@ func WriteBatchHeader(ctx context.Context, dbtx *sql.Tx, batch *core.Batch, conv
 		isCanonical,                            // is_canonical
 		header,                                 // header blob
 		batch.Header.L1Proof.Bytes(),           // l1 proof hash
+		false,                                  // executed
 	}
-	if blockId == 0 {
-		args = append(args, nil) // l1_proof block id
-	} else {
-		args = append(args, blockId)
-	}
-	args = append(args, false) // executed
-	_, err = dbtx.ExecContext(ctx, "insert into batch values (?,?,?,?,?,?,?,?,?)", args...)
+	_, err = dbtx.ExecContext(ctx, "insert into batch values (?,?,?,?,?,?,?,?)", args...)
 	return err
 }
 

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -37,6 +37,7 @@ create table if not exists tendb.block
     is_canonical boolean    NOT NULL,
     header       blob       NOT NULL,
     height       int        NOT NULL,
+    processed    boolean    NOT NULL,
     primary key (id),
     INDEX (height),
     INDEX USING HASH (hash)

--- a/go/enclave/storage/init/edgelessdb/001_init.sql
+++ b/go/enclave/storage/init/edgelessdb/001_init.sql
@@ -75,12 +75,10 @@ create table if not exists tendb.batch
     is_canonical   boolean    NOT NULL,
     header         blob       NOT NULL,
     l1_proof_hash  binary(32) NOT NULL,
-    l1_proof       INTEGER,
     is_executed    boolean    NOT NULL,
     primary key (sequence),
     INDEX USING HASH (hash),
     INDEX USING HASH (l1_proof_hash),
-    INDEX (l1_proof),
     INDEX (height),
     INDEX (is_canonical, is_executed, height)
 );

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -29,9 +29,8 @@ create table if not exists block
     hash         binary(32) NOT NULL,
     is_canonical boolean    NOT NULL,
     header       blob       NOT NULL,
-    height       int        NOT NULL
-    --   the unique constraint is commented for now because there might be multiple non-canonical blocks for the same height
---     unique (height, is_canonical)
+    height       int        NOT NULL,
+    processed    boolean    NOT NULL
 );
 create index IDX_BLOCK_HEIGHT on block (height);
 create index IDX_BLOCK_HASH on block (hash);
@@ -67,14 +66,10 @@ create table if not exists batch
     is_canonical   boolean    NOT NULL,
     header         blob       NOT NULL,
     l1_proof_hash  binary(32) NOT NULL,
-    l1_proof       INTEGER, -- normally this would be a FK, but there is a weird edge case where an L2 node might not have the block used to create this batch
     is_executed    boolean    NOT NULL
-    --   the unique constraint is commented for now because there might be multiple non-canonical batches for the same height
---   unique (height, is_canonical, is_executed)
 );
 create index IDX_BATCH_HASH on batch (hash);
 create index IDX_BATCH_BLOCK on batch (l1_proof_hash);
-create index IDX_BATCH_L1 on batch (l1_proof);
 create index IDX_BATCH_HEIGHT on batch (height);
 create index IDX_BATCH_HEIGHT_COMP on batch (is_canonical, is_executed, height);
 

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -30,6 +30,10 @@ type BlockResolver interface {
 	FetchHeadBlock(ctx context.Context) (*types.Header, error)
 	// StoreBlock persists the L1 BlockHeader and updates the canonical ancestors if there was a fork
 	StoreBlock(ctx context.Context, block *types.Header, fork *common.ChainFork) error
+	// UpdateProcessed - marks the block as processed
+	UpdateProcessed(ctx context.Context, block common.L1BlockHash) error
+	// DeleteDirtyBlocks - deletes all traces of a block that was not finished. Only called at startup.
+	DeleteDirtyBlocks(ctx context.Context) error
 	// IsAncestor returns true if maybeAncestor is an ancestor of the L1 BlockHeader, and false otherwise
 	IsAncestor(ctx context.Context, block *types.Header, maybeAncestor *types.Header) bool
 }

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -290,10 +290,11 @@ func (s *storageImpl) StoreBlock(ctx context.Context, block *types.Header, chain
 
 	// sanity check that there is always a single canonical batch or block per layer
 	// called after forks, for the latest 50 blocks
-	err = enclavedb.CheckCanonicalValidity(ctx, dbTx, blockId-50)
-	if err != nil {
-		s.logger.Crit("Should not happen.", log.ErrKey, err)
-	}
+	// uncomment when debugging a race
+	//err = enclavedb.CheckCanonicalValidity(ctx, dbTx, blockId-50)
+	//if err != nil {
+	//	s.logger.Crit("Should not happen.", log.ErrKey, err)
+	//}
 
 	if err := dbTx.Commit(); err != nil {
 		return fmt.Errorf("4. could not store block %s. Cause: %w", block.Hash(), err)
@@ -301,6 +302,68 @@ func (s *storageImpl) StoreBlock(ctx context.Context, block *types.Header, chain
 
 	s.cachingService.CacheBlock(ctx, block)
 
+	return nil
+}
+
+func (s *storageImpl) UpdateProcessed(ctx context.Context, block common.L1BlockHash) error {
+	defer s.logDuration("UpdateProcessed", measure.NewStopwatch())
+	dbTx, err := s.db.NewDBTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("could not create DB transaction - %w", err)
+	}
+	defer dbTx.Rollback()
+
+	err = enclavedb.UpdateBlockProcessed(ctx, dbTx, block)
+	if err != nil {
+		return fmt.Errorf("could not update block processed - %w", err)
+	}
+	if err := dbTx.Commit(); err != nil {
+		return fmt.Errorf(" could not update block processed. Cause: %w", err)
+	}
+	return nil
+}
+
+func (s *storageImpl) DeleteDirtyBlocks(ctx context.Context) error {
+	defer s.logDuration("DeleteDirtyBlocks", measure.NewStopwatch())
+	dbTx, err := s.db.NewDBTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("could not create DB transaction - %w", err)
+	}
+	defer dbTx.Rollback()
+	dirtyBlocks, err := enclavedb.SelectUnprocessedBlocks(ctx, dbTx)
+	if err != nil {
+		return fmt.Errorf("could not select unprocessed blocks - %w", err)
+	}
+	if len(dirtyBlocks) > 1 {
+		return fmt.Errorf("more than one dirty block found. Should not happen")
+	}
+
+	if len(dirtyBlocks) == 0 {
+		// nothing to do
+		return nil
+	}
+
+	blockId := dirtyBlocks[0]
+
+	// delete rollups
+	err = enclavedb.DeleteRollupsForBlock(ctx, dbTx, blockId)
+	if err != nil {
+		return fmt.Errorf("could not delete rollups for block %d. Cause: %w", blockId, err)
+	}
+	// delete cross chain messages
+	err = enclavedb.DeleteL1MessagesForBlock(ctx, dbTx, blockId)
+	if err != nil {
+		return fmt.Errorf("could not delete cross chain messages for block %d. Cause: %w", blockId, err)
+	}
+	// delete block
+	err = enclavedb.DeleteBlock(ctx, dbTx, blockId)
+	if err != nil {
+		return fmt.Errorf("could not delete block %d. Cause: %w", blockId, err)
+	}
+
+	if err := dbTx.Commit(); err != nil {
+		return fmt.Errorf(" could not remove dirty blocks. Cause: %w", err)
+	}
 	return nil
 }
 

--- a/integration/simulation/transaction_injector.go
+++ b/integration/simulation/transaction_injector.go
@@ -345,7 +345,7 @@ func (ti *TransactionInjector) awaitAndFinalizeWithdrawal(tx *types.Transaction,
 				time.Sleep(1 * time.Second)
 				continue
 			}
-			if strings.Contains(err.Error(), "database closed") {
+			if strings.Contains(err.Error(), "database closed") || strings.Contains(err.Error(), "database is closed") {
 				ti.logger.Info("Database closed, test over", log.ErrKey, err)
 				return
 			}


### PR DESCRIPTION
### Why this change is needed

An enclave can die while processing an L1 block. 
Because the processing itself is not atomic (for performance reasons), it can leave the database in an intermediary state.

### What changes were made as part of this PR

- Create a new field in the "block" table to mark when the processing is finished
- On startup, check and remove any dirty (un-finished) blocks.
- Remove a field that was no longer necessary from the "batch" table.


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


