### PR TITLE
add log to help debug gas spikes, and remove noise in the log

### DIFF
--- a/go/common/gethapi/transaction_args.go
+++ b/go/common/gethapi/transaction_args.go
@@ -370,7 +370,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 		gas = uint64(*args.Gas)
 	}
 	if globalGasCap != 0 && globalGasCap < gas {
-		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
+		log.Debug("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
 		gas = globalGasCap
 	}
 	var (

--- a/go/enclave/system/hooks.go
+++ b/go/enclave/system/hooks.go
@@ -177,7 +177,7 @@ func (s *systemContractCallbacks) CreatePublicCallbackHandlerTransaction(ctx con
 	}
 
 	formedTx := types.NewTx(tx)
-	s.logger.Info("CreatePublicCallbackHandlerTransaction: Successfully created transaction", "transactionHash", formedTx.Hash().Hex())
+	s.logger.Debug("CreatePublicCallbackHandlerTransaction: Successfully created transaction", "transactionHash", formedTx.Hash().Hex())
 	return formedTx, nil
 }
 
@@ -236,7 +236,7 @@ func (s *systemContractCallbacks) CreateOnBatchEndTransaction(_ context.Context,
 	}
 
 	formedTx := types.NewTx(tx)
-	s.logger.Info("CreateOnBatchEndTransaction: Successfully created synthetic transaction", log.TxKey, formedTx.Hash())
+	s.logger.Debug("CreateOnBatchEndTransaction: Successfully created synthetic transaction", log.TxKey, formedTx.Hash())
 	return formedTx, nil
 }
 


### PR DESCRIPTION
### Why this change is needed

- to reduce the noise in the logs
- help investigate an issue where a tx was delayed a couple of hours because of gas issues


