### PR TITLE
host should return only confirmed batches

### DIFF
--- a/go/common/host/host.go
+++ b/go/common/host/host.go
@@ -35,6 +35,9 @@ type Host interface {
 	// NewHeadsChan returns live batch headers
 	// Note - do not use directly. This is meant only for the NewHeadsManager, which multiplexes the headers
 	NewHeadsChan() chan *common.BatchHeader
+
+	// ConfirmedHeadBatch retrieves the most recent batch processed by the enclave
+	ConfirmedHeadBatch() (*common.BatchHeader, error)
 }
 
 type BatchMsg struct {

--- a/go/common/host/services.go
+++ b/go/common/host/services.go
@@ -133,6 +133,7 @@ type L2BatchRepository interface {
 	FetchBatchBySeqNo(background context.Context, seqNo *big.Int) (*common.ExtBatch, error)
 
 	FetchLatestBatchSeqNo() *big.Int
+	FetchLatestValidatedBatchSeqNo() *big.Int
 
 	// AddBatch is used to notify the repository of a new batch, e.g. from the enclave when seq produces one or a rollup is consumed
 	// Note: it is fine to add batches that the repo already has, it will just ignore them

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -280,6 +280,18 @@ func (h *host) NewHeadsChan() chan *common.BatchHeader {
 	return h.newHeads
 }
 
+func (h *host) ConfirmedHeadBatch() (*common.BatchHeader, error) {
+	seqNo := h.services.L2Repo().FetchLatestValidatedBatchSeqNo()
+	if seqNo == nil {
+		return nil, responses.ToInternalError(fmt.Errorf("no confirmed head batch found"))
+	}
+	b, err := h.storage.FetchBatchBySeqNo(seqNo.Uint64())
+	if err != nil {
+		return nil, err
+	}
+	return b.Header, nil
+}
+
 // Checks the host config is valid.
 func (h *host) validateConfig() {
 	if h.config.IsGenesis && h.config.NodeType != common.Sequencer {

--- a/go/host/l2/batchrepository.go
+++ b/go/host/l2/batchrepository.go
@@ -182,6 +182,10 @@ func (r *Repository) FetchLatestBatchSeqNo() *big.Int {
 	return r.latestBatchSeqNo
 }
 
+func (r *Repository) FetchLatestValidatedBatchSeqNo() *big.Int {
+	return r.latestValidatedSeqNo
+}
+
 // AddBatch allows the host to add a batch to the repository, this is used:
 // - when the node is a sequencer to store newly produced batches (the only way the sequencer host receives batches)
 // - when the node is a validator to store batches read from roll-ups

--- a/go/host/rpc/clientapi/client_api_chain.go
+++ b/go/host/rpc/clientapi/client_api_chain.go
@@ -37,13 +37,12 @@ func (api *ChainAPI) ChainId() (*hexutil.Big, error) { //nolint:stylecheck,reviv
 
 // BatchNumber returns the height of the current head batch.
 func (api *ChainAPI) BatchNumber() hexutil.Uint64 {
-	header, err := api.host.Storage().FetchHeadBatchHeader()
+	enclaveHeadBatch, err := api.host.ConfirmedHeadBatch()
 	if err != nil {
-		// This error may be nefarious, but unfortunately the Eth API doesn't allow us to return an error.
 		api.logger.Error("could not retrieve head batch header", log.ErrKey, err)
 		return 0
 	}
-	return hexutil.Uint64(header.Number.Uint64())
+	return hexutil.Uint64(enclaveHeadBatch.Number.Uint64())
 }
 
 // GetBatchByNumber returns the header of the batch with the given height.


### PR DESCRIPTION
### Why this change is needed

We get a lot of errors like this:

> ERROR[02-21|10:43:11.640] Error getting receipt                    node_id=0xBD0D613bCbDbcC93abE025117564cc4435896A5F cmp=enclave err="unable to get balance - unable to get blockchain state - batch with requested height 249443 could not be retrieved. Cause: not found"

because the host returns batches that were not processed yet by the enclave.

### What changes were made as part of this PR

only return confirmed batches as the head

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


