### PR TITLE
fix newHeads logic for fetchAncestors

### DIFF
--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -149,7 +149,7 @@ func NewHostContainerFromConfig(cfg *hostconfig.HostConfig, logger gethlog.Logge
 	// we can add more fallback clients as they become available
 	beaconFallback := ethadapter.NewBeaconHTTPClient(new(http.Client), cfg.L1BlobArchiveUrl)
 	blobResolver := l1.NewBlobResolver(ethadapter.NewL1BeaconClient(beaconClient, beaconFallback), logger)
-	l1Data := l1.NewL1DataService(l1Client, logger, contractRegistry, blobResolver)
+	l1Data := l1.NewL1DataService(l1Client, logger, contractRegistry, blobResolver, cfg.L1StartHash)
 	return NewHostContainer(cfg, services, aggP2P, l1Client, l1Data, enclaveClients, ethWallet, rpcServer, logger, metricsService, blobResolver, contractRegistry)
 }
 

--- a/integration/simulation/devnetwork/node.go
+++ b/integration/simulation/devnetwork/node.go
@@ -183,7 +183,7 @@ func (n *InMemNodeOperator) createHostContainer() *hostcontainer.HostContainer {
 	}
 
 	blobResolver := l1.NewBlobResolver(ethadapter.NewL1BeaconClient(ethadapter.NewBeaconHTTPClient(new(http.Client), fmt.Sprintf("127.0.0.1:%d", n.config.L1BeaconPort))), hostLogger)
-	l1Data := l1.NewL1DataService(n.l1Client, n.logger, contractRegistry, blobResolver)
+	l1Data := l1.NewL1DataService(n.l1Client, n.logger, contractRegistry, blobResolver, hostConfig.L1StartHash)
 	return hostcontainer.NewHostContainer(hostConfig, svcLocator, nodeP2p, n.l1Client, l1Data, enclaveClients, n.l1Wallet, rpcServer, hostLogger, metrics.New(false, 0, n.logger), blobResolver, contractRegistry)
 }
 

--- a/integration/simulation/network/network_utils.go
+++ b/integration/simulation/network/network_utils.go
@@ -112,7 +112,7 @@ func createInMemTenNode(
 	hostLogger := testlog.Logger().New(log.NodeIDKey, id, log.CmpKey, log.HostCmp)
 	// create an in memory TEN node
 	metricsService := metrics.New(hostConfig.MetricsEnabled, hostConfig.MetricsHTTPPort, hostLogger)
-	l1Data := l1.NewL1DataService(ethClient, hostLogger, contractRegistryLib, blobResolver)
+	l1Data := l1.NewL1DataService(ethClient, hostLogger, contractRegistryLib, blobResolver, hostConfig.L1StartHash)
 	currentContainer := hostcontainer.NewHostContainer(hostConfig, host.NewServicesRegistry(hostLogger), mockP2P, ethClient, l1Data, enclaveClients, ethWallet, nil, hostLogger, metricsService, blobResolver, contractRegistryLib)
 
 	return currentContainer


### PR DESCRIPTION
### Why this change is needed

To fix a bug that appears on testnet

### What changes were made as part of this PR

- instead of comparing to genesis, compare to the `cfg.L1StartHash` when stopping the recursive `fetchAncestors`

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


