### PR TITLE
bump l1 receipt wait time

### DIFF
--- a/.github/workflows/build-gateway-lib.yml
+++ b/.github/workflows/build-gateway-lib.yml
@@ -7,7 +7,7 @@ on:
       - 'tools/gateway-js/'
     branches:
       - main
-      - releases/v1.0
+      - releases/v1.1
 
 jobs:
   build-and-publish:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,7 +9,7 @@ on:
       - 'planning/**'
     branches:
       - main
-      - releases/v1.0
+      - releases/v1.1
 
 jobs:
   build:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ on:
       - v*
     branches:
       - main
-      - releases/v1.0
+      - releases/v1.1
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/hardhat-pr-check.yml
+++ b/.github/workflows/hardhat-pr-check.yml
@@ -7,7 +7,7 @@ on:
       - 'contracts/**'
     branches:
       - main
-      - releases/v1.0
+      - releases/v1.1
 
 jobs:
   build:

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -101,7 +101,7 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo)
-	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying
+	maxWaitForL1Receipt := 50 * config.L1BlockTime  // wait ~50 blocks to see if tx gets published before retrying (10 minutes)
 	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
 	l1ChainCfg := common.GetL1ChainConfig(uint64(config.L1ChainID))
 	l1Publisher := l1.NewL1Publisher(


### PR DESCRIPTION
### Why this change is needed

To make publishing l1 txs more reliable

