### PR TITLE
Fix displayed contract addresses on Tenscan

### DIFF
--- a/tools/tenscan/frontend/src/services/useContractsService.ts
+++ b/tools/tenscan/frontend/src/services/useContractsService.ts
@@ -29,8 +29,8 @@ export const useContractsService = () => {
       confirmed: true,
     },
     {
-      name: "Rollup Contract",
-      address: contracts?.item.RollupContract,
+      name: "Data Availability Registry",
+      address: contracts?.item.DataAvailabilityRegistry,
       confirmed: true,
     },
     {

--- a/tools/tenscan/frontend/src/services/useContractsService.ts
+++ b/tools/tenscan/frontend/src/services/useContractsService.ts
@@ -14,16 +14,62 @@ export const useContractsService = () => {
 
   const formattedContracts = [
     {
-      name: "Management Contract",
-      address: contracts?.item.ManagementContractAddress,
+      name: "Network Config",
+      address: contracts?.item.NetworkConfig,
       confirmed: true,
     },
     {
-      name: "Message Bus Contract",
-      address: contracts?.item.MessageBusAddress,
+      name: "Enclave Registry",
+      address: contracts?.item.EnclaveRegistry,
+      confirmed: true,
+    },
+    {
+      name: "Cross Chain",
+      address: contracts?.item.CrossChain,
+      confirmed: true,
+    },
+    {
+      name: "Rollup Contract",
+      address: contracts?.item.RollupContract,
+      confirmed: true,
+    },
+    {
+      name: "L1 Message Bus",
+      address: contracts?.item.L1MessageBus,
+      confirmed: true,
+    },
+    {
+      name: "L2 Message Bus",
+      address: contracts?.item.L2MessageBus,
+      confirmed: true,
+    },
+    {
+      name: "L1 Bridge",
+      address: contracts?.item.L1Bridge,
+      confirmed: true,
+    },
+    {
+      name: "L2 Bridge",
+      address: contracts?.item.L2Bridge,
+      confirmed: true,
+    },
+    {
+      name: "L1 Cross Chain Messenger",
+      address: contracts?.item.L1CrossChainMessenger,
+      confirmed: true,
+    },
+    {
+      name: "L2 Cross Chain Messenger",
+      address: contracts?.item.L2CrossChainMessenger,
+      confirmed: true,
+    },
+    {
+      name: "Transactions Post Processor",
+      address: contracts?.item.TransactionsPostProcessor,
       confirmed: true,
     },
   ];
+
   const sequencerData = [
     {
       name: "Sequencer ID",


### PR DESCRIPTION
### Why this change is needed

After splitting ManagementContract: 

https://github.com/ten-protocol/go-ten/commit/848428fdbb5c7e3493f04d9d0257645ebc42cc1b#diff-6d91c392b4adaf4cc04af487236a674e93068b7066aeb2c7cc0e2ce65d40f45aL113

We are using multiple addresses and not just a single ManagementContract address and this needs to be reflected also in Tencan.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


