### PR TITLE
Add relaxed log method duration threshold

### DIFF
--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -52,7 +52,7 @@ func NewRollupConsumer(
 
 // ProcessRollups - processes the rollups found in the block, verifies the rollups and stores them
 func (rc *rollupConsumerImpl) ProcessRollups(ctx context.Context, rollups []*common.ExtRollup) ([]common.ExtRollupMetadata, error) {
-	defer core.LogMethodDuration(rc.logger, measure.NewStopwatch(), "Rollup consumer processed blobs")
+	defer core.LogMethodDuration(rc.logger, measure.NewStopwatch(), "Rollup consumer processed blobs", &core.RelaxedThresholds)
 
 	rollupMetadata := make([]common.ExtRollupMetadata, len(rollups))
 	for idx, rollup := range rollups {

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -221,7 +221,7 @@ func (e *enclaveAdminService) SubmitBatch(ctx context.Context, extBatch *common.
 		e.logger.Crit("Can't submit a batch to the active sequencer")
 	}
 
-	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "SubmitBatch call completed.", log.BatchHashKey, extBatch.Hash())
+	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "SubmitBatch call completed.", &core.RelaxedThresholds, log.BatchHashKey, extBatch.Hash())
 
 	e.logger.Info("Received new p2p batch", log.BatchHeightKey, extBatch.Header.Number, log.BatchHashKey, extBatch.Hash(), "l1", extBatch.Header.L1Proof)
 	seqNo := extBatch.Header.SequencerOrderNo.Uint64()
@@ -271,7 +271,7 @@ func (e *enclaveAdminService) CreateBatch(ctx context.Context, skipBatchIfEmpty 
 		e.logger.Crit("Only the active sequencer can create batches")
 	}
 
-	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateBatch call ended")
+	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateBatch call ended", &core.RelaxedThresholds)
 
 	e.dataInMutex.RLock()
 	defer e.dataInMutex.RUnlock()
@@ -288,7 +288,7 @@ func (e *enclaveAdminService) CreateRollup(ctx context.Context, fromSeqNo uint64
 	if !e.isActiveSequencer(ctx) {
 		e.logger.Crit("Only the active sequencer can create rollups")
 	}
-	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateRollup call ended")
+	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateRollup call ended", &core.RelaxedThresholds)
 
 	// allow the simultaneous production of rollups and batches
 	e.dataInMutex.RLock()

--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -332,7 +332,7 @@ func (c *Client) HealthCheck(ctx context.Context) (bool, common.SystemError) {
 }
 
 func (c *Client) CreateBatch(ctx context.Context, skipIfEmpty bool) common.SystemError {
-	defer core.LogMethodDuration(c.logger, measure.NewStopwatch(), "CreateBatch rpc call")
+	defer core.LogMethodDuration(c.logger, measure.NewStopwatch(), "CreateBatch rpc call", &core.RelaxedThresholds)
 
 	response, err := c.protoClient.CreateBatch(ctx, &generated.CreateBatchRequest{SkipIfEmpty: skipIfEmpty})
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

ERRORs in the logs that are definitely not errors, not even warnings in some functions that take longer - rollup creation/ consumption for example.

### What changes were made as part of this PR

* Add an optional `RelaxedThreshold` parameter you can provide to the `LogMethodDuration` to set the values to longer timescales. 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


