### PR TITLE
optimize locks

### DIFF
--- a/go/common/subscription/new_heads_manager.go
+++ b/go/common/subscription/new_heads_manager.go
@@ -92,11 +92,16 @@ func (nhs *NewHeadsService) onNewBatch(head *common.BatchHeader) error {
 		msg = ConvertBatchHeader(head)
 	}
 
-	nhs.notifiersMutex.Lock()
-	defer nhs.notifiersMutex.Unlock()
+	// copy the notifiers
+	nhs.notifiersMutex.RLock()
+	notifiers := make(map[rpc.ID]*rpc.Notifier)
+	for id, notifier := range nhs.newHeadNotifiers {
+		notifiers[id] = notifier
+	}
+	nhs.notifiersMutex.RUnlock()
 
 	// for each new head, notify all registered subscriptions
-	for id, notifier := range nhs.newHeadNotifiers {
+	for id, notifier := range notifiers {
 		if nhs.stopped.Load() {
 			return nil
 		}

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -250,11 +250,15 @@ func (e *enclaveAdminService) SubmitBatch(ctx context.Context, extBatch *common.
 		return err
 	}
 
+	// todo - review whether we need to lock here.
+	e.dataInMutex.Lock()
 	// if the signature is valid, then store the batch together with the converted hash
 	err = e.storage.StoreBatch(ctx, batch, convertedHeader.Hash())
 	if err != nil {
+		e.dataInMutex.Unlock()
 		return responses.ToInternalError(fmt.Errorf("could not store batch. Cause: %w", err))
 	}
+	e.dataInMutex.Unlock()
 
 	err = e.validator().ExecuteStoredBatches(ctx)
 	if err != nil {

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -250,9 +250,6 @@ func (e *enclaveAdminService) SubmitBatch(ctx context.Context, extBatch *common.
 		return err
 	}
 
-	e.dataInMutex.Lock()
-	defer e.dataInMutex.Unlock()
-
 	// if the signature is valid, then store the batch together with the converted hash
 	err = e.storage.StoreBatch(ctx, batch, convertedHeader.Hash())
 	if err != nil {

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ten-protocol/go-ten/go/enclave/core"
 )
 
-func WriteBatchHeader(ctx context.Context, dbtx *sql.Tx, batch *core.Batch, convertedHash gethcommon.Hash, blockId int64, isCanonical bool) error {
+func WriteBatchHeader(ctx context.Context, dbtx *sql.Tx, batch *core.Batch, convertedHash gethcommon.Hash, isCanonical bool) error {
 	header, err := rlp.EncodeToBytes(batch.Header)
 	if err != nil {
 		return fmt.Errorf("could not encode batch header. Cause: %w", err)

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -624,13 +624,6 @@ func (s *storageImpl) StoreBatch(ctx context.Context, batch *core.Batch, convert
 	}
 	defer dbTx.Rollback()
 
-	// it is possible that the block is not available if this is a validator
-	blockId, err := enclavedb.GetBlockId(ctx, dbTx, batch.Header.L1Proof)
-	if err != nil {
-		s.logger.Warn("could not get block id from db", log.ErrKey, err)
-	}
-	s.logger.Trace("write batch", log.BatchHashKey, batch.Hash(), "l1Proof", batch.Header.L1Proof, log.BatchSeqNoKey, batch.SeqNo(), "block_id", blockId)
-
 	// the batch is canonical only if the l1 proof is canonical
 	isL1ProofCanonical, err := enclavedb.IsCanonicalBlock(ctx, dbTx, &batch.Header.L1Proof)
 	if err != nil {
@@ -652,7 +645,7 @@ func (s *storageImpl) StoreBatch(ctx context.Context, batch *core.Batch, convert
 		return fmt.Errorf("could not read ExistsBatchAtHeight. Cause: %w", err)
 	}
 
-	if err := enclavedb.WriteBatchHeader(ctx, dbTx, batch, convertedHash, blockId, isL1ProofCanonical); err != nil {
+	if err := enclavedb.WriteBatchHeader(ctx, dbTx, batch, convertedHash, isL1ProofCanonical); err != nil {
 		return fmt.Errorf("could not write batch header. Cause: %w", err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

To avoid deadlocks

### What changes were made as part of this PR

- reduce the scope of various mutexes
- remove a query that is no longer necessary ( because of a previous PR)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


