### PR TITLE
Skip beacon provider tests for now 

### DIFF
--- a/go/ethadapter/blob_beacon_client_test.go
+++ b/go/ethadapter/blob_beacon_client_test.go
@@ -124,7 +124,8 @@ func TestBlobEncodingLarge(t *testing.T) {
 }
 
 func TestBlobArchiveClient(t *testing.T) {
-	client := NewArchivalHTTPClient(new(http.Client), "https://api.ethernow.xyz")
+	t.Skipf("TODO need to fix this")
+	client := NewArchivalHTTPClient(new(http.Client), "https://eth-beacon-chain.drpc.org/rest/")
 	vHashes := []gethcommon.Hash{gethcommon.HexToHash(vHash1), gethcommon.HexToHash(vHash2)}
 	ctx := context.Background()
 

--- a/go/host/l1/blobresolver_test.go
+++ b/go/host/l1/blobresolver_test.go
@@ -18,6 +18,7 @@ const (
 )
 
 func TestBlobResolver(t *testing.T) {
+	t.Skipf("TODO need to work out new params that will work with a new fallback provider")
 	beaconClient := ethadapter.NewBeaconHTTPClient(new(http.Client), "https://docs-demo.quiknode.pro/")
 	fallback := ethadapter.NewArchivalHTTPClient(new(http.Client), "https://api.ethernow.xyz")
 	blobResolver := NewBlobResolver(ethadapter.NewL1BeaconClient(beaconClient, fallback), nil)


### PR DESCRIPTION
### Why this change is needed

One of the providers has deprecated their API. Need to spend time finding the right mixture of request params to trigger a failure on one provider to fall to the next. 

### What changes were made as part of this PR

Skipped them for now as low priority

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


