### PR TITLE
Deploy: require confirmation for sepolia deployments

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -5,6 +5,8 @@
 #
 # This script uses GitHub Environments for variables (vars) and secrets - these are configured on GitHub and
 #  the environments match the input.testnet_type options
+#
+# To deploy sepolia the user must type 'confirm' in the confirmation field
 
 name: '[M] Deploy Testnet L2'
 run-name: '[M] Deploy Testnet L2 ( ${{ github.event.inputs.testnet_type }} )'
@@ -25,6 +27,10 @@ on:
         required: true
         default: 3
         type: number
+      confirmation:
+          description: 'Type "confirm" if deploying sepolia'
+          required: false
+          type: string
 
 jobs:
   build:
@@ -40,6 +46,14 @@ jobs:
 
 
     steps:
+      - name: 'Check confirmation'
+        # if env is sepolia then confirmation field needs to say 'confirm'
+        run: |
+          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to deploy sepolia to avoid accidental deployments"
+            exit 1
+          fi
+
       - name: 'Print GitHub variables'
         # This is a useful record of what the environment variables were at the time the job ran, for debugging and reference
         run: |

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -10,6 +10,8 @@
 #
 # This script uses GitHub Environments for variables (vars) and secrets - these are configured on GitHub and
 #  the environments match the input.testnet_type options
+#
+# To upgrade sepolia the user must type 'confirm' in the confirmation field
 
 name: '[M] Upgrade Testnet L2'
 run-name: '[M] Upgrade Testnet L2 ( ${{ github.event.inputs.testnet_type }} )'
@@ -32,6 +34,10 @@ on:
         required: true
         default: 3
         type: number
+      confirmation:
+        description: 'Type "confirm" if upgrading sepolia'
+        required: false
+        type: string
 
 jobs:
   build:
@@ -43,6 +49,14 @@ jobs:
       VM_BUILD_NUMBER: ${{ steps.outputVars.outputs.VM_BUILD_NUMBER }}
 
     steps:
+      - name: 'Check confirmation'
+        # if env is sepolia then confirmation field needs to say 'confirm'
+        run: |
+          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to upgrade sepolia to avoid accidental upgrades"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
### Why this change is needed

Reduce risk by requiring user to type 'confirm' to deploy/upgrade sepolia.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


