### PR TITLE
fix races

### DIFF
--- a/tools/walletextension/ratelimiter/rate_limiter.go
+++ b/tools/walletextension/ratelimiter/rate_limiter.go
@@ -193,7 +193,7 @@ func (rl *RateLimiter) Allow(userID common.Address) (bool, uuid.UUID) {
 	// Check if the user has reached the maximum number of concurrent requests
 	if uint32(rl.CountOpenRequests(userID)) >= rl.GetMaxConcurrentRequest() {
 		rl.IncrementRateLimitedRequests()
-		rl.logger.Info("User %s has reached the maximum number of concurrent requests.", userID.Hex())
+		rl.logger.Info("User has reached the maximum number of concurrent requests.", "uid", userID.Hex())
 		return false, zeroUUID
 	}
 

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -95,10 +95,10 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 	// w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(user.ID))
 
 	rateLimitAllowed, requestUUID := w.RateLimiter.Allow(gethcommon.Address(user.ID))
-	defer w.RateLimiter.SetRequestEnd(gethcommon.Address(user.ID), requestUUID)
 	if !rateLimitAllowed {
 		return nil, fmt.Errorf("rate limit exceeded")
 	}
+	defer w.RateLimiter.SetRequestEnd(gethcommon.Address(user.ID), requestUUID)
 
 	cacheArgs := []any{user.ID, method}
 	cacheArgs = append(cacheArgs, args...)


### PR DESCRIPTION
### Why this change is needed

Fix potential race conditions in the gateway.

### What changes were made as part of this PR

- cache.lastEviction is atomic
- use `singleflight` to serialise (and optimise) requests to the same cache entry
- in the ratelimiter, mark a request ending only if it was started

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


