### PR TITLE
Testnet: re-enable HA enclaves in testnet deployments

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -213,8 +213,7 @@ jobs:
          run: |
            if [[ ${{ matrix.host_id }} -eq 0 ]]; then
              echo "VM_SIZE=Standard_DC8s_v3" >> $GITHUB_ENV
-             # HA disabled, only 1 enclave for now
-             echo "NUM_ENCLAVES=1" >> $GITHUB_ENV 
+             echo "NUM_ENCLAVES=2" >> $GITHUB_ENV 
            else
              echo "VM_SIZE=Standard_DC8_v2" >> $GITHUB_ENV
              echo "NUM_ENCLAVES=1" >> $GITHUB_ENV

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -148,8 +148,8 @@ jobs:
             host_id: 1
           - node_l1_ws_lookup: L1_WS_URL_2
             host_id: 2
-          # sequencer has an HA setup with 2 enclaves TODO: HA DISABLED HERE, switch back to 2 enclaves when stable
-          - num_enclaves: 1
+          # sequencer has an HA setup with 2 enclaves
+          - num_enclaves: 2
             host_id: 0
           - num_enclaves: 1
             host_id: 1

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -25,8 +25,8 @@ func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		[]string{"http://erpc.sepolia-testnet.ten.xyz:80"},
 		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"wss://ethereum-sepolia-rpc.publicnode.com",
-		"https://rpc.testnet.ten.xyz",
-		"wss://rpc.testnet.ten.xyz:81",
+		"https://rpc.testnet.ten.xyz",  //"https://rpc.dexynth-gateway.ten.xyz",
+		"wss://rpc.testnet.ten.xyz:81", // "wss://rpc.dexynth-gateway.ten.xyz:81",
 	)
 	return newTestnetEnv(connector, opts...)
 }


### PR DESCRIPTION
### Why this change is needed

We turned off the second enclave because of fragility in testnets but with recent commits that should be solved on main now.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


