### PR TITLE
Fix for race condition on underpriced tx

### DIFF
--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -303,6 +303,11 @@ func (t *Testnet) grantSequencerStatus(mgmtContractAddr string) error {
 		return fmt.Errorf("unable to start l1 grant sequencers - %w", err)
 	}
 
+	err = l1grantsequencers.WaitForFinish()
+	if err != nil {
+		return fmt.Errorf("unable to wait for l1 grant sequencers to finish - %w", err)
+	}
+
 	fmt.Println("Enclaves were successfully granted sequencer roles...")
 
 	return nil


### PR DESCRIPTION
### Why this change is needed

Both containers start at the same time with diff hardhat instances using hte same private keys and sending transactions.
### What changes were made as part of this PR

Made the process sequential as it should be. 
### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


