### PR TITLE
Ziga/fix gateway metrics

### DIFF
--- a/tools/walletextension/metrics/metrics.go
+++ b/tools/walletextension/metrics/metrics.go
@@ -32,7 +32,7 @@ const (
 type Metrics interface {
 	RecordNewUser()
 	RecordAccountRegistered()
-	RecordUserActivity(anonymousID string)
+	RecordUserActivity(anonymousID []byte)
 	GetTotalUsers() uint64
 	GetTotalAccountsRegistered() uint64
 	GetMonthlyActiveUsers() int
@@ -105,8 +105,8 @@ func (mt *MetricsTracker) RecordAccountRegistered() {
 }
 
 // RecordUserActivity updates the last activity timestamp for a user
-func (mt *MetricsTracker) RecordUserActivity(anonymousID string) {
-	hashedUserID := mt.hashUserID([]byte(anonymousID))
+func (mt *MetricsTracker) RecordUserActivity(anonymousID []byte) {
+	hashedUserID := mt.hashUserID(anonymousID)
 	now := time.Now()
 
 	// Update in-memory cache
@@ -281,7 +281,7 @@ func NewNoOpMetricsTracker(logger gethlog.Logger) Metrics {
 
 func (mt *NoOpMetricsTracker) RecordNewUser()                     {}
 func (mt *NoOpMetricsTracker) RecordAccountRegistered()           {}
-func (mt *NoOpMetricsTracker) RecordUserActivity(string)          {}
+func (mt *NoOpMetricsTracker) RecordUserActivity([]byte)          {}
 func (mt *NoOpMetricsTracker) GetTotalUsers() uint64              { return 0 }
 func (mt *NoOpMetricsTracker) GetTotalAccountsRegistered() uint64 { return 0 }
 func (mt *NoOpMetricsTracker) GetMonthlyActiveUsers() int         { return 0 }

--- a/tools/walletextension/metrics/metrics.go
+++ b/tools/walletextension/metrics/metrics.go
@@ -78,13 +78,14 @@ func NewMetricsTracker(storage *cosmosdb.MetricsStorageCosmosDB) Metrics {
 	return mt
 }
 
-// hashUserID creates a double-hashed version of the userID
+// hashUserID creates a double-hashed version of the userID, using only the first 8 bytes of the hash
 func (mt *MetricsTracker) hashUserID(userID []byte) string {
 	// First hash
 	firstHash := sha256.Sum256(userID)
 	// Second hash
 	secondHash := sha256.Sum256(firstHash[:])
-	return hex.EncodeToString(secondHash[:])
+	// Return only first 8 bytes of the hash (sufficient for ~1M users)
+	return hex.EncodeToString(secondHash[:8])
 }
 
 func (mt *MetricsTracker) RecordNewUser() {

--- a/tools/walletextension/metrics/metrics.go
+++ b/tools/walletextension/metrics/metrics.go
@@ -18,7 +18,7 @@ const (
 	InactiveUserCleanupInterval = 1 * time.Hour
 
 	// Update intervals for daily stats
-	DailyStatsUpdateInterval = 1 * time.Hour
+	DailyStatsUpdateInterval = 5 * time.Minute
 
 	// Activity thresholds
 	UserInactivityThreshold = 30 * 24 * time.Hour // 30 days

--- a/tools/walletextension/metrics/metrics.go
+++ b/tools/walletextension/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"crypto/sha256"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,7 +18,7 @@ const (
 	InactiveUserCleanupInterval = 1 * time.Hour
 
 	// Update intervals for daily stats
-	DailyStatsUpdateInterval = 5 * time.Minute
+	DailyStatsUpdateInterval = 8 * time.Hour
 
 	// Activity thresholds
 	UserInactivityThreshold = 30 * 24 * time.Hour // 30 days
@@ -63,7 +62,7 @@ func NewMetricsTracker(storage *cosmosdb.MetricsStorageCosmosDB, logger gethlog.
 		activityBatch:     make(map[string]time.Time),
 		storage:           storage,
 		persistTicker:     time.NewTicker(MetricsPersistInterval),
-		batchUpdateTicker: time.NewTicker(1 * time.Minute), // Process batches more frequently
+		batchUpdateTicker: time.NewTicker(5 * time.Minute),
 		dailyStatsTicker:  time.NewTicker(DailyStatsUpdateInterval),
 		logger:            logger,
 	}
@@ -112,7 +111,6 @@ func (mt *MetricsTracker) RecordAccountRegistered() {
 
 // RecordUserActivity updates the last activity timestamp for a user
 func (mt *MetricsTracker) RecordUserActivity(anonymousID []byte) {
-	fmt.Println("RECORDING USER ACTIVITY")
 	hashedUserID := mt.hashUserID(anonymousID)
 	now := time.Now()
 
@@ -129,7 +127,6 @@ func (mt *MetricsTracker) RecordUserActivity(anonymousID []byte) {
 
 	// If batch size exceeds threshold, trigger immediate processing
 	if batchSize >= ActivityBatchSize {
-		fmt.Println("PROCESSING BATCH UPDATES")
 		go mt.processBatchUpdates()
 	}
 }
@@ -170,7 +167,6 @@ func (mt *MetricsTracker) GetMonthlyActiveUsers() int {
 
 // processBatchUpdates handles batch updates to the database
 func (mt *MetricsTracker) processBatchUpdates() {
-	fmt.Println("PROCESSING BATCH UPDATES function called")
 	// Get current batch and reset
 	mt.activityBatchLock.Lock()
 	if len(mt.activityBatch) == 0 {

--- a/tools/walletextension/metrics/metrics.go
+++ b/tools/walletextension/metrics/metrics.go
@@ -79,7 +79,7 @@ func NewMetricsTracker(storage *cosmosdb.MetricsStorageCosmosDB) Metrics {
 	go mt.updateDailyStats()
 
 	// Update stats immediately on startup
-	go mt.storage.UpdateDailyStats()
+	go mt.updateDailyStats()
 
 	return mt
 }

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -92,7 +92,7 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 		return nil, err
 	}
 
-	// w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(user.ID))
+	w.MetricsTracker.RecordUserActivity(user.ID)
 
 	rateLimitAllowed, requestUUID := w.RateLimiter.Allow(gethcommon.Address(user.ID))
 	if !rateLimitAllowed {

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -93,6 +93,7 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 	}
 
 	w.MetricsTracker.RecordUserActivity(user.ID)
+	audit(w, "LOGGING USER ACTIVITY")
 
 	rateLimitAllowed, requestUUID := w.RateLimiter.Allow(gethcommon.Address(user.ID))
 	if !rateLimitAllowed {

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -93,7 +93,6 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 	}
 
 	w.MetricsTracker.RecordUserActivity(user.ID)
-	audit(w, "LOGGING USER ACTIVITY")
 
 	rateLimitAllowed, requestUUID := w.RateLimiter.Allow(gethcommon.Address(user.ID))
 	if !rateLimitAllowed {

--- a/tools/walletextension/services/wallet_extension.go
+++ b/tools/walletextension/services/wallet_extension.go
@@ -203,7 +203,7 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 		w.Logger().Error(fmt.Sprintf("failed to save user to the database: %s", err))
 		return nil, err
 	}
-	// w.MetricsTracker.RecordNewUser()
+	w.MetricsTracker.RecordNewUser()
 
 	requestEndTime := time.Now()
 	duration := requestEndTime.Sub(requestStartTime)
@@ -213,7 +213,7 @@ func (w *Services) GenerateAndStoreNewUser() ([]byte, error) {
 
 // AddAddressToUser checks if a message is in correct format and if signature is valid. If all checks pass we save address and signature against userID
 func (w *Services) AddAddressToUser(userID []byte, address string, signature []byte, signatureType viewingkey.SignatureType) error {
-	// w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
+	w.MetricsTracker.RecordUserActivity(userID)
 	audit(w, "Adding address to user: %s, address: %s", common.HashForLogging(userID), address)
 	requestStartTime := time.Now()
 	addressFromMessage := gethcommon.HexToAddress(address)
@@ -233,7 +233,7 @@ func (w *Services) AddAddressToUser(userID []byte, address string, signature []b
 		w.Logger().Error(fmt.Errorf("error while storing account (%s) for user (%s): %w", addressFromMessage.Hex(), userID, err).Error())
 		return err
 	}
-	// w.MetricsTracker.RecordAccountRegistered()
+	w.MetricsTracker.RecordAccountRegistered()
 
 	audit(w, "Storing new address for user: %s, address: %s, duration: %d ", hexutils.BytesToHex(userID), address, time.Since(requestStartTime).Milliseconds())
 	return nil
@@ -241,7 +241,7 @@ func (w *Services) AddAddressToUser(userID []byte, address string, signature []b
 
 // UserHasAccount checks if provided account exist in the database for given userID
 func (w *Services) UserHasAccount(userID []byte, address string) (bool, error) {
-	// w.MetricsTracker.RecordUserActivity(hexutils.BytesToHex(userID))
+	w.MetricsTracker.RecordUserActivity(userID)
 	audit(w, "Checking if user has account: %s, address: %s", common.HashForLogging(userID), address)
 	addressBytes, err := hex.DecodeString(address[2:]) // remove 0x prefix from address
 	if err != nil {

--- a/tools/walletextension/storage/database/cosmosdb/metrics_storage.go
+++ b/tools/walletextension/storage/database/cosmosdb/metrics_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -13,21 +14,33 @@ import (
 const (
 	METRICS_CONTAINER_NAME = "metrics"
 	METRICS_DOC_ID         = "global_metrics"
+	SHARD_PREFIX           = "user_shard_"
+	DEFAULT_SHARD_COUNT    = 10 // Number of shards to distribute users across
 )
 
-type MetricsDocument struct {
-	ID                 string            `json:"id"`
-	TotalUsers         uint64            `json:"totalUsers"`
-	AccountsRegistered uint64            `json:"accountsRegistered"`
-	ActiveUsers        map[string]string `json:"activeUsers"` // double-hashed userID -> ISO timestamp
-	ActiveUsersCount   int               `json:"activeUsersCount"`
-	LastUpdated        string            `json:"lastUpdated"`
+// GlobalMetricsDocument contains global metrics without user activity data
+type GlobalMetricsDocument struct {
+	ID                 string `json:"id"`
+	TotalUsers         uint64 `json:"totalUsers"`
+	AccountsRegistered uint64 `json:"accountsRegistered"`
+	ActiveUsersCount   int    `json:"activeUsersCount"`
+	LastUpdated        string `json:"lastUpdated"`
+	ShardCount         int    `json:"shardCount"` // Number of shards being used
+}
+
+// UserShardDocument contains activity data for a subset of users
+type UserShardDocument struct {
+	ID          string            `json:"id"`
+	ActiveUsers map[string]string `json:"activeUsers"` // double-hashed userID -> ISO timestamp
+	ShardIndex  int               `json:"shardIndex"`
+	LastUpdated string            `json:"lastUpdated"`
 }
 
 // MetricsStorageCosmosDB handles metrics persistence in CosmosDB
 type MetricsStorageCosmosDB struct {
 	client           *azcosmos.Client
 	metricsContainer *azcosmos.ContainerClient
+	shardCount       int
 }
 
 func NewMetricsStorage(connectionString string) (*MetricsStorageCosmosDB, error) {
@@ -52,53 +65,117 @@ func NewMetricsStorage(connectionString string) (*MetricsStorageCosmosDB, error)
 	return &MetricsStorageCosmosDB{
 		client:           client,
 		metricsContainer: metricsContainer,
+		shardCount:       DEFAULT_SHARD_COUNT,
 	}, nil
 }
 
-func (m *MetricsStorageCosmosDB) LoadMetrics() (*MetricsDocument, error) {
+// getShardDocumentID determines which shard a user belongs to
+func (m *MetricsStorageCosmosDB) getShardDocumentID(userID string) string {
+	// Use hash function to determine shard
+	h := fnv.New32a()
+	h.Write([]byte(userID))
+	shardIndex := int(h.Sum32()) % m.shardCount
+
+	return fmt.Sprintf("%s%d", SHARD_PREFIX, shardIndex)
+}
+
+// getShardIndexFromID extracts shard index from document ID
+func (m *MetricsStorageCosmosDB) getShardIndexFromID(shardID string) int {
+	var index int
+	fmt.Sscanf(shardID, SHARD_PREFIX+"%d", &index)
+	return index
+}
+
+// LoadGlobalMetrics loads the global metrics document
+func (m *MetricsStorageCosmosDB) LoadGlobalMetrics() (*GlobalMetricsDocument, error) {
 	ctx := context.Background()
 	partitionKey := azcosmos.NewPartitionKeyString(METRICS_DOC_ID)
 
 	response, err := m.metricsContainer.ReadItem(ctx, partitionKey, METRICS_DOC_ID, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
-			// Initialize with empty metrics if not found
-			return &MetricsDocument{
-				ID:          METRICS_DOC_ID,
-				ActiveUsers: make(map[string]string),
+			// Initialize with empty global metrics if not found
+			return &GlobalMetricsDocument{
+				ID:         METRICS_DOC_ID,
+				ShardCount: m.shardCount,
 			}, nil
 		}
 		return nil, err
 	}
 
-	var doc MetricsDocument
+	var doc GlobalMetricsDocument
+	if err := json.Unmarshal(response.Value, &doc); err != nil {
+		return nil, err
+	}
+
+	// Update shard count if it has changed
+	if doc.ShardCount > 0 {
+		m.shardCount = doc.ShardCount
+	}
+
+	return &doc, nil
+}
+
+// LoadUserShard loads a specific user shard document
+func (m *MetricsStorageCosmosDB) LoadUserShard(shardID string) (*UserShardDocument, error) {
+	ctx := context.Background()
+	partitionKey := azcosmos.NewPartitionKeyString(shardID)
+
+	response, err := m.metricsContainer.ReadItem(ctx, partitionKey, shardID, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			// Initialize empty shard if not found
+			shardIndex := m.getShardIndexFromID(shardID)
+			return &UserShardDocument{
+				ID:          shardID,
+				ActiveUsers: make(map[string]string),
+				ShardIndex:  shardIndex,
+			}, nil
+		}
+		return nil, err
+	}
+
+	var doc UserShardDocument
 	if err := json.Unmarshal(response.Value, &doc); err != nil {
 		return nil, err
 	}
 	return &doc, nil
 }
 
-func (m *MetricsStorageCosmosDB) SaveMetrics(metrics *MetricsDocument) error {
+// LoadAllShards loads all user shard documents
+func (m *MetricsStorageCosmosDB) LoadAllShards() ([]*UserShardDocument, error) {
+	var shards []*UserShardDocument
+
+	// Load global metrics first to get current shard count
+	global, err := m.LoadGlobalMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	if global.ShardCount > 0 {
+		m.shardCount = global.ShardCount
+	}
+
+	// Load each shard
+	for i := 0; i < m.shardCount; i++ {
+		shardID := fmt.Sprintf("%s%d", SHARD_PREFIX, i)
+		shard, err := m.LoadUserShard(shardID)
+		if err != nil {
+			return nil, err
+		}
+		shards = append(shards, shard)
+	}
+
+	return shards, nil
+}
+
+// SaveGlobalMetrics saves the global metrics document
+func (m *MetricsStorageCosmosDB) SaveGlobalMetrics(metrics *GlobalMetricsDocument) error {
 	ctx := context.Background()
 	partitionKey := azcosmos.NewPartitionKeyString(METRICS_DOC_ID)
 
-	// Calculate active users count and clean up inactive users
-	activeThreshold := time.Now().Add(-30 * 24 * time.Hour) // 30 days
-	activeCount := 0
-	activeUsersMap := make(map[string]string)
-
-	for userID, timestampStr := range metrics.ActiveUsers {
-		if timestamp, err := time.Parse(time.RFC3339, timestampStr); err == nil {
-			if timestamp.After(activeThreshold) {
-				activeCount++
-				activeUsersMap[userID] = timestampStr
-			}
-		}
-	}
-
-	metrics.ActiveUsers = activeUsersMap // Only keep active users
-	metrics.ActiveUsersCount = activeCount
 	metrics.LastUpdated = time.Now().UTC().Format(time.RFC3339)
+	metrics.ShardCount = m.shardCount
 
 	docJSON, err := json.Marshal(metrics)
 	if err != nil {
@@ -109,14 +186,215 @@ func (m *MetricsStorageCosmosDB) SaveMetrics(metrics *MetricsDocument) error {
 	return err
 }
 
-// NoOpMetricsStorage is a no-op implementation of metrics storage
-type noOpMetricsStorage struct{}
+// SaveUserShard saves a specific user shard document
+func (m *MetricsStorageCosmosDB) SaveUserShard(shard *UserShardDocument) error {
+	ctx := context.Background()
+	partitionKey := azcosmos.NewPartitionKeyString(shard.ID)
+
+	shard.LastUpdated = time.Now().UTC().Format(time.RFC3339)
+
+	docJSON, err := json.Marshal(shard)
+	if err != nil {
+		return err
+	}
+
+	_, err = m.metricsContainer.UpsertItem(ctx, partitionKey, docJSON, nil)
+	return err
+}
+
+// For backward compatibility with existing interface
+// LoadMetrics returns combined metrics from all shards
+func (m *MetricsStorageCosmosDB) LoadMetrics() (*MetricsDocument, error) {
+	// Load global metrics
+	global, err := m.LoadGlobalMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load all shards
+	shards, err := m.LoadAllShards()
+	if err != nil {
+		return nil, err
+	}
+
+	// Combine active users from all shards
+	combinedActiveUsers := make(map[string]string)
+	for _, shard := range shards {
+		for userID, timestamp := range shard.ActiveUsers {
+			combinedActiveUsers[userID] = timestamp
+		}
+	}
+
+	// Create combined metrics document
+	return &MetricsDocument{
+		ID:                 METRICS_DOC_ID,
+		TotalUsers:         global.TotalUsers,
+		AccountsRegistered: global.AccountsRegistered,
+		ActiveUsers:        combinedActiveUsers,
+		ActiveUsersCount:   global.ActiveUsersCount,
+		LastUpdated:        global.LastUpdated,
+	}, nil
+}
+
+// SaveMetrics splits metrics into global and sharded user documents
+func (m *MetricsStorageCosmosDB) SaveMetrics(metrics *MetricsDocument) error {
+	// Create global metrics document
+	global := &GlobalMetricsDocument{
+		ID:                 METRICS_DOC_ID,
+		TotalUsers:         metrics.TotalUsers,
+		AccountsRegistered: metrics.AccountsRegistered,
+		ShardCount:         m.shardCount,
+	}
+
+	// Clean up inactive users and count active ones
+	activeThreshold := time.Now().Add(-30 * 24 * time.Hour) // 30 days
+	activeCount := 0
+
+	// Create a map of shards
+	shards := make(map[string]*UserShardDocument)
+
+	// Process each active user
+	for userID, timestampStr := range metrics.ActiveUsers {
+		if timestamp, err := time.Parse(time.RFC3339, timestampStr); err == nil {
+			if timestamp.After(activeThreshold) {
+				activeCount++
+
+				// Determine which shard this user belongs to
+				shardID := m.getShardDocumentID(userID)
+
+				// Create shard document if it doesn't exist
+				if _, exists := shards[shardID]; !exists {
+					shardIndex := m.getShardIndexFromID(shardID)
+					shards[shardID] = &UserShardDocument{
+						ID:          shardID,
+						ActiveUsers: make(map[string]string),
+						ShardIndex:  shardIndex,
+					}
+				}
+
+				// Add user to appropriate shard
+				shards[shardID].ActiveUsers[userID] = timestampStr
+			}
+		}
+	}
+
+	// Update global active user count
+	global.ActiveUsersCount = activeCount
+
+	// Save global metrics
+	if err := m.SaveGlobalMetrics(global); err != nil {
+		return err
+	}
+
+	// Save each shard
+	for _, shard := range shards {
+		if err := m.SaveUserShard(shard); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetUserActivityTimestamp retrieves the activity timestamp for a specific user
+func (m *MetricsStorageCosmosDB) GetUserActivityTimestamp(userID string) (time.Time, bool, error) {
+	// Determine which shard this user belongs to
+	shardID := m.getShardDocumentID(userID)
+
+	// Load the appropriate shard
+	shard, err := m.LoadUserShard(shardID)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	// Find the user in the shard
+	if timestampStr, exists := shard.ActiveUsers[userID]; exists {
+		timestamp, err := time.Parse(time.RFC3339, timestampStr)
+		if err != nil {
+			return time.Time{}, true, err
+		}
+		return timestamp, true, nil
+	}
+
+	return time.Time{}, false, nil
+}
+
+// UpdateUserActivity updates activity for a specific user
+func (m *MetricsStorageCosmosDB) UpdateUserActivity(userID string, timestamp time.Time) error {
+	// Determine which shard this user belongs to
+	shardID := m.getShardDocumentID(userID)
+
+	// Load the appropriate shard
+	shard, err := m.LoadUserShard(shardID)
+	if err != nil {
+		return err
+	}
+
+	// Update the user's activity timestamp
+	shard.ActiveUsers[userID] = timestamp.UTC().Format(time.RFC3339)
+
+	// Save the updated shard
+	return m.SaveUserShard(shard)
+}
+
+// CountActiveUsers counts active users across all shards
+func (m *MetricsStorageCosmosDB) CountActiveUsers(activeThreshold time.Time) (int, error) {
+	shards, err := m.LoadAllShards()
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, shard := range shards {
+		for _, timestampStr := range shard.ActiveUsers {
+			if timestamp, err := time.Parse(time.RFC3339, timestampStr); err == nil {
+				if timestamp.After(activeThreshold) {
+					count++
+				}
+			}
+		}
+	}
+
+	return count, nil
+}
+
+// ResizeShards changes the number of shards and redistributes users
+// Warning: This is a costly operation, should be used rarely
+func (m *MetricsStorageCosmosDB) ResizeShards(newShardCount int) error {
+	if newShardCount <= 0 {
+		return fmt.Errorf("new shard count must be positive")
+	}
+
+	// Load all current data
+	metrics, err := m.LoadMetrics()
+	if err != nil {
+		return err
+	}
+
+	// Change shard count
+	oldShardCount := m.shardCount
+	m.shardCount = newShardCount
+
+	// Save metrics with new shard count, which will redistribute users
+	if err := m.SaveMetrics(metrics); err != nil {
+		// Revert on failure
+		m.shardCount = oldShardCount
+		return err
+	}
+
+	return nil
+}
 
 // MetricsStorage interface defines the metrics storage operations
 type MetricsStorage interface {
 	LoadMetrics() (*MetricsDocument, error)
 	SaveMetrics(*MetricsDocument) error
+	UpdateUserActivity(string, time.Time) error
+	GetUserActivityTimestamp(string) (time.Time, bool, error)
 }
+
+// NoOpMetricsStorage is a no-op implementation of metrics storage
+type noOpMetricsStorage struct{}
 
 func NewNoOpMetricsStorage() MetricsStorage {
 	return &noOpMetricsStorage{}
@@ -130,4 +408,12 @@ func (n *noOpMetricsStorage) LoadMetrics() (*MetricsDocument, error) {
 
 func (n *noOpMetricsStorage) SaveMetrics(*MetricsDocument) error {
 	return nil
+}
+
+func (n *noOpMetricsStorage) UpdateUserActivity(string, time.Time) error {
+	return nil
+}
+
+func (n *noOpMetricsStorage) GetUserActivityTimestamp(string) (time.Time, bool, error) {
+	return time.Time{}, false, nil
 }

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -55,9 +55,9 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 			logger.Crit("unable to create metrics storage", log.ErrKey, err)
 			os.Exit(1)
 		}
-		metricsTracker = metrics.NewMetricsTracker(metricsStorage)
+		metricsTracker = metrics.NewMetricsTracker(metricsStorage, logger)
 	} else {
-		metricsTracker = metrics.NewNoOpMetricsTracker()
+		metricsTracker = metrics.NewNoOpMetricsTracker(logger)
 	}
 
 	// start the database with the encryption key


### PR DESCRIPTION
### Why this change is needed

This PR addresses a critical issue where we were hitting CosmosDB document size limits when tracking active users.

### What changes were made as part of this PR

- Split user activity data across multiple shards instead of storing everything in one document
- Added a new stats document that tracks daily/weekly/monthly active users over time
- Reduced the hash size for user IDs from 32 to 8 bytes to save storage space
- Implemented batch processing for more efficient database updates

The sharding approach distributes users evenly across multiple documents using a hash function. When a user is active, we calculate which shard they belong to and update only that document.
I also added a daily stats tracker that maintains historical metrics, making it easy to query activity trends without scanning all user data each time. The stats document has a 90-day retention policy by default but this is configurable.

Here is a screenshot from dev-testnet:

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/e8ecd5b5-e3dc-4b5c-9a40-472e28b3a020" />

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


