### PR TITLE
Host: include estimated transactions size in batches table

### DIFF
--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -21,7 +21,7 @@ const (
 	selectBatchSeqByTx  = "SELECT b_sequence FROM transaction_host WHERE hash = "
 	selectTxBySeq       = "SELECT hash FROM transaction_host WHERE b_sequence = "
 	selectBatchTxs      = "SELECT t.hash, b.sequence, b.height, b.ext_batch FROM transaction_host t JOIN batch_host b ON t.b_sequence = b.sequence"
-	selectSumBatchSizes = "SELECT SUM(LENGTH(ext_batch)) FROM batch_host WHERE sequence >= "
+	selectSumBatchSizes = "SELECT SUM(txs_size) FROM batch_host WHERE sequence >= "
 )
 
 // AddBatch adds a batch and its header to the DB
@@ -36,6 +36,7 @@ func AddBatch(dbtx *dbTransaction, statements *SQLStatements, batch *common.ExtB
 		batch.Hash(),                 // full hash
 		batch.Header.Number.Uint64(), // height
 		extBatch,                     // ext_batch
+		len(batch.EncryptedTxBlob),   // txs_size
 	)
 	if err != nil {
 		if IsRowExistsError(err) {

--- a/go/host/storage/hostdb/sql_statements.go
+++ b/go/host/storage/hostdb/sql_statements.go
@@ -23,7 +23,7 @@ func (s SQLStatements) GetPlaceHolder(pos int) string {
 
 func SQLiteSQLStatements() *SQLStatements {
 	return &SQLStatements{
-		InsertBatch:             "INSERT INTO batch_host (sequence, hash, height, ext_batch) VALUES (?, ?, ?, ?)",
+		InsertBatch:             "INSERT INTO batch_host (sequence, hash, height, ext_batch, txs_size) VALUES (?, ?, ?, ?, ?)",
 		InsertTransactions:      "INSERT INTO transaction_host (hash, b_sequence) VALUES ",
 		UpdateTxCount:           "UPDATE transaction_count SET total=? WHERE id=1",
 		InsertRollup:            "INSERT INTO rollup_host (hash, start_seq, end_seq, time_stamp, ext_rollup, compression_block) values (?,?,?,?,?,?) RETURNING id",
@@ -36,7 +36,7 @@ func SQLiteSQLStatements() *SQLStatements {
 
 func PostgresSQLStatements() *SQLStatements {
 	return &SQLStatements{
-		InsertBatch:             "INSERT INTO batch_host (sequence, hash, height, ext_batch) VALUES ($1, $2, $3, $4)",
+		InsertBatch:             "INSERT INTO batch_host (sequence, hash, height, ext_batch, txs_size) VALUES ($1, $2, $3, $4, $5)",
 		InsertTransactions:      "INSERT INTO transaction_host (hash, b_sequence) VALUES ",
 		UpdateTxCount:           "UPDATE transaction_count SET total=$1 WHERE id=1",
 		InsertRollup:            "INSERT INTO rollup_host (hash, start_seq, end_seq, time_stamp, ext_rollup, compression_block) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",

--- a/go/host/storage/init/postgres/001_init.sql
+++ b/go/host/storage/init/postgres/001_init.sql
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS batch_host
     sequence    INT PRIMARY KEY,
     hash        BYTEA         NOT NULL ,
     height      INT           NOT NULL,
-    ext_batch   BYTEA         NOT NULL
+    ext_batch   BYTEA         NOT NULL,
+    txs_size    INT           NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS IDX_BATCH_HASH_HOST ON batch_host USING HASH (hash);

--- a/go/host/storage/init/sqlite/001_init.sql
+++ b/go/host/storage/init/sqlite/001_init.sql
@@ -39,7 +39,8 @@ create table if not exists batch_host
     sequence       int primary key,
     hash           binary(32) NOT NULL,
     height         int        NOT NULL,
-    ext_batch      mediumblob NOT NULL
+    ext_batch      mediumblob NOT NULL,
+    txs_size       int        NOT NULL
 );
 create index IDX_BATCH_HASH_HOST on batch_host (hash);
 create index IDX_BATCH_HEIGHT_HOST on batch_host (height);


### PR DESCRIPTION
This PR adds a new `txs_size` column to the `batch_host` table, modifying database schema and related SQL statements.

This allows us to more accurately estimate roll-up size.

![image](https://github.com/user-attachments/assets/45f7fd47-840b-45f8-9b21-0f93046f1cdc)

Now we see that rollups are being triggered by interval timeout rather than size caps but the size is non-zero and the queries are working. There will still be tuning required of course but that's config based.