### PR TITLE
Fix typos in code comments and error messages

### DIFF
--- a/go/common/viewingkey/viewing_key_signature.go
+++ b/go/common/viewingkey/viewing_key_signature.go
@@ -24,7 +24,7 @@ type (
 // CheckSignature checks if signature is valid for provided encryptionToken and chainID and return address or nil if not valid
 func (psc PersonalSignChecker) CheckSignature(encryptionToken []byte, signature []byte, chainID int64) (*gethcommon.Address, error) {
 	if len(signature) != 65 {
-		return nil, fmt.Errorf("invalid signaure length: %d", len(signature))
+		return nil, fmt.Errorf("invalid signature length: %d", len(signature))
 	}
 	// We transform the V from 27/28 to 0/1. This same change is made in Geth internals, for legacy reasons to be able
 	// to recover the address: https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L452-L459
@@ -53,7 +53,7 @@ func (psc PersonalSignChecker) CheckSignature(encryptionToken []byte, signature 
 
 func (e EIP712Checker) CheckSignature(encryptionToken []byte, signature []byte, chainID int64) (*gethcommon.Address, error) {
 	if len(signature) != 65 {
-		return nil, fmt.Errorf("invalid signaure length: %d", len(signature))
+		return nil, fmt.Errorf("invalid signature length: %d", len(signature))
 	}
 
 	msg, err := GenerateMessage(encryptionToken, chainID, 1, EIP712Signature)

--- a/integration/erc20contract/libs/openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol
+++ b/integration/erc20contract/libs/openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol
@@ -147,7 +147,7 @@ abstract contract ERC4626 is ERC20, IERC4626 {
      * @dev Internal conversion function (from assets to shares) with support for rounding direction.
      *
      * Will revert if assets > 0, totalSupply > 0 and totalAssets = 0. That corresponds to a case where any asset
-     * would represent an infinite amout of shares.
+     * would represent an infinite amount of shares.
      */
     function _convertToShares(uint256 assets, Math.Rounding rounding) internal view virtual returns (uint256 shares) {
         uint256 supply = totalSupply();

--- a/lib/gethfork/node/rpc_server.go
+++ b/lib/gethfork/node/rpc_server.go
@@ -33,7 +33,7 @@ type Route struct {
 	Func func(resp http.ResponseWriter, req *http.Request)
 }
 
-// Server manages the lifeycle of an RPC Server
+// Server manages the lifecycle of an RPC Server
 type Server interface {
 	Start() error
 	Stop()


### PR DESCRIPTION


Description:
This PR fixes several typos across the codebase:
- Corrects "signaure" to "signature" in error messages in go/common/viewingkey/viewing_key_signature.go
- Fixes "amout" to "amount" in comments in integration/erc20contract/libs/openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol
- Corrects "lifeycle" to "lifecycle" in comments in lib/gethfork/node/rpc_server.go

These changes improve code readability and consistency without affecting functionality.