### PR TITLE
fix rollup not found errors and tweak duration logging

### DIFF
--- a/go/common/rollups.go
+++ b/go/common/rollups.go
@@ -1,15 +1,11 @@
 package common
 
-import (
-	"sync/atomic"
-)
-
 // ExtRollup is an encrypted form of rollup used when passing the rollup around outside an enclave.
 type ExtRollup struct {
 	Header               *RollupHeader // the fields required by the management contract
 	CalldataRollupHeader []byte        // encrypted header useful for recreating the batches
 	BatchPayloads        []byte        // The transactions included in the rollup, in external/encrypted form.
-	hash                 atomic.Value
+	// hash                 atomic.Pointer[L2RollupHash]
 }
 
 // ExtRollupMetadata metadata that should not be in the rollup, but rather is derived from one.
@@ -20,12 +16,12 @@ type ExtRollupMetadata struct {
 }
 
 // Hash returns the keccak256 hash of the rollup's header.
-// The hash is computed on the first call and cached thereafter.
+// The hash is computed on the first call and cached thereafter - disabled because we mutate the header
 func (r *ExtRollup) Hash() L2RollupHash {
-	if hash := r.hash.Load(); hash != nil {
-		return hash.(L2RollupHash)
-	}
-	v := r.Header.Hash()
-	r.hash.Store(v)
-	return v
+	//if hash := r.hash.Load(); hash != nil {
+	//	return *hash
+	//}
+	h := r.Header.Hash()
+	// r.hash.Store(&h)
+	return h
 }

--- a/go/common/rpc/converters.go
+++ b/go/common/rpc/converters.go
@@ -220,35 +220,6 @@ func ToRollupHeaderMsg(header *common.RollupHeader) *generated.RollupHeaderMsg {
 	return &headerMsg
 }
 
