### PR TITLE
Enclave: avoid log spam during initial L1 catchup

### DIFF
--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -578,7 +578,9 @@ func (e *enclaveAdminService) getNodeType(ctx context.Context) common.NodeType {
 	id := e.enclaveKeyService.EnclaveID()
 	attestedEnclave, err := e.storage.GetEnclavePubKey(ctx, id)
 	if err != nil {
-		e.logger.Info("could not read enclave pub key. Defaulting to validator type", log.ErrKey, err)
+		// this log message doesn't need to be info level, we can assume enclave is in this state until we see a msg like
+		// "Store attestation. Owner: <EnclaveID>" in the logs (i.e. after initial L1 catchup)
+		e.logger.Trace("could not read enclave pub key. Defaulting to validator type", log.ErrKey, err)
 		return common.Validator
 	}
 	return attestedEnclave.Type


### PR DESCRIPTION
### Why this change is needed

This info level log msg was getting spammed by enclave during initial L1 catchup of a new node (because it doesn't see its own attestation until it gets close to the latest L1 blocks, it was only just sent).

### What changes were made as part of this PR

Downgrade spammy log msg

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


