### PR TITLE
fix gas estimation

### DIFF
--- a/go/enclave/gas/oracle.go
+++ b/go/enclave/gas/oracle.go
@@ -41,9 +41,9 @@ func (o *oracle) EstimateL1StorageGasCost(tx *types.Transaction, block *types.He
 }
 
 func (o *oracle) EstimateL1CostForMsg(args *gethapi.TransactionArgs, block *types.Header, header *common.BatchHeader) (*big.Int, error) {
-	encoded := make([]byte, 0)
-	if args.Data != nil {
-		encoded = append(encoded, *args.Data...)
+	encoded, err := rlp.EncodeToBytes(args)
+	if err != nil {
+		return nil, err
 	}
 
 	return o.calculateL1Cost(block, header, encoded)

--- a/go/enclave/rpc/EstimateGas.go
+++ b/go/enclave/rpc/EstimateGas.go
@@ -23,7 +23,7 @@ import (
 	gethrpc "github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 )
 
-var adjustPublishingGas = gethcommon.Big3
+var adjustPublishingGas = gethcommon.Big2
 
 func EstimateGasValidate(reqParams []any, builder *CallBuilder[CallParamsWithBlock, hexutil.Uint64], _ *EncryptionManager) error {
 	// Parameters are [callMsg, BlockHeader number (optional)]


### PR DESCRIPTION
### Why this change is needed

When estimating gas, we were ignoring all fields except "data".
For value transfers, without "data", the l1 cost for estimation differed a lot from the actual execution.
This was apparent when blob prices were high.


