### PR TITLE
Make deleting unprocessed blocks less brittle

### DIFF
--- a/go/enclave/storage/enclavedb/block.go
+++ b/go/enclave/storage/enclavedb/block.go
@@ -284,17 +284,17 @@ func SelectUnprocessedBlocks(ctx context.Context, dbtx *sql.Tx) ([]uint64, error
 	return ids, rows.Err()
 }
 
-func DeleteRollupsForBlock(ctx context.Context, tx *sql.Tx, blockId uint64) error {
-	_, err := tx.ExecContext(ctx, "delete from rollup where compression_block=?", blockId)
+func DeleteUnprocessedRollups(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "delete from rollup where compression_block in (select id from block where processed=false)")
 	return err
 }
 
-func DeleteL1MessagesForBlock(ctx context.Context, tx *sql.Tx, blockId uint64) error {
-	_, err := tx.ExecContext(ctx, "delete from l1_msg where block=?", blockId)
+func DeleteUnprocessedL1Messages(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "delete from l1_msg where block in (select id from block where processed=false)")
 	return err
 }
 
-func DeleteBlock(ctx context.Context, tx *sql.Tx, blockId uint64) error {
-	_, err := tx.ExecContext(ctx, "delete from block where id=?", blockId)
+func DeleteUnProcessedBlock(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "delete from block where processed=false")
 	return err
 }

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -334,31 +334,26 @@ func (s *storageImpl) DeleteDirtyBlocks(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not select unprocessed blocks - %w", err)
 	}
-	if len(dirtyBlocks) > 1 {
-		return fmt.Errorf("more than one dirty block found. Should not happen")
-	}
-
 	if len(dirtyBlocks) == 0 {
 		// nothing to do
 		return nil
 	}
-
-	blockId := dirtyBlocks[0]
+	s.logger.Warn("Found unprocessed blocks", "count", len(dirtyBlocks))
 
 	// delete rollups
-	err = enclavedb.DeleteRollupsForBlock(ctx, dbTx, blockId)
+	err = enclavedb.DeleteUnprocessedRollups(ctx, dbTx)
 	if err != nil {
-		return fmt.Errorf("could not delete rollups for block %d. Cause: %w", blockId, err)
+		return fmt.Errorf("could not delete unprocessed rollups. Cause: %w", err)
 	}
 	// delete cross chain messages
-	err = enclavedb.DeleteL1MessagesForBlock(ctx, dbTx, blockId)
+	err = enclavedb.DeleteUnprocessedL1Messages(ctx, dbTx)
 	if err != nil {
-		return fmt.Errorf("could not delete cross chain messages for block %d. Cause: %w", blockId, err)
+		return fmt.Errorf("could not delete unprocessed cross chain messages. Cause: %w", err)
 	}
 	// delete block
-	err = enclavedb.DeleteBlock(ctx, dbTx, blockId)
+	err = enclavedb.DeleteUnProcessedBlock(ctx, dbTx)
 	if err != nil {
-		return fmt.Errorf("could not delete block %d. Cause: %w", blockId, err)
+		return fmt.Errorf("could not delete unprocessed blocks. Cause: %w", err)
 	}
 
 	if err := dbTx.Commit(); err != nil {


### PR DESCRIPTION
### Why this change is needed

On startup, we delete "unprocessed" blocks. The current version is more resistant to error conditions because it deletes all unprocessed blocks, rollups and xchain messages.


