### PR TITLE
Duplicate rollup error handling 

### DIFF
--- a/go/host/storage/hostdb/rollup.go
+++ b/go/host/storage/hostdb/rollup.go
@@ -48,6 +48,9 @@ func AddRollup(dbtx *dbTransaction, statements *SQLStatements, rollup *common.Ex
 		blockId,                              // l1 block hash
 	).Scan(&rollupId)
 	if err != nil {
+		if IsRowExistsError(err) {
+			return errutil.ErrAlreadyExists
+		}
 		return fmt.Errorf("could not insert rollup: %w", err)
 	}
 


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/4619

### What changes were made as part of this PR

* Add same error handling if we encounter a duplicate key error on rollup insertion as we added for writing batches

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


