### PR TITLE
k8s: placeholder scripts for initialise and finalise testnet

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -1,0 +1,215 @@
+# Last step deploying a new testnet, deploys L2 contracts and faucet etc.
+#
+# This script uses GitHub Environments for variables (vars) and secrets - these are configured on GitHub and
+#  the environments match the input.testnet_type options
+#
+# To deploy sepolia the user must type 'confirm' in the confirmation field
+
+# TODO: this is a placeholder, not ready yet! We need to wire in contract addresses etc.
+
+name: '[M] k8s Complete testnet setup'
+run-name: '[M] k8s Complete testnet setup ( ${{ github.event.inputs.testnet_type }} )'
+on:
+   workflow_dispatch:
+      inputs:
+         testnet_type:
+            description: 'Testnet Type'
+            required: true
+            default: 'dev-testnet'
+            type: choice
+            options:
+               - 'dev-testnet'
+               - 'uat-testnet'
+               - 'sepolia-testnet'
+         log_level:
+            description: 'Log Level 1-Error 5-Trace'
+            required: true
+            default: 3
+            type: number
+         confirmation:
+            description: 'Type "confirm" if deploying sepolia'
+            required: false
+            type: string
+
+jobs:
+   check-obscuro-is-healthy:
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      steps:
+         - uses: actions/checkout@v4
+
+         - name: "Wait until obscuro node is healthy"
+           shell: bash
+           run: |
+              ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+              ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+              ./.github/workflows/runner-scripts/wait-node-healthy.sh --host=obscuronode-2-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+   
+
+   grant-sequencer-enclaves:
+      needs:
+         - check-obscuro-is-healthy
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      steps:
+         -  uses: actions/checkout@v4
+
+         -  name: 'Grant permission to sequencer enclave(s)'
+            id: grantSequencerPermission
+            shell: bash
+            env:
+               DOCKER_API_VERSION: "1.45"
+               DEPLOY_DOCKERIMAGE: ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+               DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
+               DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
+               DEPLOY_L2_SEQUENCERURL: http://obscuronode-0-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com:80
+               NETWORK_L1_CONTRACTS_ENCLAVEREGISTRY: ${{ needs.build.outputs.ENCLAVE_REGISTRY_ADDR }}
+
+            run: |
+               go run ./testnet/launcher/l1grantsequencers/cmd
+
+         -  name: 'Save sequencer permissioning container logs'
+            run: |
+               docker logs `docker ps -aqf "name=grant-sequencers"` > grant-sequencers.out 2>&1
+
+         -  name: 'Upload sequencer permissioning container logs'
+            uses: actions/upload-artifact@v4
+            with:
+               name: grant-sequencers
+               path: |
+                  grant-sequencers.out
+               retention-days: 7
+
+   set-challenge-period:
+      needs:
+         - build
+         - check-obscuro-is-healthy
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      env:
+         DOCKER_API_VERSION: "1.45"
+         NETWORK_L1_CONTRACTS_ROLLUP: ${{ needs.build.outputs.DA_REGISTRY_ADDR }}
+         DEPLOY_DOCKERIMAGE: ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+         DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
+         DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
+         DEPLOY_L1_CHALLENGEPERIOD: ${{ vars.L1_CHALLENGE_PERIOD }}
+      steps:
+         -  uses: actions/checkout@v4
+
+         -  name: 'Set challenge period on rollup contract'
+            id: setChallengePeriod
+            shell: bash
+            run: |
+               go run ./testnet/launcher/l1challengeperiod/cmd
+               echo "Setting challenge period to ${{ vars.L1_CHALLENGE_PERIOD }}"
+
+         -  name: 'Save challenge period container logs'
+            run: |
+               docker logs `docker ps -aqf "name=set-challenge-period"` > set-challenge-period.out 2>&1
+
+         -  name: 'Upload challenge period container logs'
+            uses: actions/upload-artifact@v4
+            with:
+               name: set-challenge-period
+               path: |
+                  set-challenge-period.out
+               retention-days: 7
+
+   deploy-l2-contracts:
+      needs:
+         - build
+         - grant-sequencer-enclaves
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      steps:
+         - uses: actions/checkout@v4
+
+         - name: 'Deploy L2 contracts'
+           id: deployL2Contracts
+           shell: bash
+           env:
+              DOCKER_API_VERSION: "1.45"
+              DEPLOY_DOCKERIMAGE: ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+              DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
+              DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
+              DEPLOY_L2_DEPLOYERPK: ${{ secrets.L2_DEPLOYER_KEY }}
+              DEPLOY_L2_RPCADDRESS: obscuronode-1-${{ github.event.inputs.testnet_type }}.uksouth.cloudapp.azure.com
+              DEPLOY_L2_WSPORT: 81
+              DEPLOY_L2_FAUCETFUNDS: ${{ vars.FAUCET_INITIAL_FUNDS }}
+              NETWORK_L1_CONTRACTS_NETWORKCONFIG: ${{ needs.build.outputs.NETWORK_CONFIG_ADDR }}
+              NETWORK_L1_CONTRACTS_MESSAGEBUS: ${{ needs.build.outputs.MSG_BUS_CONTRACT_ADDR }}
+              NETWORK_L1_CONTRACTS_ROLLUP: ${{ needs.build.outputs.DA_REGISTRY_ADDR }}
+              NETWORK_L1_CONTRACTS_CROSSCHAIN: ${{ needs.build.outputs.CROSS_CHAIN_ADDR }}
+              NETWORK_L1_CONTRACTS_ENCLAVEREGISTRY: ${{ needs.build.outputs.ENCLAVE_REGISTRY_ADDR }}
+           run: |
+              go run ./testnet/launcher/l2contractdeployer/cmd \
+
+         - name: 'Save L2 deployer container logs'
+           run: |
+              docker logs `docker ps -aqf "name=hh-l2-deployer"` > deploy-l2-contracts.out 2>&1
+
+         - name: 'Upload L2 deployer container logs'
+           uses: actions/upload-artifact@v4
+           with:
+              name: deploy-l2-artifacts
+              path: |
+                 deploy-l2-contracts.out
+              retention-days: 7
+
+   update-loadbalancer:
+      needs:
+         - grant-sequencer-enclaves
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      steps:
+         - uses: actions/checkout@v4
+
+         - name: 'Login via Azure CLI'
+           uses: azure/login@v1
+           with:
+              creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+         - name: 'Remove existing backend nodes from the load balancer'
+           run: ./.github/workflows/runner-scripts/testnet-clear-loadbalancer.sh ${{ github.event.inputs.testnet_type }}
+
+         - name: 'Add load balancer address pool to the IP configuration'
+           uses: azure/CLI@v1
+           with:
+              inlineScript: |
+                 az network nic ip-config address-pool add \
+                   --address-pool ${{ github.event.inputs.testnet_type }}-backend-pool \
+                   --ip-config-name ipconfig${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }} \
+                   --nic-name ${{ vars.AZURE_RESOURCE_PREFIX }}-1-${{ GITHUB.RUN_NUMBER }}VMNic \
+                   --resource-group Testnet \
+                   --lb-name ${{ github.event.inputs.testnet_type }}-loadbalancer
+
+   deploy-faucet:
+      name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'
+      uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
+      with:
+         testnet_type: ${{ github.event.inputs.testnet_type }}
+      secrets: inherit
+      needs:
+         - grant-sequencer-enclaves
+
+   obscuro-test-repository-dispatch:
+      runs-on: ubuntu-latest
+      environment:
+         name: ${{ github.event.inputs.testnet_type }}
+      needs:
+         - deploy-faucet
+      steps:
+         - name: 'Send a repository dispatch to obscuro-test on deployment of dev-testnet'
+           if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') }}
+           run: |
+              curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/ten-protocol/ten-test/dispatches --data '{ "event_type": "dev_testnet_deployed", "client_payload": { "ref": "${{ github.ref_name }}" }'
+
+         - name: 'Send a repository dispatch to obscuro-test on deployment of testnet'
+           if: ${{ (github.event.inputs.testnet_type == 'uat-testnet') }}
+           run: |
+              curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/ten-protocol/ten-test/dispatches --data '{ "event_type": "uat_testnet_deployed", "client_payload": { "ref": "${{ github.ref_name }}" }'

