### PR TITLE
small fixes

### DIFF
--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -13,7 +13,7 @@ network:
     interval: 5s
     maxInterval: 10m # rollups will be produced after this time even if the data blob is not full
     maxSize: 131072 # 128kb - the size of a blob
-  gas: # todo: ask stefan about these fields
+  gas:
     baseFee: 100000000
     minGasPrice: 100000000
     paymentAddress: 0xd6C9230053f45F873Cb66D8A02439380a37A4fbF

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -100,11 +100,10 @@ func DeterministicEmptyBatch(parent *common.BatchHeader, block *types.Header, ti
 		L1Proof:          block.Hash(),
 		Number:           big.NewInt(0).Add(parent.Number, big.NewInt(1)),
 		SequencerOrderNo: sequencerNo,
-		// todo (#1548) - Consider how this time should align with the time of the L1 block used as proof.
-		Time:     time,
-		BaseFee:  baseFee,
-		Coinbase: coinbase,
-		GasLimit: gasLimit,
+		Time:             time,
+		BaseFee:          baseFee,
+		Coinbase:         coinbase,
+		GasLimit:         gasLimit,
 	}
 	b := Batch{
 		Header: &h,

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -29,7 +29,6 @@ func NewTenMessageBusManager(
 	storage storage.Storage,
 	logger gethlog.Logger,
 ) Manager {
-	// todo (#1549) - implement with cryptography epic, remove this key and use the DeriveKey
 	logger = logger.New(log.CmpKey, log.CrossChainCmp)
 
 	return &MessageBusManager{

--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -14,10 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// PoolAddress - address of the pool where the gas will go
-// todo (#627) - this has to be reworked when the gas/fee work starts
-var PoolAddress = common.HexToAddress("0x0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A")
-
 // NoOpConsensusEngine - implements the geth consensus.Engine, but doesn't do anything
 // This is needed for running evm transactions
 type NoOpConsensusEngine struct {
@@ -26,7 +22,7 @@ type NoOpConsensusEngine struct {
 
 // Author is used to determine where to send the gas collected from the fees.
 func (e *NoOpConsensusEngine) Author(_ *types.Header) (common.Address, error) {
-	return PoolAddress, nil
+	return common.Address{}, nil
 }
 
 func (e *NoOpConsensusEngine) VerifyHeader(_ consensus.ChainHeaderReader, _ *types.Header) error {

--- a/go/enclave/evm/no_op_engine.go
+++ b/go/enclave/evm/no_op_engine.go
@@ -14,6 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// PoolAddress - address of the pool where the gas will go
+// todo (#627) - this has to be reworked when the gas/fee work starts
+var PoolAddress = common.HexToAddress("0x0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A")
+
 // NoOpConsensusEngine - implements the geth consensus.Engine, but doesn't do anything
 // This is needed for running evm transactions
 type NoOpConsensusEngine struct {
@@ -22,7 +26,7 @@ type NoOpConsensusEngine struct {
 
 // Author is used to determine where to send the gas collected from the fees.
 func (e *NoOpConsensusEngine) Author(_ *types.Header) (common.Address, error) {
-	return common.Address{}, nil
+	return PoolAddress, nil
 }
 
 func (e *NoOpConsensusEngine) VerifyHeader(_ consensus.ChainHeaderReader, _ *types.Header) error {

--- a/go/enclave/rpc_server.go
+++ b/go/enclave/rpc_server.go
@@ -269,7 +269,6 @@ func (s *RPCServer) GetBatch(ctx context.Context, request *generated.GetBatchReq
 	batch, err := s.enclave.GetBatch(ctx, gethcommon.BytesToHash(request.KnownHead))
 	if err != nil {
 		s.logger.Error("Error getting batch", log.ErrKey, err)
-		// todo  do we want to exit here or return the usual response
 		return nil, err
 	}
 
@@ -291,7 +290,6 @@ func (s *RPCServer) GetBatchBySeqNo(ctx context.Context, request *generated.GetB
 	batch, err := s.enclave.GetBatchBySeqNo(ctx, request.SeqNo)
 	if err != nil {
 		s.logger.Error("Error getting batch by seq", log.ErrKey, err)
-		// todo  do we want to exit here or return the usual response
 		return nil, err
 	}
 

--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -79,7 +79,7 @@ var defaultCacheConfig = &gethcore.CacheConfig{
 	TrieTimeLimit:  5 * time.Minute,
 	SnapshotLimit:  256,
 	SnapshotWait:   true,
-	StateScheme:    rawdb.HashScheme, // todo - change to rawdb.PathScheme for next release
+	StateScheme:    rawdb.PathScheme,
 }
 
 var trieDBConfig = &triedb.Config{

--- a/go/ethadapter/interface.go
+++ b/go/ethadapter/interface.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 
-	"github.com/ten-protocol/go-ten/go/common"
-
 	"github.com/ethereum/go-ethereum"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -15,7 +13,6 @@ import (
 )
 
 // EthClient defines the interface for RPC communications with the ethereum nodes
-// todo (#1617) - some of these methods are composed calls that should be decoupled in the future (ie: BlocksBetween or IsBlockAncestor)
 type EthClient interface {
 	BlockNumber() (uint64, error)                                                 // retrieves the number of the head block
 	FetchHeadBlock() (*types.Header, error)                                       // retrieves the block at head height
@@ -40,8 +37,6 @@ type EthClient interface {
 	SupportsEventLogs() bool                                                      // returns false for the in-mem simulation
 
 	// todo - all the below should be removed from the interface
-	BlocksBetween(block *types.Header, head *types.Header) ([]*types.Header, error) // returns the blocks between two blocks
-	IsBlockAncestor(block *types.Header, maybeAncestor common.L1BlockHash) bool     // returns if the node considers a block the ancestor
 	FetchLastBatchSeqNo(address gethcommon.Address) (*big.Int, error)
 }
 

--- a/go/ethadapter/utils.go
+++ b/go/ethadapter/utils.go
@@ -137,7 +137,7 @@ func BlocksBetween(e EthClient, startBlock *types.Header, endBlock *types.Header
 	tempBlock := endBlock
 	for {
 		path = append(path, tempBlock)
-		if tempBlock.Hash() == startHash {
+		if (tempBlock.Hash() == startHash) || (tempBlock.ParentHash == gethcommon.HexToHash("")) {
 			break
 		}
 		parent, err := e.HeaderByHash(tempBlock.ParentHash)

--- a/integration/simulation/simulation.go
+++ b/integration/simulation/simulation.go
@@ -141,7 +141,7 @@ func (s *Simulation) waitForTenGenesisOnL1() {
 			panic(fmt.Errorf("could not fetch head block. Cause: %w", err))
 		}
 		if err == nil {
-			blocks, err := client.BlocksBetween(ethereummock.MockGenesisBlock.Header(), head)
+			blocks, err := ethadapter.BlocksBetween(client, ethereummock.MockGenesisBlock.Header(), head)
 			if err != nil {
 				continue
 			}

--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -253,7 +253,7 @@ func ExtractDataFromEthereumChain(startBlock *types.Header, endBlock *types.Head
 	rollupReceipts := make(types.Receipts, 0)
 	totalDeposited := big.NewInt(0)
 
-	blockchain, err := node.BlocksBetween(startBlock, endBlock)
+	blockchain, err := ethadapter.BlocksBetween(node, startBlock, endBlock)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Why this change is needed

Move to the go-ethereum statedb "Path scheme" (from the "Hash scheme" which is deprecated).
General cleanup

### What changes were made as part of this PR

- use PathScheme
- remove todos
- remove unnecessary functions from the `EthClient` and move to utils

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


