### PR TITLE
optimize rollup processing and increase rollup timeout

### DIFF
--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -11,7 +11,7 @@ network:
     maxSize: 125952 # (128-5)kb - the size of the rollup minus overhead
   rollup:
     interval: 5s
-    maxInterval: 10m # rollups will be produced after this time even if the data blob is not full
+    maxInterval: 120m # rollups will be produced after this time even if the data blob is not full
     maxSize: 131072 # 128kb - the size of a blob
   gas:
     baseFee: 100000000

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -90,6 +90,21 @@ func (rc *rollupConsumerImpl) ProcessRollup(ctx context.Context, rollup *common.
 		rc.logger.Warn("Skipping rollup because it was compressed on top of a non-canonical block", "block_hash", rollup.Header.CompressionL1Head, log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
 		return nil, nil
 	}
+
+	// if all batches included in this rollup exist, we don't need to process
+	lastBatch, err := rc.storage.FetchBatchBySeqNo(ctx, rollup.Header.LastBatchSeqNo)
+	if err == nil {
+		// check that the stored batches match the rollup
+		if lastBatch.Hash() != rollup.Header.LastBatchHash {
+			rc.logger.Error("Last batch hash mismatch", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
+			return nil, fmt.Errorf(
+				"last batch hash mismatch. Expected %s, got %s",
+				rollup.Header.LastBatchHash.Hex(),
+				lastBatch.Hash().Hex(),
+			)
+		}
+	}
+
 	// read batch data from rollup, verify and store it
 	internalHeader, err := rc.rollupCompression.ProcessExtRollup(ctx, rollup)
 	if err != nil {

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -91,10 +91,16 @@ func (rc *rollupConsumerImpl) ProcessRollup(ctx context.Context, rollup *common.
 		return nil, nil
 	}
 
+	internalHeader := new(common.CalldataRollupHeader)
+	err = rc.rollupCompression.DecryptDecompressAndDeserialise(rollup.CalldataRollupHeader, internalHeader)
+	if err != nil {
+		return nil, err
+	}
+
 	// if all batches included in this rollup exist, we don't need to process
 	lastBatch, err := rc.storage.FetchBatchBySeqNo(ctx, rollup.Header.LastBatchSeqNo)
 	if err == nil {
-		// check that the stored batches match the rollup
+		// security check that the stored batches match the rollup
 		if lastBatch.Hash() != rollup.Header.LastBatchHash {
 			rc.logger.Error("Last batch hash mismatch", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
 			return nil, fmt.Errorf(
@@ -103,15 +109,21 @@ func (rc *rollupConsumerImpl) ProcessRollup(ctx context.Context, rollup *common.
 				lastBatch.Hash().Hex(),
 			)
 		}
+		return rc.storeRollupAndGenerateMetadata(ctx, rollup, internalHeader)
 	}
 
 	// read batch data from rollup, verify and store it
-	internalHeader, err := rc.rollupCompression.ProcessExtRollup(ctx, rollup)
+	err = rc.rollupCompression.ProcessExtRollup(ctx, rollup, internalHeader)
 	if err != nil {
 		rc.logger.Error("Failed processing rollup", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
 		// todo - issue challenge as a validator
 		return nil, err
 	}
+
+	return rc.storeRollupAndGenerateMetadata(ctx, rollup, internalHeader)
+}
+
+func (rc *rollupConsumerImpl) storeRollupAndGenerateMetadata(ctx context.Context, rollup *common.ExtRollup, internalHeader *common.CalldataRollupHeader) (*common.ExtRollupMetadata, error) {
 	if err := rc.storage.StoreRollup(ctx, rollup, internalHeader); err != nil {
 		rc.logger.Error("Failed storing rollup", log.RollupHashKey, rollup.Hash(), log.ErrKey, err)
 		return nil, err
@@ -126,7 +138,6 @@ func (rc *rollupConsumerImpl) ProcessRollup(ctx context.Context, rollup *common.
 	rollupMetadata := common.ExtRollupMetadata{
 		CrossChainTree: serializedTree,
 	}
-
 	return &rollupMetadata, nil
 }
 

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -373,6 +373,7 @@ func (e *enclaveAdminService) StreamL2Updates() (chan common.StreamL2UpdatesResp
 	}
 
 	e.registry.SubscribeForExecutedBatches(func(batch *core.Batch, receipts types.Receipts) {
+		defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "stream batch")
 		e.sendBatch(batch, l2UpdatesChannel)
 		if receipts != nil {
 			e.streamEventsForNewHeadBatch(context.Background(), batch, receipts, l2UpdatesChannel)


### PR DESCRIPTION
### Why this change is needed

To match the production setup, rollups must be able to be produced less frequently, when usage it low, to optimize costs

### What changes were made as part of this PR

- increase the rollup timeout to 2hrs
- optimize rollup processing. The validator can skip when the last batch exists and the hash matches.

Todo: as part of a different PR, the sequencer will produce rollups on the backup enclave.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


