### PR TITLE
Host: log l1 tx failures between retries

### DIFF
--- a/go/common/retry/retry.go
+++ b/go/common/retry/retry.go
@@ -17,7 +17,6 @@ func DoWithCount(fn func(int) error, retryStrat Strategy) error {
 	retryStrat.Reset()
 	retryNr := 0
 	for {
-		retryNr++
 		// attempt to execute the function
 		err := fn(retryNr)
 		if err == nil {
@@ -25,6 +24,7 @@ func DoWithCount(fn func(int) error, retryStrat Strategy) error {
 			return nil
 		}
 
+		retryNr++
 		var ffErr *FailFastError
 		if errors.As(err, &ffErr) {
 			// if error has been wrapped as fail fast then we don't continue to retry


### PR DESCRIPTION
### Why this change is needed

Silent failures making it hard to diagnose testnet issues. Particularly for L1 tx (non-blobs) which retry forever.

Also Tudor recently added a WithCount version for the retry func so seems like a good fit here.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


