### PR TITLE
use shorter error for user not found

### DIFF
--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -208,7 +208,11 @@ func extractUserForRequest(ctx context.Context, w *services.Services) (*common.G
 	}
 	user, err := w.Storage.GetUser(userID)
 	if err != nil {
-		return nil, fmt.Errorf("authentication failed: %w", err)
+		// Check if it's a "not found" error from CosmosDB
+		if strings.Contains(err.Error(), "NotFound") {
+			return nil, fmt.Errorf("authentication failed: user not found")
+		}
+		return nil, fmt.Errorf("authentication failed: %v", err)
 	}
 	return user, nil
 }


### PR DESCRIPTION
### Why this change is needed

We saw some error logs that were very long because of the CosmosDB error message. It was confusing and appeared as there is something wrong with CosmosDB instance.
It turns out that just someone tried to make a call with non existing user (or old user - before migration to cosmosDB).. we can expect more errors like those in the future so I am creating smaller error message in this case.

### What changes were made as part of this PR

Check error message and if it is the case that it is "Not found" error message, then we should print custom error, otherwise print full error as it might indicate other issues with CosmosDB.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


