### PR TITLE
Add set state root manager role to deployment scripts

### DIFF
--- a/contracts/deployment_scripts/core/001_deploy_contracts.ts
+++ b/contracts/deployment_scripts/core/001_deploy_contracts.ts
@@ -73,12 +73,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         log: true,
     });
 
+
     console.log(`NetworkConfig= ${networkConfigDeployment.address}`);
     console.log(`CrossChain= ${crossChainDeployment.address}`);
     console.log(`MerkleMessageBus= ${merkleMessageBusAddress}`);
     console.log(`NetworkEnclaveRegistry= ${networkEnclaveRegistryDeployment.address}`);
     console.log(`DataAvailabilityRegistry= ${daRegistryDeployment.address}`);
     console.log(`L1Start= ${networkConfigDeployment.receipt!!.blockHash}`);
+
+    // Get the MerkleTreeMessageBus contract instance
+    const merkleMessageBusContract = await hre.ethers.getContractAt('MerkleTreeMessageBus', merkleMessageBusAddress);
+    console.log(`Adding DataAvailabilityRegistry (${daRegistryDeployment.address}) as state root manager...`);
+    const tx = await merkleMessageBusContract.addStateRootManager(daRegistryDeployment.address);
+    await tx.wait();
+    console.log('Successfully added DataAvailabilityRegistry as state root manager');
 };
 
 export default func;

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -363,7 +363,7 @@ func (p *Publisher) publishBlobTxWithRetry(tx types.TxData, nonce uint64) error 
 		pricedTx, err := p.executeTransaction(tx, nonce, retryCount)
 		if pricedTx == nil {
 			// even if there was an error we expect pricedTx to be populated for common failures
-			return retry.FailFast(fmt.Errorf("could not price transaction"))
+			return retry.FailFast(fmt.Errorf("could not price transaction. Cause: %w", err))
 		}
 		if err != nil {
 			if retryCount > maxRetries {


### PR DESCRIPTION
### Why this change is needed

As part of the management contract refactor we now have an additional step where we need to grant the DARegistry contract the permission to add state roots to the MerkleMessageBus contract. 

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


