### PR TITLE
fix /getmessage endpoint in the GW

### DIFF
--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -531,7 +531,6 @@ func getMessageRequestHandler(walletExt *services.Services, conn UserConn) {
 
 		if domainMap, ok := messageMap["domain"].(map[string]interface{}); ok {
 			delete(domainMap, "salt")
-			delete(domainMap, "verifyingContract")
 		}
 
 		if typesMap, ok := messageMap["types"].(map[string]interface{}); ok {


### PR DESCRIPTION
### Why this change is needed

We changed the message format and we were still not displaying verifyingcontract which caused the message to be wrong.


### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


