### PR TITLE
refactor and fix statedb

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -8,8 +8,6 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/ten-protocol/go-ten/go/common/gethutil"
-
 	"github.com/ten-protocol/go-ten/go/common/compression"
 
 	gethcore "github.com/ethereum/go-ethereum/core"
@@ -374,8 +372,6 @@ func (executor *batchExecutor) execMempoolTransactions(ec *BatchExecutionContext
 		}
 	}
 
-	ec.stateDB.Finalise(true)
-
 	ec.Transactions = results.BatchTransactions()
 	ec.batchTxResults = results
 
@@ -396,7 +392,6 @@ func (executor *batchExecutor) executeExistingBatch(ec *BatchExecutionContext) e
 		return fmt.Errorf("could not process transactions. Cause: %w", err)
 	}
 	ec.batchTxResults = txResults
-	ec.stateDB.Finalise(true)
 	return nil
 }
 
@@ -521,47 +516,52 @@ func (executor *batchExecutor) execOnBlockEndTx(ec *BatchExecutionContext) error
 }
 
 func (executor *batchExecutor) execResult(ec *BatchExecutionContext) (*ComputedBatch, error) {
+	executor.stateDBMutex.Lock()
+	defer executor.stateDBMutex.Unlock()
+
 	batch, allResults, err := executor.createBatch(ec)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating batch. Cause: %w", err)
 	}
 