-func FromExtRollupMsg(msg *generated.ExtRollupMsg) *common.ExtRollup {
-	if msg.Header == nil {
-		return &common.ExtRollup{
-			Header: nil,
-		}
-	}
-
-	return &common.ExtRollup{
-		Header:               FromRollupHeaderMsg(msg.Header),
-		BatchPayloads:        msg.BatchPayloads,
-		CalldataRollupHeader: msg.CalldataRollupHeader,
-	}
-}
-
-func FromRollupHeaderMsg(header *generated.RollupHeaderMsg) *common.RollupHeader {
-	if header == nil {
-		return nil
-	}
-
-	return &common.RollupHeader{
-		CompressionL1Head:   gethcommon.BytesToHash(header.CompressionL1Head),
-		CompressionL1Number: big.NewInt(0).SetBytes(header.CompressionL1Number),
-		CrossChainRoot:      gethcommon.BytesToHash(header.CrossChainRoot),
-		FirstBatchSeqNo:     header.FirstBatchSeqNo,
-		LastBatchSeqNo:      header.LastBatchSeqNo,
-		LastBatchHash:       gethcommon.BytesToHash(header.LastBatchHash),
-	}
-}
-
 func ToRollupDataMsg(rollupData *common.PublicRollupMetadata) generated.PublicRollupDataMsg {
 	if rollupData == nil {
 		return generated.PublicRollupDataMsg{}

--- a/go/enclave/components/rollup_consumer.go
+++ b/go/enclave/components/rollup_consumer.go
@@ -113,6 +113,8 @@ func (rc *rollupConsumerImpl) ProcessRollup(ctx context.Context, rollup *common.
 		return rc.storeRollupAndGenerateMetadata(ctx, rollup, internalHeader)
 	}
 
+	rc.logger.Info("Catching up from rollup", log.RollupHashKey, rollup.Hash())
+
 	// read batch data from rollup, verify and store it
 	err = rc.rollupCompression.ProcessExtRollup(ctx, rollup, internalHeader)
 	if err != nil {

--- a/go/enclave/core/rollup.go
+++ b/go/enclave/core/rollup.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"sync/atomic"
-
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ten-protocol/go-ten/go/common"
@@ -13,16 +11,16 @@ type Rollup struct {
 	Header  *common.RollupHeader
 	Batches []*Batch
 	Blocks  map[common.L1BlockHash]*types.Header // these are the blocks required during compression. The key is the hash
-	hash    atomic.Value
+	// hash    atomic.Pointer[common.L2RollupHash]
 }
 
 // Hash returns the keccak256 hash of b's header.
-// The hash is computed on the first call and cached thereafter.
+// The hash is computed on the first call and cached thereafter - disabled because we mutate the header
 func (r *Rollup) Hash() common.L2BatchHash {
-	if hash := r.hash.Load(); hash != nil {
-		return hash.(common.L2BatchHash)
-	}
-	v := r.Header.Hash()
-	r.hash.Store(v)
-	return v
+	//if hash := r.hash.Load(); hash != nil {
+	//	return *hash
+	//}
+	h := r.Header.Hash()
+	// r.hash.Store(&h)
+	return h
 }

--- a/go/enclave/debugger/tracers.go
+++ b/go/enclave/debugger/tracers.go
@@ -109,7 +109,7 @@ func (d *Debugger) DebugTraceTransaction(context.Context, gethcommon.Hash, *trac
 //		tracer = logger.NewStructLogger(config.Config)
 //	}
 //	// Run the transaction with tracing enabled.
-//	vmenv := vm.NewEVM(vmctx, txContext, statedb, d.chainConfig, vm.Config{Trivial: true, Tracer: tracer, NoBaseFee: true})
+//	vmenv := vm.NewEVM(vmctx, txContext, statedb, d.chainConfig, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 //
 //	// Call Prepare to clear out the statedb access list
 //	statedb.Prepare(txctx.TxHash, txctx.TxIndex)

--- a/go/enclave/debugger/tracers.go
+++ b/go/enclave/debugger/tracers.go
@@ -109,7 +109,7 @@ func (d *Debugger) DebugTraceTransaction(context.Context, gethcommon.Hash, *trac
 //		tracer = logger.NewStructLogger(config.Config)
 //	}
 //	// Run the transaction with tracing enabled.
-//	vmenv := vm.NewEVM(vmctx, txContext, statedb, d.chainConfig, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
+//	vmenv := vm.NewEVM(vmctx, txContext, statedb, d.chainConfig, vm.Config{Trivial: true, Tracer: tracer, NoBaseFee: true})
 //
 //	// Call Prepare to clear out the statedb access list
 //	statedb.Prepare(txctx.TxHash, txctx.TxIndex)

--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -543,7 +543,7 @@ func (e *enclaveAdminService) ingestL1Block(ctx context.Context, processed *comm
 
 	var rollupMetadataList []common.ExtRollupMetadata
 	if processed.HasEvents(common.RollupTx) {
-		rollupMetadataList, err = e.processRollups(ctx, processed, rollupMetadataList)
+		rollupMetadataList, err = e.processRollups(ctx, processed)
 		if err != nil && e.isCriticalError(err) {
 			// only propagate the error if we encounter a critical error on a sequencer signed rollup
 			return nil, nil, err
@@ -560,7 +560,8 @@ func (e *enclaveAdminService) ingestL1Block(ctx context.Context, processed *comm
 	return ingestion, rollupMetadataList, nil
 }
 
-func (e *enclaveAdminService) processRollups(ctx context.Context, processed *common.ProcessedL1Data, rollupMetadataList []common.ExtRollupMetadata) ([]common.ExtRollupMetadata, error) {
+func (e *enclaveAdminService) processRollups(ctx context.Context, processed *common.ProcessedL1Data) ([]common.ExtRollupMetadata, error) {
+	var rollupMetadataList []common.ExtRollupMetadata
 	rollupTxs := processed.GetEvents(common.RollupTx)
 	txsSeen := make(map[gethcommon.Hash]bool)
 


### PR DESCRIPTION
### Why this change is needed

- we were getting "rollup not found" errors on the host
- `LogMethodDuration` is annoying

### What changes were made as part of this PR

- remove hash caching for the rollup because we mutate the rollup header during construction
- tweak LogMethodDuration to log at Info or lower only

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


