### PR TITLE
Tudor/fix maxgas

### DIFF
--- a/go/enclave/components/interfaces.go
+++ b/go/enclave/components/interfaces.go
@@ -51,8 +51,9 @@ type BatchExecutionContext struct {
 	ParentPtr common.L2BatchHash
 
 	// either use the transactions from an existing batch, or fetch transactions from the mempool
-	UseMempool   bool
-	Transactions common.L2Transactions
+	UseMempool    bool
+	Transactions  common.L2Transactions
+	BatchGasLimit uint64
 
 	AtTime      uint64
 	Creator     gethcommon.Address

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -503,6 +503,7 @@ func (rc *RollupCompression) executeAndSaveIncompleteBatches(ctx context.Context
 				incompleteBatch.seqNo,
 				incompleteBatch.coinbase,
 				incompleteBatch.baseFee,
+				incompleteBatch.gasLimit,
 			)
 			if err != nil {
 				return err
@@ -573,28 +574,20 @@ func (rc *RollupCompression) decryptDecompressAndDeserialise(blob []byte, obj an
 	return nil
 }
 
-func (rc *RollupCompression) computeBatch(
-	ctx context.Context,
-	BlockPtr common.L1BlockHash,
-	ParentPtr common.L2BatchHash,
-	Transactions common.L2Transactions,
-	AtTime uint64,
-	SequencerNo *big.Int,
-	Coinbase gethcommon.Address,
-	BaseFee *big.Int,
-) (*ComputedBatch, error) {
+func (rc *RollupCompression) computeBatch(ctx context.Context, BlockPtr common.L1BlockHash, ParentPtr common.L2BatchHash, Transactions common.L2Transactions, AtTime uint64, SequencerNo *big.Int, Coinbase gethcommon.Address, BaseFee *big.Int, gasLimit uint64) (*ComputedBatch, error) {
 	return rc.batchExecutor.ComputeBatch(
 		ctx,
 		&BatchExecutionContext{
-			BlockPtr:     BlockPtr,
-			ParentPtr:    ParentPtr,
-			UseMempool:   false,
-			Transactions: Transactions,
-			AtTime:       AtTime,
-			Creator:      Coinbase,
-			ChainConfig:  rc.chainConfig,
-			SequencerNo:  SequencerNo,
-			BaseFee:      big.NewInt(0).Set(BaseFee),
+			BlockPtr:      BlockPtr,
+			ParentPtr:     ParentPtr,
+			UseMempool:    false,
+			BatchGasLimit: gasLimit,
+			Transactions:  Transactions,
+			AtTime:        AtTime,
+			Creator:       Coinbase,
+			ChainConfig:   rc.chainConfig,
+			SequencerNo:   SequencerNo,
+			BaseFee:       big.NewInt(0).Set(BaseFee),
 		}, false)
 }
 

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -227,15 +227,16 @@ func (s *sequencer) produceBatch(
 ) (*components.ComputedBatch, error) {
 	cb, err := s.batchProducer.ComputeBatch(ctx,
 		&components.BatchExecutionContext{
-			BlockPtr:     l1Hash,
-			ParentPtr:    headBatch,
-			UseMempool:   useMempool,
-			Transactions: transactions,
-			AtTime:       batchTime,
-			Creator:      s.settings.GasPaymentAddress,
-			BaseFee:      s.settings.BaseFee,
-			ChainConfig:  s.chainConfig,
-			SequencerNo:  sequencerNo,
+			BlockPtr:      l1Hash,
+			ParentPtr:     headBatch,
+			UseMempool:    useMempool,
+			BatchGasLimit: s.settings.BatchGasLimit,
+			Transactions:  transactions,
+			AtTime:        batchTime,
+			Creator:       s.settings.GasPaymentAddress,
+			BaseFee:       s.settings.BaseFee,
+			ChainConfig:   s.chainConfig,
+			SequencerNo:   sequencerNo,
 		}, failForEmptyBatch)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing batch. Cause: %w", err)


### PR DESCRIPTION
### Why this change is needed

Validators used the configured batch max gas limit instead of the one specified on chain.

### What changes were made as part of this PR

- only the sequencer uses the configured gas limit

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


