### PR TITLE
Enclave: tweak to allow non-active sequencer to use CreateRollup

### DIFF
--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -300,7 +300,8 @@ func (e *enclaveAdminService) CreateRollup(ctx context.Context, fromSeqNo uint64
 		return nil, responses.ToInternalError(fmt.Errorf("not initialised yet"))
 	}
 
-	result, err := e.sequencer().CreateRollup(ctx, fromSeqNo)
+	// we use the sequencer service directly because backup sequencers don't have the service active, but they can still create rollups
+	result, err := e.sequencerService.CreateRollup(ctx, fromSeqNo)
 	if err != nil {
 		return nil, responses.ToInternalError(err)
 	}


### PR DESCRIPTION
### Why this change is needed

Stop backup enclave killing itself when it's asked to produce a rollup.

Allowing direct access to this service smells a bit, I think this services thing might need a slight refactor to more clearly fit the validator/sequencer/active-sequencer enclave types but couldn't see a clean way to achieve that under time pressure.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


