### PR TITLE
GH Actions: fix script name to avoid chaos

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -5,8 +5,8 @@
 #
 # To deploy sepolia the user must type 'confirm' in the confirmation field
 
-name: '[M] Deploy Testnet L2'
-run-name: '[M] Deploy Testnet L2 ( ${{ github.event.inputs.testnet_type }} )'
+name: '[M] k8s Prepare testnet setup'
+run-name: '[M] k8s Prepare testnet setup ( ${{ github.event.inputs.testnet_type }} )'
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Why this change is needed

Accidentally duplicated main testnet deploy name, need to fix that to avoid confusion.
<img width="236" alt="image" src="https://github.com/user-attachments/assets/573406a1-8937-40e8-8d82-6e67b45caca2" />

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


