### PR TITLE
Logging: only log tenconfig explicitly

### DIFF
--- a/go/config/loader.go
+++ b/go/config/loader.go
@@ -87,7 +87,5 @@ func load(filePaths []string) (*TenConfig, error) {
 		return nil, err
 	}
 
-	fmt.Println("Successfully loaded Ten config.")
-	tenCfg.PrettyPrint()
 	return &tenCfg, nil
 }

--- a/go/enclave/main/main.go
+++ b/go/enclave/main/main.go
@@ -17,6 +17,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting enclave with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	enclaveConfig := enclaveconfig.EnclaveConfigFromTenConfig(tenCfg)
 

--- a/go/host/main/main.go
+++ b/go/host/main/main.go
@@ -17,6 +17,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting host with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	hostCfg := hostconfig.HostConfigFromTenConfig(tenCfg)
 	hostContainer := hostcontainer.NewHostContainerFromConfig(hostCfg, nil)

--- a/go/node/docker_node.go
+++ b/go/node/docker_node.go
@@ -36,7 +36,7 @@ func NewDockerNode(cfg *config.TenConfig, hostImage, enclaveImage, edgelessDBIma
 }
 
 func (d *DockerNode) Start() error {
-	// todo (@pedro) - this should probably be removed in the future
+	fmt.Printf("Starting node (%s) with the following config:\n", d.cfg.Node.Name)
 	d.cfg.PrettyPrint() // dump config to stdout
 
 	var err error

--- a/testnet/launcher/l1challengeperiod/cmd/main.go
+++ b/testnet/launcher/l1challengeperiod/cmd/main.go
@@ -14,6 +14,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting L1 challenge period with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	challengePeriodCfg := l1cp.NewChallengePeriodConfig(tenCfg)
 	l1challengeperiod, err := l1cp.NewSetChallengePeriod(challengePeriodCfg)

--- a/testnet/launcher/l1contractdeployer/cmd/main.go
+++ b/testnet/launcher/l1contractdeployer/cmd/main.go
@@ -15,6 +15,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting L1 contract deployer with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	deployerConfig := l1cd.NewContractDeployerConfig(tenCfg)
 	l1ContractDeployer, err := l1cd.NewDockerContractDeployer(deployerConfig)

--- a/testnet/launcher/l1grantsequencers/cmd/main.go
+++ b/testnet/launcher/l1grantsequencers/cmd/main.go
@@ -14,6 +14,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting L1 grant sequencer with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	grantSeqCfg := l1gs.NewGrantSequencerConfig(tenCfg)
 	l1grantsequencers, err := l1gs.NewGrantSequencers(grantSeqCfg)

--- a/testnet/launcher/l2contractdeployer/cmd/main.go
+++ b/testnet/launcher/l2contractdeployer/cmd/main.go
@@ -14,6 +14,8 @@ func main() {
 		fmt.Println("Error loading ten config:", err)
 		os.Exit(1)
 	}
+	fmt.Println("Starting L2 contract deployer with the following TenConfig:")
+	tenCfg.PrettyPrint() // dump config to stdout
 
 	l2CDCfg := l2cd.NewContractDeployerConfig(tenCfg)
 	l2ContractDeployer, err := l2cd.NewDockerContractDeployer(l2CDCfg)


### PR DESCRIPTION
### Why this change is needed

We were dumping tenconfig out in the main loading method which caused some weird effects (like when starting a node it causes the cfg to get dumped twice, once with the 0-base-cfg values and then again with the actual values.

### What changes were made as part of this PR

Make it so ten config is just logged when explicitly requested by calling code. Have all the main methods log it once it has loaded.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


