### PR TITLE
add verifying contract to gateway eip712 message

### DIFF
--- a/go/common/viewingkey/viewing_key_messages.go
+++ b/go/common/viewingkey/viewing_key_messages.go
@@ -23,17 +23,19 @@ const (
 type SignatureType uint8
 
 const (
-	EIP712Domain              = "EIP712Domain"
-	EIP712Type                = "Authentication"
-	EIP712DomainName          = "name"
-	EIP712DomainVersion       = "version"
-	EIP712DomainChainID       = "chainId"
-	EIP712EncryptionToken     = "Encryption Token"
-	EIP712DomainNameValue     = "Ten"
-	EIP712DomainVersionValue  = "1.0"
-	UserIDLength              = 20
-	PersonalSignMessageFormat = "Token: %s on chain: %d version: %d"
-	PersonalSignVersion       = 1
+	EIP712Domain                 = "EIP712Domain"
+	EIP712Type                   = "Authentication"
+	EIP712DomainName             = "name"
+	EIP712DomainVersion          = "version"
+	EIP712DomainChainID          = "chainId"
+	EIP712VerifyingContract      = "verifyingContract"
+	EIP712EncryptionToken        = "Encryption Token"
+	EIP712DomainNameValue        = "Ten"
+	EIP712DomainVersionValue     = "1.0"
+	EIP712VerifyingContractValue = "0x0000000000000000000000000000000000000000"
+	UserIDLength                 = 20
+	PersonalSignMessageFormat    = "Token: %s on chain: %d version: %d"
+	PersonalSignVersion          = 1
 )
 
 type MessageGenerator interface {
@@ -145,9 +147,10 @@ func createTypedDataForEIP712Message(encryptionToken []byte, chainID int64) apit
 	hexToken := hexutils.BytesToHex(encryptionToken)
 
 	domain := apitypes.TypedDataDomain{
-		Name:    EIP712DomainNameValue,
-		Version: EIP712DomainVersionValue,
-		ChainId: (*math.HexOrDecimal256)(big.NewInt(chainID)),
+		Name:              EIP712DomainNameValue,
+		Version:           EIP712DomainVersionValue,
+		ChainId:           (*math.HexOrDecimal256)(big.NewInt(chainID)),
+		VerifyingContract: EIP712VerifyingContractValue,
 	}
 
 	message := map[string]interface{}{
@@ -159,6 +162,7 @@ func createTypedDataForEIP712Message(encryptionToken []byte, chainID int64) apit
 			{Name: EIP712DomainName, Type: "string"},
 			{Name: EIP712DomainVersion, Type: "string"},
 			{Name: EIP712DomainChainID, Type: "uint256"},
+			{Name: EIP712VerifyingContract, Type: "address"},
 		},
 		EIP712Type: {
 			{Name: EIP712EncryptionToken, Type: "address"},

--- a/tools/walletextension/frontend/src/api/ethRequests.ts
+++ b/tools/walletextension/frontend/src/api/ethRequests.ts
@@ -3,7 +3,7 @@ import {
   tenChainIDDecimal,
   tenChainIDHex, tenNetworkName,
   tenscanAddress,
-  userStorageAddress,
+  zeroAddress,
 } from "@/lib/constants";
 import {
   getRandomIntAsString,
@@ -22,6 +22,7 @@ const typedData = {
       { name: "name", type: "string" },
       { name: "version", type: "string" },
       { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
     ],
     Authentication: [{ name: "Encryption Token", type: "address" }],
   },
@@ -30,6 +31,7 @@ const typedData = {
     name: "Ten",
     version: "1.0",
     chainId: tenChainIDDecimal,
+    verifyingContract: zeroAddress,
   },
   message: {
     "Encryption Token": "0x",

--- a/tools/walletextension/frontend/src/lib/constants.ts
+++ b/tools/walletextension/frontend/src/lib/constants.ts
@@ -28,7 +28,7 @@ export const tenChainIDHex = "0x" + tenChainIDDecimal.toString(16); // Convert t
 
 export const METAMASK_CONNECTION_TIMEOUT = 3000;
 
-export const userStorageAddress = "0x0000000000000000000000000000000000000001";
+export const zeroAddress = "0x0000000000000000000000000000000000000000"
 
 export const nativeCurrency = {
   name: "Sepolia Ether",

--- a/tools/walletextension/frontend/src/services/useGatewayService.ts
+++ b/tools/walletextension/frontend/src/services/useGatewayService.ts
@@ -89,7 +89,7 @@ const useGatewayService = () => {
       // MetaMask v12.14.* is throwing an unexpected error while adding a network to.
       // Despite the error the network is successfully added.
       // This is a temporary workaround.
-      if (error.message === 'l is not a function' || error.message === 'h is not a function') {
+      if (error.message.includes(' is not a function')) {
         await finaliseConnectAccounts()
       } else {
         showToast(ToastType.DESTRUCTIVE, `${error?.message}`);

--- a/tools/walletextension/frontend/src/services/useGatewayService.ts
+++ b/tools/walletextension/frontend/src/services/useGatewayService.ts
@@ -89,7 +89,7 @@ const useGatewayService = () => {
       // MetaMask v12.14.* is throwing an unexpected error while adding a network to.
       // Despite the error the network is successfully added.
       // This is a temporary workaround.
-      if (error.message === 'l is not a function') {
+      if (error.message === 'l is not a function' || error.message === 'h is not a function') {
         await finaliseConnectAccounts()
       } else {
         showToast(ToastType.DESTRUCTIVE, `${error?.message}`);


### PR DESCRIPTION
### Why this change is needed

With recent Metamask update field `verifyingContract` became mandatory. 
In the past we used EIP-712 message without it, because no contract is verifying it and we only check it in the gateway.

### What changes were made as part of this PR

We added `verifyingContract` to both FE and BE inside EIP-712 message.

Verifying contract is set to `0x0` address. Is there any good reason why we should use the address of `management contract`.

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


