### PR TITLE
move driver wrapper to common and use it for the host postgres db

### DIFF
--- a/go/common/storage/driver_wrapper.go
+++ b/go/common/storage/driver_wrapper.go
@@ -8,7 +8,7 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-// PanicOnDBErrorDriver wraps an SQL driver and panics on connection refused errors
+// PanicOnDBErrorDriver wraps an SQL driver and panics on unexpected errors
 type PanicOnDBErrorDriver struct {
 	driver.Driver
 	logger     gethlog.Logger

--- a/go/common/storage/driver_wrapper.go
+++ b/go/common/storage/driver_wrapper.go
@@ -8,7 +8,7 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-// PanicOnDBErrorDriver wraps the MySQL driver and panics on connection refused errors
+// PanicOnDBErrorDriver wraps an SQL driver and panics on connection refused errors
 type PanicOnDBErrorDriver struct {
 	driver.Driver
 	logger     gethlog.Logger

--- a/go/common/storage/driver_wrapper.go
+++ b/go/common/storage/driver_wrapper.go
@@ -1,0 +1,69 @@
+package storage
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
+)
+
+// PanicOnDBErrorDriver wraps the MySQL driver and panics on connection refused errors
+type PanicOnDBErrorDriver struct {
+	driver.Driver
+	logger     gethlog.Logger
+	isCritical func(error) bool
+}
+
+// NewPanicOnDBErrorDriver is a constructor for PanicOnDBErrorDriver
+func NewPanicOnDBErrorDriver(driver driver.Driver, logger gethlog.Logger, isCritical func(error) bool) *PanicOnDBErrorDriver {
+	return &PanicOnDBErrorDriver{
+		Driver:     driver,
+		logger:     logger,
+		isCritical: isCritical,
+	}
+}
+
+// Open implements the driver.Driver interface
+func (d *PanicOnDBErrorDriver) Open(dsn string) (driver.Conn, error) {
+	conn, err := d.Driver.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &panicOnErrorConn{Conn: conn, logger: d.logger, isCritical: d.isCritical}, nil
+}
+
+// panicOnErrorConn wraps a driver.Conn and panics on connection refused errors
+type panicOnErrorConn struct {
+	driver.Conn
+	driver.ExecerContext
+	driver.QueryerContext
+	logger     gethlog.Logger
+	isCritical func(error) bool
+}
+
+func (c *panicOnErrorConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	result, err := execer.ExecContext(ctx, query, args)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database operation failed with connection refused: %v", err))
+	}
+	return result, err
+}
+
+func (c *panicOnErrorConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	rows, err := queryer.QueryContext(ctx, query, args)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database query failed with connection refused: %v", err))
+	}
+	return rows, err
+}

--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"database/sql"
-	"database/sql/driver"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -24,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ten-protocol/go-ten/go/common/storage"
 
 	"github.com/ten-protocol/go-ten/go/common/log"
 	enclaveconfig "github.com/ten-protocol/go-ten/go/enclave/config"
