### PR TITLE
Auto restart TEN Gateway and comment out collecting metrics

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -412,7 +412,7 @@ jobs:
             docker pull ${{ env.DOCKER_BUILD_TAG_GATEWAY }}
 
             # Start Ten Gateway Container
-            docker run -d -p 80:80 -p 81:81 -p 443:443 --name "${{ env.VM_NAME }}" \
+            docker run -d --restart=unless-stopped -p 80:80 -p 81:81 -p 443:443 --name "${{ env.VM_NAME }}" \
             --device /dev/sgx_enclave --device /dev/sgx_provision \
             -v "TENGateway-${{ github.event.inputs.testnet_type }}-data:/data" \
             -e OBSCURO_GATEWAY_VERSION="${{ github.run_number }}-${{ github.sha }}" \

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -92,7 +92,7 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 		return nil, err
 	}
 
-	w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(user.ID))
+	//w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(user.ID))
 
 	rateLimitAllowed, requestUUID := w.RateLimiter.Allow(gethcommon.Address(user.ID))
 	defer w.RateLimiter.SetRequestEnd(gethcommon.Address(user.ID), requestUUID)

--- a/tools/walletextension/services/wallet_extension.go
+++ b/tools/walletextension/services/wallet_extension.go
@@ -203,7 +203,7 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 		w.Logger().Error(fmt.Sprintf("failed to save user to the database: %s", err))
 		return nil, err
 	}
-	w.MetricsTracker.RecordNewUser()
+	//w.MetricsTracker.RecordNewUser()
 
 	requestEndTime := time.Now()
 	duration := requestEndTime.Sub(requestStartTime)
@@ -213,7 +213,7 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
 func (w *Services) AddAddressToUser(userID []byte, address string, signature []byte, signatureType viewingkey.SignatureType) error {
-	w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
+	//w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
 	audit(w, "Adding address to user: %s, address: %s", common.HashForLogging(userID), address)
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
@@ -233,7 +233,7 @@ func (w *Services) AddAddressToUser(userID []byte, address string, signature []b
 		w.Logger().Error(fmt.Errorf("error while storing account (%s) for user (%s): %w", addressFromMessage.Hex(), userID, err).Error())
 		return err
 	}
-	w.MetricsTracker.RecordAccountRegistered()
+	// w.MetricsTracker.RecordAccountRegistered()
 
 	audit(w, "Storing new address for user: %s, address: %s, duration: %d ", hexutils.BytesToHex(userID), address, time.Since(requestStartTime).Milliseconds())
 	return nil
@@ -241,7 +241,7 @@ func (w *Services) AddAddressToUser(userID []byte, address string, signature []b
 
 // UserHasAccount checks if provided account exist in the database for given userID
 func (w *Services) UserHasAccount(userID []byte, address string) (bool, error) {
-	w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
+	//w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
 	audit(w, "Checking if user has account: %s, address: %s", common.HashForLogging(userID), address)
 	addressBytes, err := hex.DecodeString(address[2:]) // remove 0x prefix from address
 	if err != nil {


### PR DESCRIPTION
### Why this change is needed

We experienced crashes in the gateway when testing in UAT.


### What changes were made as part of this PR

- Auto restart will enable the gateway container to auto restart if the crash happens again
- Crash is very likely coming from collecting metrics on active users and it needs to be refactored. Commenting this out to confirm and in the next PR I will introduce new way of measuring user activity in the GW.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


