### PR TITLE
Host: handle promotion for single-enclave node recovery

### DIFF
--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -133,7 +133,7 @@ func (e *Service) GetEnclaveClients() []common.Enclave {
 // NotifyUnavailable is called by enclave guardians when they detect that the enclave is unavailable.
 // If this is a sequencer host then this function will start a search for a live standby enclave to promote to active sequencer.
 func (e *Service) NotifyUnavailable(enclaveID *common.EnclaveID) {
-	if len(e.enclaveGuardians) <= 1 || e.activeSequencerID.Load() != enclaveID {
+	if e.activeSequencerID.Load() != enclaveID {
 		e.logger.Debug("Failed enclave is not an active sequencer on an HA node, no action required.", log.EnclaveIDKey, enclaveID)
 		return
 	}
@@ -149,6 +149,7 @@ func (e *Service) NotifyUnavailable(enclaveID *common.EnclaveID) {
 		return
 	}
 	e.enclaveGuardians[failedEnclaveIdx].DemoteFromActiveSequencer()
+	e.activeSequencerID.Store(_noActiveSequencer)
 
 	go e.promoteNewActiveSequencer()
 }
@@ -187,7 +188,6 @@ func (e *Service) Unsubscribe(id rpc.ID) error {
 // promoteNewActiveSequencer is a background goroutine that promotes a new active sequencer at startup or when the current one fails.
 // It will never give up, it just cycles through current enclaves until one can be successfully promoted.
 func (e *Service) promoteNewActiveSequencer() {
-	e.activeSequencerID.Store(_noActiveSequencer)
 	for e.activeSequencerID.Load() == _noActiveSequencer && e.running.Load() {
 		for _, guardian := range e.enclaveGuardians {
 			enclID := guardian.GetEnclaveID()

--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -134,7 +134,7 @@ func (e *Service) GetEnclaveClients() []common.Enclave {
 // If this is a sequencer host then this function will start a search for a live standby enclave to promote to active sequencer.
 func (e *Service) NotifyUnavailable(enclaveID *common.EnclaveID) {
 	if e.activeSequencerID.Load() != enclaveID {
-		e.logger.Debug("Failed enclave is not an active sequencer on an HA node, no action required.", log.EnclaveIDKey, enclaveID)
+		e.logger.Debug("Failed enclave is not an active sequencer, no action required.", log.EnclaveIDKey, enclaveID)
 		return
 	}
 	failedEnclaveIdx := -1


### PR DESCRIPTION
### Why this change is needed

This change addresses an issue with single enclave nodes where the host would not promote the enclave after it was restarted.

### What changes were made as part of this PR

Host changed to behave the same with promoting dead enclaves, regardless of how many enclaves are configured.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