@@ -132,8 +133,6 @@ type Credentials struct {
 
 // Connector (re-)establishes a connection to the Edgeless DB for the TEN enclave
 func Connector(edbCfg *Config, config *enclaveconfig.EnclaveConfig, logger gethlog.Logger) (enclavedb.EnclaveDB, error) {
-	RegisterPanicOnConnectionRefusedDriver(logger)
-
 	// rather than fail immediately if EdgelessDB is not available yet we wait up for `edgelessDBStartTimeout` for it to be available
 	err := waitForEdgelessDBToStart(edbCfg.Host, logger)
 	if err != nil {
@@ -462,6 +461,7 @@ func verifyEdgelessDB(edbHost string, m *manifest, httpClient *http.Client, logg
 }
 
 func ConnectToEdgelessDB(edbHost string, tlsCfg *tls.Config, logger gethlog.Logger) (*sql.DB, error) {
+	driverName := registerPanicOnConnectionRefusedDriver(logger)
 	err := mysql.RegisterTLSConfig("custom", tlsCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register tls config for mysql connection - %w", err)
@@ -474,7 +474,7 @@ func ConnectToEdgelessDB(edbHost string, tlsCfg *tls.Config, logger gethlog.Logg
 	cfg.TLSConfig = "custom"
 	dsn := cfg.FormatDSN()
 	logger.Info(fmt.Sprintf("Configuring mysql connection: %s", dsn))
-	db, err := sql.Open("mysql-panic-on-refused", dsn)
+	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize mysql connection to edb - %w", err)
 	}
@@ -482,56 +482,16 @@ func ConnectToEdgelessDB(edbHost string, tlsCfg *tls.Config, logger gethlog.Logg
 	return db, nil
 }
 
-// PanicOnConnectionRefusedDriver wraps the MySQL driver and panics on connection refused errors
-type PanicOnConnectionRefusedDriver struct {
-	driver.Driver
-	logger gethlog.Logger
-}
-
-// Open implements the driver.Driver interface
-func (d *PanicOnConnectionRefusedDriver) Open(dsn string) (driver.Conn, error) {
-	conn, err := d.Driver.Open(dsn)
-	if err != nil {
-		return nil, err
-	}
-	return &panicOnErrorConn{Conn: conn, logger: d.logger}, nil
-}
-
-// panicOnErrorConn wraps a driver.Conn and panics on connection refused errors
-type panicOnErrorConn struct {
-	driver.Conn
-	driver.ExecerContext
-	driver.QueryerContext
-	logger gethlog.Logger
-}
-
-func (c *panicOnErrorConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	execer, ok := c.Conn.(driver.ExecerContext)
-	if !ok {
-		return nil, driver.ErrSkip
-	}
-
-	result, err := execer.ExecContext(ctx, query, args)
-	if err != nil && strings.Contains(err.Error(), "connection refused") {
-		c.logger.Crit(fmt.Sprintf("Database operation failed with connection refused: %v", err))
-	}
-	return result, err
-}
-
-func (c *panicOnErrorConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	queryer, ok := c.Conn.(driver.QueryerContext)
-	if !ok {
-		return nil, driver.ErrSkip
-	}
-
-	rows, err := queryer.QueryContext(ctx, query, args)
-	if err != nil && strings.Contains(err.Error(), "connection refused") {
-		c.logger.Crit(fmt.Sprintf("Database query failed with connection refused: %v", err))
-	}
-	return rows, err
-}
-
-// RegisterPanicOnConnectionRefusedDriver registers the custom driver
-func RegisterPanicOnConnectionRefusedDriver(logger gethlog.Logger) {
-	sql.Register("mysql-panic-on-refused", &PanicOnConnectionRefusedDriver{Driver: &mysql.MySQLDriver{}, logger: logger})
+// registerPanicOnConnectionRefusedDriver registers the custom driver
+func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
+	driverName := "mysql-panic-on-refused"
+	sql.Register(driverName,
+		storage.NewPanicOnDBErrorDriver(
+			&mysql.MySQLDriver{},
+			logger,
+			func(err error) bool {
+				return strings.Contains(err.Error(), "connection refused")
+			}),
+	)
+	return driverName
 }

--- a/go/host/storage/db_init.go
+++ b/go/host/storage/db_init.go
@@ -28,7 +28,7 @@ func CreateDBFromConfig(cfg *hostconfig.HostConfig, logger gethlog.Logger) (host
 		return hostdb.NewHostDB(sqliteDB, hostdb.SQLiteSQLStatements())
 	}
 	logger.Info(fmt.Sprintf("Preparing Postgres DB connection to %s...", cfg.PostgresDBHost))
-	postgresDB, err := postgres.CreatePostgresDBConnection(cfg.PostgresDBHost, dbName)
+	postgresDB, err := postgres.CreatePostgresDBConnection(cfg.PostgresDBHost, dbName, logger)
 	if err != nil {
 		return nil, fmt.Errorf("could not create postresql connection: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

When the host database dies, we encounter unexpected behaviour. It's better to just panic the host process and let it restart automatically when the db is back up

### What changes were made as part of this PR

- move the SQL driver wrapper to common
- use it for postgres
- small refactor and adding custom "isCritical" function

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