--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -1,0 +1,137 @@
+# First step to deploying a new testnet, deploys the L1 contracts
+#
+# This script uses GitHub Environments for variables (vars) and secrets - these are configured on GitHub and
+#  the environments match the input.testnet_type options
+#
+# To deploy sepolia the user must type 'confirm' in the confirmation field
+
+name: '[M] Deploy Testnet L2'
+run-name: '[M] Deploy Testnet L2 ( ${{ github.event.inputs.testnet_type }} )'
+on:
+  workflow_dispatch:
+    inputs:
+      testnet_type:
+        description: 'Testnet Type'
+        required: true
+        default: 'dev-testnet'
+        type: choice
+        options:
+          - 'dev-testnet'
+          - 'uat-testnet'
+          - 'sepolia-testnet'
+      log_level:
+        description: 'Log Level 1-Error 5-Trace'
+        required: true
+        default: 3
+        type: number
+      confirmation:
+          description: 'Type "confirm" if deploying sepolia'
+          required: false
+          type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.testnet_type }}
+
+    # Map a step output to a job output
+    outputs:
+      NETWORK_CONFIG_ADDR: ${{ steps.deployContracts.outputs.NETWORK_CONFIG_ADDR }}
+      MSG_BUS_CONTRACT_ADDR: ${{ steps.deployContracts.outputs.MSG_BUS_CONTRACT_ADDR }}
+      BRIDGE_CONTRACT_ADDR: ${{ steps.deployContracts.outputs.BRIDGE_CONTRACT_ADDR }}
+      CROSS_CHAIN_ADDR: ${{ steps.deployContracts.outputs.CROSS_CHAIN_ADDR }}
+      DA_REGISTRY_ADDR: ${{ steps.deployContracts.outputs.DA_REGISTRY_ADDR }}
+      ENCLAVE_REGISTRY_ADDR: ${{ steps.deployContracts.outputs.ENCLAVE_REGISTRY_ADDR }}
+      L1_START_HASH: ${{ steps.deployContracts.outputs.L1_START_HASH }}
+
+
+    steps:
+      - name: 'Check confirmation'
+        # if env is sepolia then confirmation field needs to say 'confirm'
+        run: |
+          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to deploy sepolia to avoid accidental deployments"
+            exit 1
+          fi
+
+      - name: 'Print GitHub variables'
+        # This is a useful record of what the environment variables were at the time the job ran, for debugging and reference
+        run: |
+          echo "GitHub Variables = ${{ toJSON(vars) }}"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.5
+
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: 'Login to Azure docker registry'
+        uses: azure/docker-login@v1
+        with:
+          login-server: testnetobscuronet.azurecr.io
+          username: testnetobscuronet
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 'Build and push obscuro node images'
+        run: |
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }} -f dockerfiles/enclave.Dockerfile  .
+          docker push ${{ vars.DOCKER_BUILD_TAG_ENCLAVE }}
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_HOST }} -f dockerfiles/host.Dockerfile .
+          docker push ${{ vars.DOCKER_BUILD_TAG_HOST }}
+          DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }} -f tools/hardhatdeployer/Dockerfile .
+          docker push ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+
+      - name: 'Deploy Contracts'
+        id: deployContracts
+        shell: bash
+        env:
+          DOCKER_API_VERSION: "1.45"
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          DEPLOY_DOCKERIMAGE: ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+          DEPLOY_NETWORKNAME: ${{ github.event.inputs.testnet_type }}
+          DEPLOY_OUTPUTAZUREKV: ${{ secrets.AZURE_KEY_VAULT_URL }}
+          DEPLOY_OUTPUTENV: ./testnet/.env
+          DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
+          DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
+        run: |
+          # Run deployer and capture output
+          go run ./testnet/launcher/l1contractdeployer/cmd
+          
+          if [ -f ./testnet/.env ]; then
+            source ./testnet/.env
+          fi          
+          # Fix variable names and GITHUB_OUTPUT reference
+          echo "NETWORK_CONFIG_ADDR=$NETWORKCONFIGADDR" >> $GITHUB_ENV
+          echo "NETWORK_CONFIG_ADDR=$NETWORKCONFIGADDR" >> $GITHUB_OUTPUT
+          
+          echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_ENV
+          echo "MSG_BUS_CONTRACT_ADDR=$MSGBUSCONTRACTADDR" >> $GITHUB_OUTPUT
+          
+          echo "BRIDGE_CONTRACT_ADDR=$BRIDGECONTRACTADDR" >> $GITHUB_ENV
+          echo "BRIDGE_CONTRACT_ADDR=$BRIDGECONTRACTADDR" >> $GITHUB_OUTPUT
+          
+          echo "CROSS_CHAIN_ADDR=$CROSSCHAINADDR" >> $GITHUB_ENV
+          echo "CROSS_CHAIN_ADDR=$CROSSCHAINADDR" >> $GITHUB_OUTPUT
+          
+          echo "DA_REGISTRY_ADDR=$DAREGISTRYADDR" >> $GITHUB_ENV
+          echo "DA_REGISTRY_ADDR=$DAREGISTRYADDR" >> $GITHUB_OUTPUT
+          
+          echo "ENCLAVE_REGISTRY_ADDR=$ENCLAVEREGISTRYADDR" >> $GITHUB_ENV
+          echo "ENCLAVE_REGISTRY_ADDR=$ENCLAVEREGISTRYADDR" >> $GITHUB_OUTPUT
+          
+          echo "L1_START_HASH=$L1START" >> $GITHUB_ENV
+          echo "L1_START_HASH=$L1START" >> $GITHUB_OUTPUT
+
+      - name: 'Save L1 deployer container logs'
+        # Wait to make sure the logs are available in the container
+        run: |
+          sleep 60
+          docker logs `docker ps -aqf "name=hh-l1-deployer"` > deploy-l1-contracts.out 2>&1


### PR DESCRIPTION
### Why this change is needed

To start testing the before/after node deployment k8s scripts we need to get them merged so they are available in the GH actions workflows.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


