### PR TITLE
Debug logging for rollups to see if we're losing any

### DIFF
--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -14,7 +14,7 @@ network:
     maxInterval: 10m # rollups will be produced after this time even if the data blob is not full
     maxSize: 131072 # 128kb - the size of a blob
   gas: # todo: ask stefan about these fields
-    baseFee: 100000000 # using geth's initial base fee for EIP-1559 blocks.
+    baseFee: 1000000000 # using geth's initial base fee for EIP-1559 blocks.
     minGasPrice: 1000000000 # using geth's initial base fee for EIP-1559 blocks.
     paymentAddress: 0xd6C9230053f45F873Cb66D8A02439380a37A4fbF
     batchExecutionLimit: 30000000 # same as Ethereum blocks

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -159,11 +159,13 @@ func (rc *rollupConsumerImpl) extractAndVerifyRollups(processed *common.Processe
 			rc.logger.Warn(fmt.Sprintf("could not decode tx at index %d. Cause: %s", i, err))
 		}
 		if t == nil {
+			rc.logger.Debug(fmt.Sprintf("rollup event was provided with a tx that is not a rollup."))
 			continue
 		}
 
 		rollupHashes, ok := t.(*common.L1RollupHashes)
 		if !ok {
+			rc.logger.Debug(fmt.Sprintf("could not cast decoded transaction to l1 rollup hashes. Cause: %s", err))
 			continue
 		}
 

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -159,7 +159,7 @@ func (rc *rollupConsumerImpl) extractAndVerifyRollups(processed *common.Processe
 			rc.logger.Warn(fmt.Sprintf("could not decode tx at index %d. Cause: %s", i, err))
 		}
 		if t == nil {
-			rc.logger.Debug(fmt.Sprintf("rollup event was provided with a tx that is not a rollup."))
+			rc.logger.Debug("rollup event was provided with a tx that is not a rollup.")
 			continue
 		}
 

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -159,13 +159,13 @@ func (rc *rollupConsumerImpl) extractAndVerifyRollups(processed *common.Processe
 			rc.logger.Warn(fmt.Sprintf("could not decode tx at index %d. Cause: %s", i, err))
 		}
 		if t == nil {
-			rc.logger.Debug("could not cast decoded transaction to l1 rollup hashes", log.ErrKey, err)
+			rc.logger.Debug("could not decode transaction")
 			continue
 		}
 
 		rollupHashes, ok := t.(*common.L1RollupHashes)
 		if !ok {
-			rc.logger.Debug(fmt.Sprintf("could not cast decoded transaction to l1 rollup hashes. Cause: %s", err))
+			rc.logger.Error(fmt.Sprintf("could not cast decoded rollup tx to l1 rollup hashes"))
 			continue
 		}
 

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -159,7 +159,7 @@ func (rc *rollupConsumerImpl) extractAndVerifyRollups(processed *common.Processe
 			rc.logger.Warn(fmt.Sprintf("could not decode tx at index %d. Cause: %s", i, err))
 		}
 		if t == nil {
-			rc.logger.Debug("rollup event was provided with a tx that is not a rollup.")
+			rc.logger.Debug("could not cast decoded transaction to l1 rollup hashes", log.ErrKey, err)
 			continue
 		}
 

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -303,7 +303,10 @@ func (r *DataService) processRollupLogs(l types.Log, txData *common.L1TxData, pr
 			},
 		}
 		processed.AddEvent(common.RollupTx, txData)
+	} else {
+		r.logger.Debug(fmt.Sprintf("error while fetching blobs. Cause: %s", err))
 	}
+
 }
 
 // processManagementContractTx handles decoded transaction types

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -306,7 +306,6 @@ func (r *DataService) processRollupLogs(l types.Log, txData *common.L1TxData, pr
 	} else {
 		r.logger.Debug(fmt.Sprintf("error while fetching blobs. Cause: %s", err))
 	}
-
 }
 
 // processManagementContractTx handles decoded transaction types

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -298,6 +298,7 @@ func (r *DataService) processRollupLogs(l types.Log, txData *common.L1TxData, pr
 	blobs, err := r.blobResolver.FetchBlobs(context.Background(), processed.BlockHeader, []gethcommon.Hash{event.RollupHash})
 	if err != nil {
 		r.logger.Error(fmt.Sprintf("error while fetching blobs. Cause: %s", err))
+		return
 	}
 	txData.BlobsWithSignature = []common.BlobAndSignature{
 		{

--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -295,17 +295,17 @@ func (r *DataService) processRollupLogs(l types.Log, txData *common.L1TxData, pr
 		r.logger.Error("Error unpacking RollupAdded event", log.ErrKey, err)
 		return
 	}
-	if blobs, err := r.blobResolver.FetchBlobs(context.Background(), processed.BlockHeader, []gethcommon.Hash{event.RollupHash}); err == nil {
-		txData.BlobsWithSignature = []common.BlobAndSignature{
-			{
-				Blob:      blobs[0],
-				Signature: event.Signature,
-			},
-		}
-		processed.AddEvent(common.RollupTx, txData)
-	} else {
-		r.logger.Debug(fmt.Sprintf("error while fetching blobs. Cause: %s", err))
+	blobs, err := r.blobResolver.FetchBlobs(context.Background(), processed.BlockHeader, []gethcommon.Hash{event.RollupHash})
+	if err != nil {
+		r.logger.Error(fmt.Sprintf("error while fetching blobs. Cause: %s", err))
 	}
+	txData.BlobsWithSignature = []common.BlobAndSignature{
+		{
+			Blob:      blobs[0],
+			Signature: event.Signature,
+		},
+	}
+	processed.AddEvent(common.RollupTx, txData)
 }
 
 // processManagementContractTx handles decoded transaction types


### PR DESCRIPTION
### Why this change is needed

Rollups not being found in blocks on k8s validator and no way to determine why currently. 

### What changes were made as part of this PR

* Debug logging on the host and enclave side

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


