### PR TITLE
Add mempool l1 gas check

### DIFF
--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -17,7 +17,7 @@ network:
     baseFee: 100000000
     minGasPrice: 100000000
     paymentAddress: 0xd6C9230053f45F873Cb66D8A02439380a37A4fbF
-    batchExecutionLimit: 30000000 # same as Ethereum blocks
+    batchExecutionLimit: 300000000
     localExecutionCap: 300000000000 # 300 gwei
   l1:
     chainId: 1337

--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -205,7 +205,7 @@ func (executor *batchExecutor) verifyContext(ec *BatchExecutionContext) error {
 func (executor *batchExecutor) prepareState(ec *BatchExecutionContext) error {
 	var err error
 	// Create a new batch based on the provided context
-	ec.currentBatch = core.DeterministicEmptyBatch(ec.parentBatch, ec.l1block, ec.AtTime, ec.SequencerNo, ec.BaseFee, ec.Creator)
+	ec.currentBatch = core.DeterministicEmptyBatch(ec.parentBatch, ec.l1block, ec.AtTime, ec.SequencerNo, ec.BaseFee, ec.Creator, executor.batchGasLimit)
 	ec.stateDB, err = executor.batchRegistry.GetBatchState(ec.ctx, rpc.BlockNumberOrHash{BlockHash: &ec.currentBatch.Header.ParentHash})
 	if err != nil {
 		return fmt.Errorf("could not create stateDB. Cause: %w", err)

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -94,14 +94,7 @@ func ToBatch(extBatch *common.ExtBatch, transactionBlobCrypto *crypto.DAEncrypti
 	}, nil
 }
 
-func DeterministicEmptyBatch(
-	parent *common.BatchHeader,
-	block *types.Header,
-	time uint64,
-	sequencerNo *big.Int,
-	baseFee *big.Int,
-	coinbase gethcommon.Address,
-) *Batch {
+func DeterministicEmptyBatch(parent *common.BatchHeader, block *types.Header, time uint64, sequencerNo *big.Int, baseFee *big.Int, coinbase gethcommon.Address, gasLimit uint64) *Batch {
 	h := common.BatchHeader{
 		ParentHash:       parent.Hash(),
 		L1Proof:          block.Hash(),
@@ -111,7 +104,7 @@ func DeterministicEmptyBatch(
 		Time:     time,
 		BaseFee:  baseFee,
 		Coinbase: coinbase,
-		GasLimit: parent.GasLimit,
+		GasLimit: gasLimit,
 	}
 	b := Batch{
 		Header: &h,

--- a/go/enclave/evm/l1_publishing_gas.go
+++ b/go/enclave/evm/l1_publishing_gas.go
@@ -34,7 +34,6 @@ func adjustPublishingCostGas(tx *common.L2PricedTransaction, msg *gethcore.Messa
 
 		// The gas limit of the transaction (evm message) should always be higher than the gas overhead
 		// used to cover the l1 cost
-		// todo - this check has to be added to the mempool as well
 		if msg.GasLimit < l1Gas.Uint64() {
 			return nil, fmt.Errorf("%w. Want at least: %d have: %d", ErrGasNotEnoughForL1, l1Gas, msg.GasLimit)
 		}

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -327,7 +327,11 @@ func (s *RPCServer) ExportCrossChainData(ctx context.Context, request *generated
 func (s *RPCServer) GetRollupData(ctx context.Context, request *generated.GetRollupDataRequest) (*generated.GetRollupDataResponse, error) {
 	rollupMetadata, sysError := s.enclave.GetRollupData(ctx, gethcommon.BytesToHash(request.Hash))
 	if sysError != nil {
-		s.logger.Error("Error fetching rollup metadata", log.ErrKey, sysError)
+		if errors.Is(sysError, errutil.ErrNotFound) {
+			s.logger.Debug("Error fetching rollup metadata", log.ErrKey, sysError)
+		} else {
+			s.logger.Error("Error fetching rollup metadata", log.ErrKey, sysError)
+		}
 		return nil, sysError
 	}
 


### PR DESCRIPTION
### Why this change is needed

Check l1 costs on validators to return a meaningful error to the users

### What changes were made as part of this PR

- on validators check that the tx is submitted with enough gas to pay the l1 costs

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


