### PR TITLE
Fix missing blocks from L1 "newHeads" subscription

### DIFF
--- a/go/host/l1/dataservice.go
+++ b/go/host/l1/dataservice.go
@@ -435,7 +435,7 @@ func (r *DataService) streamLiveBlocks() {
 	for r.running.Load() {
 		select {
 		case blockHeader := <-liveStream:
-			r.logger.Info(fmt.Sprintf("received block from l1 stream: %v", blockHeader))
+			r.logger.Info("received block from l1 stream", log.BlockHashKey, blockHeader.Hash(), log.BlockHeightKey, blockHeader.Number)
 
 			// recursively check that the ancestors are available in the host db
 			err := r.fetchAncestors(blockHeader.ParentHash)

--- a/integration/simulation/network/inmemory.go
+++ b/integration/simulation/network/inmemory.go
@@ -126,7 +126,7 @@ func (n *basicNetworkOfInMemoryNodes) Create(params *params.SimParams, stats *st
 
 		// the nodes are healthy, we can continue
 		return nil
-	}, retry.NewTimeoutStrategy(30*params.AvgBlockDuration, params.AvgBlockDuration))
+	}, retry.NewTimeoutStrategy(50*params.AvgBlockDuration, params.AvgBlockDuration))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Why this change is needed

Currently, the integrity of the host L1 block storage depends on the reliability of the "newHeads" subscription.

### What changes were made as part of this PR

Introduce an extra check and logic to fetch missing blocks during the "newHeads" subscription handling

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


