### PR TITLE
Host: load head batch num on restart

### DIFF
--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -258,15 +258,6 @@ func GetBatchByHash(db HostDB, hash common.L2BatchHash) (*common.ExtBatch, error
 	return fetchFullBatch(db.GetSQLDB(), whereQuery, hash.Bytes())
 }
 
-// GetLatestBatch returns the head batch header
-func GetLatestBatch(db HostDB) (*common.BatchHeader, error) {
-	headBatch, err := fetchHeadBatch(db.GetSQLDB())
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch head batch: %w", err)
-	}
-	return headBatch.Header, nil
-}
-
 // GetBatchHeaderByHeight returns the batch header given the height
 func GetBatchHeaderByHeight(db HostDB, height *big.Int) (*common.BatchHeader, error) {
 	whereQuery := " WHERE height=" + db.GetSQLStatement().Placeholder

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -174,7 +174,7 @@ func (s *storageImpl) FetchBatchByTx(txHash gethcommon.Hash) (*common.ExtBatch, 
 }
 
 func (s *storageImpl) FetchLatestBatch() (*common.BatchHeader, error) {
-	return hostdb.GetLatestBatch(s.db)
+	return hostdb.GetHeadBatchHeader(s.db)
 }
 
 func (s *storageImpl) FetchBatchHeaderByHeight(height *big.Int) (*common.BatchHeader, error) {


### PR DESCRIPTION
### Why this change is needed

Restarted host should read the head batch num from its DB rather than waiting for next batch to arrive/be produced.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