-	commitFunc := func(deleteEmptyObjects bool) (gethcommon.Hash, error) {
-		executor.stateDBMutex.Lock()
-		defer executor.stateDBMutex.Unlock()
-		h, err := ec.stateDB.Commit(batch.Number().Uint64(), deleteEmptyObjects)
-		if err != nil {
-			return gethutil.EmptyHash, fmt.Errorf("commit failure for batch %d. Cause: %w", ec.currentBatch.SeqNo(), err)
-		}
-		trieDB := executor.storage.TrieDB()
-		err = trieDB.Commit(h, false)
-
-		// When system contract deployment genesis batch is committed, initialize executor's addresses for the hooks.
-		// Further restarts will call into Load() which will take the receipts for batch number 2 (which should never be deleted)
-		// and reinitialize them.
-		if err == nil && ec.currentBatch.Header.SequencerOrderNo.Uint64() == common.L2SysContractGenesisSeqNo {
-			if len(ec.genesisSysCtrResult) == 0 {
-				return h, fmt.Errorf("failed to instantiate system contracts: expected receipt for system deployer transaction, but no receipts found in batch")
-			}
-
-			return h, executor.systemContracts.Initialize(batch, *ec.genesisSysCtrResult.Receipts()[0], executor.crossChainProcessors.Local)
-		}
-		return h, err
+	rootHash, err := ec.stateDB.Commit(batch.Number().Uint64(), true)
+	if err != nil {
+		return nil, fmt.Errorf("commit failure for batch %d. Cause: %w", ec.currentBatch.SeqNo(), err)
 	}
 
+	trieDB := executor.storage.TrieDB()
+	err = trieDB.Commit(rootHash, false)
+	if err != nil {
+		executor.logger.Error("Failed to commit trieDB", "error", err)
+		return nil, fmt.Errorf("failed to commit trieDB. Cause: %w", err)
+	}
+	batch.Header.Root = rootHash
+
+	// When system contract deployment genesis batch is committed, initialize executor's addresses for the hooks.
+	// Further restarts will call into Load() which will take the receipts for batch number 2 (which should never be deleted)
+	// and reinitialize them.
+	if ec.currentBatch.Header.SequencerOrderNo.Uint64() == common.L2SysContractGenesisSeqNo {
+		if len(ec.genesisSysCtrResult) == 0 {
+			return nil, fmt.Errorf("failed to instantiate system contracts: expected receipt for system deployer transaction, but no receipts found in batch")
+		}
+
+		err := executor.systemContracts.Initialize(batch, *ec.genesisSysCtrResult.Receipts()[0], executor.crossChainProcessors.Local)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize system contracts: %w", err)
+		}
+	}
+
+	batch.ResetHash()
 	return &ComputedBatch{
 		Batch:         batch,
 		TxExecResults: allResults,
-		Commit:        commitFunc,
 	}, nil
 }
 
 func (executor *batchExecutor) createBatch(ec *BatchExecutionContext) (*core.Batch, core.TxExecResults, error) {
 	// we need to copy the batch to reset the internal hash cache
 	batch := *ec.currentBatch
-	batch.Header.Root = ec.stateDB.IntermediateRoot(false)
 	batch.Transactions = ec.batchTxResults.BatchTransactions()
-	batch.ResetHash()
 
 	txReceipts := ec.batchTxResults.Receipts()
 	if err := executor.populateOutboundCrossChainData(ec.ctx, &batch, ec.l1block, txReceipts); err != nil {
@@ -571,13 +571,13 @@ func (executor *batchExecutor) createBatch(ec *BatchExecutionContext) (*core.Bat
 	allResults := append(append(append(append(ec.batchTxResults, ec.xChainResults...), ec.callbackTxResults...), ec.blockEndResult...), ec.genesisSysCtrResult...)
 	receipts := allResults.Receipts()
 	if len(receipts) == 0 {
-		batch.Header.ReceiptHash = types.EmptyRootHash
+		batch.Header.ReceiptHash = types.EmptyReceiptsHash
 	} else {
 		batch.Header.ReceiptHash = types.DeriveSha(receipts, trie.NewStackTrie(nil))
 	}
 
 	if len(batch.Transactions) == 0 {
-		batch.Header.TxHash = types.EmptyRootHash
+		batch.Header.TxHash = types.EmptyTxsHash
 	} else {
 		batch.Header.TxHash = types.DeriveSha(types.Transactions(batch.Transactions), trie.NewStackTrie(nil))
 	}
@@ -589,6 +589,7 @@ func (executor *batchExecutor) createBatch(ec *BatchExecutionContext) (*core.Bat
 			l.BlockHash = batch.Hash()
 		}
 	}
+
 	return &batch, allResults, nil
 }
 
@@ -619,10 +620,6 @@ func (executor *batchExecutor) ExecuteBatch(ctx context.Context, batch *core.Bat
 		// todo @stefan - generate a validator challenge here and return it
 		executor.logger.Error(fmt.Sprintf("Error validating batch. Calculated: %+v    Incoming: %+v", cb.Batch.Header, batch.Header))
 		return nil, fmt.Errorf("batch is in invalid state. Incoming hash: %s  Computed hash: %s", batch.Hash(), cb.Batch.Hash())
-	}
-
-	if _, err := cb.Commit(true); err != nil {
-		return nil, fmt.Errorf("cannot commit stateDB for incoming valid batch %s. Cause: %w", batch.Hash(), err)
 	}
 
 	return cb.TxExecResults, nil

--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -95,7 +95,6 @@ type BatchExecutionContext struct {
 type ComputedBatch struct {
 	Batch         *core.Batch
 	TxExecResults []*core.TxExecResult
-	Commit        func(bool) (gethcommon.Hash, error)
 }
 
 type BatchExecutor interface {

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -513,10 +513,6 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 					rc.logger.Crit("Rollup decompression failure. The check hashes don't match")
 				}*/
 
-			if _, err := computedBatch.Commit(true); err != nil {
-				return fmt.Errorf("cannot commit stateDB for incoming valid batch seq=%d. Cause: %w", incompleteBatch.seqNo, err)
-			}
-
 			convertedHeader, err := rc.gethEncodingService.CreateEthHeaderForBatch(ctx, computedBatch.Batch.Header)
 			if err != nil {
 				return err

--- a/go/enclave/enclave.go
+++ b/go/enclave/enclave.go
@@ -110,8 +110,8 @@ func NewEnclave(config *enclaveconfig.EnclaveConfig, genesis *genesis.Genesis, m
 	dataCompressionService := compression.NewBrotliDataCompressionService(int64(config.DecompressionLimit))
 	batchExecutor := components.NewBatchExecutor(storage, batchRegistry, evmFacade, config, gethEncodingService, crossChainProcessors, genesis, gasOracle, chainConfig, scb, evmEntropyService, mempool, dataCompressionService, logger)
 
-	// ensure cached chain state data is up-to-date using the persisted batch data
-	err = restoreStateDBCache(context.Background(), storage, batchRegistry, batchExecutor, genesis, logger)
+	// ensure EVM state data is up-to-date using the persisted batch data
+	err = syncExecutedBatchesWithEVMStateDB(context.Background(), storage, batchRegistry, logger)
 	if err != nil {
 		logger.Crit("failed to resync L2 chain state DB after restart", log.ErrKey, err)
 	}

--- a/go/enclave/evm/evm_facade.go
+++ b/go/enclave/evm/evm_facade.go
@@ -133,9 +133,6 @@ func (exec *evmExecutor) execute(tx *common.L2PricedTransaction, from gethcommon
 func (exec *evmExecutor) ExecuteCall(ctx context.Context, msg *gethcore.Message, s *state.StateDB, header *common.BatchHeader) (*gethcore.ExecutionResult, error, common.SystemError) {
 	defer core.LogMethodDuration(exec.logger, measure.NewStopwatch(), "evm_facade.go:Call()")
 
-	snapshot := s.Snapshot()
-	defer s.RevertToSnapshot(snapshot) // Always revert after simulation
-
 	vmCfg := vm.Config{
 		NoBaseFee: true,
 	}
@@ -149,6 +146,8 @@ func (exec *evmExecutor) ExecuteCall(ctx context.Context, msg *gethcore.Message,
 	gp.SetGas(exec.gasEstimationCap)
 
 	cleanState := createCleanState(s, msg, ethHeader, exec.cc)
+	snapshot := cleanState.Snapshot()
+	defer cleanState.RevertToSnapshot(snapshot) // Always revert after simulation
 
 	blockContext := gethcore.NewEVMBlockContext(ethHeader, exec.chain, nil)
 	// sets TxKey.origin

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -241,10 +241,6 @@ func (s *sequencer) produceBatch(
 		return nil, fmt.Errorf("failed computing batch. Cause: %w", err)
 	}
 
-	if _, err := cb.Commit(true); err != nil {
-		return nil, fmt.Errorf("failed committing batch state. Cause: %w", err)
-	}
-
 	if err := s.signBatch(cb.Batch); err != nil {
 		return nil, fmt.Errorf("failed signing created batch. Cause: %w", err)
 	}

--- a/go/enclave/rpc/TenStorageRead.go
+++ b/go/enclave/rpc/TenStorageRead.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ten-protocol/go-ten/go/common/gethencoding"
 	"github.com/ten-protocol/go-ten/go/common/log"
 	"github.com/ten-protocol/go-ten/go/common/syserr"
@@ -62,9 +61,7 @@ func TenStorageReadValidate(reqParams []any, builder *CallBuilder[storageReadWit
 }
 
 func TenStorageReadExecute(builder *CallBuilder[storageReadWithBlock, string], rpc *EncryptionManager) error {
-	var err error
-	var stateDb *state.StateDB
-	stateDb, err = rpc.registry.GetBatchState(builder.ctx, *builder.Param.block)
+	stateDb, err := rpc.registry.GetBatchState(builder.ctx, *builder.Param.block)
 	if err != nil {
 		builder.Err = fmt.Errorf("unable to read block number - %w", err)
 		return nil

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -374,6 +374,11 @@ func BatchWasExecuted(ctx context.Context, db *sql.DB, hash common.L2BatchHash) 
 	return result, nil
 }
 
+func MarkBatchAsUnexecuted(ctx context.Context, dbTx *sql.Tx, seqNo *big.Int) error {
+	_, err := dbTx.ExecContext(ctx, "update batch set is_executed=false where sequence=?", seqNo.Uint64())
+	return err
+}
+
 func GetTransactionsPerAddress(ctx context.Context, db *sql.DB, address *gethcommon.Address, pagination *common.QueryPagination) ([]*core.InternalReceipt, error) {
 	return loadReceiptList(ctx, db, address, " ", []any{}, " ORDER BY b.sequence DESC LIMIT ? OFFSET ?", []any{pagination.Size, pagination.Offset})
 }

--- a/go/enclave/storage/interfaces.go
+++ b/go/enclave/storage/interfaces.go
@@ -68,6 +68,7 @@ type BatchResolver interface {
 
 	// BatchWasExecuted - return true if the batch was executed
 	BatchWasExecuted(ctx context.Context, hash common.L2BatchHash) (bool, error)
+	MarkBatchAsUnexecuted(ctx context.Context, seqNo *big.Int) error
 
 	// StoreBatch stores an un-executed batch.
 	StoreBatch(ctx context.Context, batch *core.Batch, convertedHash gethcommon.Hash) error


### PR DESCRIPTION
### Why this change is needed

On testnet we experienced a bug after a node restart where the root hash was different.

### What changes were made as part of this PR

- refactor batch execution to avoid a separate commit function
- this avoids the use of "statedb.IntermediateRoot"
- remove some satedb.finalize calls  - unclear why they were needed
- refactor the statedb/main db synch to only mark batches as unexecuted, instead of trying to execute them.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


