### PR TITLE
Short term fix for issue in Metamask v12.14+ which prevented accounts…

### DIFF
--- a/tools/walletextension/frontend/src/services/useGatewayService.ts
+++ b/tools/walletextension/frontend/src/services/useGatewayService.ts
@@ -35,14 +35,18 @@ const useGatewayService = () => {
 
   const finaliseConnectAccounts = async () => {
     const metamaskConnected = await isMetamaskConnected()
+    try {
+      if (!metamaskConnected) {
+        showToast(ToastType.INFO, "No accounts found, connecting...");
+        await connectAccounts();
+        showToast(ToastType.SUCCESS, "Connected to TEN Testnet");
+      }
 
-    if (!metamaskConnected) {
-      showToast(ToastType.INFO, "No accounts found, connecting...");
-      await connectAccounts();
-      showToast(ToastType.SUCCESS, "Connected to TEN Testnet");
+      await fetchUserAccounts();
+    } catch (error: Error | any) {
+      showToast(ToastType.DESTRUCTIVE, `${error?.message}`);
+      throw error;
     }
-
-    await fetchUserAccounts();
   }
 
   const connectToTenTestnet = async () => {
@@ -82,6 +86,9 @@ const useGatewayService = () => {
       await finaliseConnectAccounts()
 
     } catch (error: Error | any) {
+      // MetaMask v12.14.* is throwing an unexpected error while adding a network to.
+      // Despite the error the network is successfully added.
+      // This is a temporary workaround.
       if (error.message === 'l is not a function') {
         await finaliseConnectAccounts()
       } else {

--- a/tools/walletextension/frontend/src/services/useGatewayService.ts
+++ b/tools/walletextension/frontend/src/services/useGatewayService.ts
@@ -33,6 +33,18 @@ const useGatewayService = () => {
     }
   };
 
+  const finaliseConnectAccounts = async () => {
+    const metamaskConnected = await isMetamaskConnected()
+
+    if (!metamaskConnected) {
+      showToast(ToastType.INFO, "No accounts found, connecting...");
+      await connectAccounts();
+      showToast(ToastType.SUCCESS, "Connected to TEN Testnet");
+    }
+
+    await fetchUserAccounts();
+  }
+
   const connectToTenTestnet = async () => {
     showToast(ToastType.INFO, "Connecting to TEN Testnet...");
     setLoading(true);
@@ -67,15 +79,16 @@ const useGatewayService = () => {
         showToast(ToastType.SUCCESS, "Added TEN Testnet");
       }
 
-      if (!(await isMetamaskConnected())) {
-        showToast(ToastType.INFO, "No accounts found, connecting...");
-        await connectAccounts();
-        showToast(ToastType.SUCCESS, "Connected to TEN Testnet");
-      }
-      await fetchUserAccounts();
+      await finaliseConnectAccounts()
+
     } catch (error: Error | any) {
-      showToast(ToastType.DESTRUCTIVE, `${error?.message}`);
-      throw error;
+      if (error.message === 'l is not a function') {
+        await finaliseConnectAccounts()
+      } else {
+        showToast(ToastType.DESTRUCTIVE, `${error?.message}`);
+        throw error;
+      }
+
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
### Why this change is needed
Metamask v12.14.* is throwing an error (l is not a function) when adding attempting to add a TEN chain to the wallet via `wallet_addEthereumChain`. While the network is still added to the wallet, the error prevents further methods firing which allow the user to add accounts to the chain. 

### What changes were made as part of this PR
When this specific error message is returned after calling wallet_addEthereumChain we ignore it proceed connecting accounts.

This is intended as a short term fix until a thorough investigation into the cause of the issue can be carried out. 


### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


