### PR TITLE
Fix gateway encryption key handling

### DIFF
--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -12,9 +12,8 @@
 # If we are deploying to a non primary instance all those variables should be prefixed with the instance name
 # example: DEXYNTH_DOCKER_BUILD_TAG_GATEWAY
 
-
-name: '[M] Deploy Ten Gateway Backend'
-run-name: '[M] Deploy Ten Gateway Backend ( ${{ github.event.inputs.testnet_type }} )'
+name: "[M] Deploy Ten Gateway Backend"
+run-name: "[M] Deploy Ten Gateway Backend ( ${{ github.event.inputs.testnet_type }} )"
 on:
   workflow_dispatch:
     inputs:
@@ -97,7 +96,7 @@ jobs:
             "GATEWAY_RATE_LIMIT_USER_COMPUTE_TIME"
             "GATEWAY_RATE_LIMIT_WINDOW"
             "GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER"
-            "GATEWAY_KEY_EXCHANGE_URL"
+            "GATEWAY_ENCRYPTION_KEY_SOURCE"
             "GATEWAY_TLS_DOMAIN"
             "GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED"
             "GATEWAY_DISABLE_CACHING"
@@ -129,7 +128,7 @@ jobs:
           echo "GATEWAY_RATE_LIMIT_USER_COMPUTE_TIME: $GATEWAY_RATE_LIMIT_USER_COMPUTE_TIME"
           echo "GATEWAY_RATE_LIMIT_WINDOW: $GATEWAY_RATE_LIMIT_WINDOW"
           echo "GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER: $GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER"
-          echo "GATEWAY_KEY_EXCHANGE_URL: $GATEWAY_KEY_EXCHANGE_URL"
+          echo "GATEWAY_ENCRYPTION_KEY_SOURCE: $GATEWAY_ENCRYPTION_KEY_SOURCE"
           echo "GATEWAY_TLS_DOMAIN: $GATEWAY_TLS_DOMAIN"
           echo "GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED: $GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED"
 
@@ -217,7 +216,7 @@ jobs:
               --authentication-type password --security-type Standard 
               
             az vm open-port -g Testnet -n "${{ env.VM_NAME }}" --port 80,81,443
-            
+
             # Allow time for VM initialization
             sleep 30
 
@@ -235,7 +234,7 @@ jobs:
               --authentication-type password --security-type Standard 
               
             az vm open-port -g Testnet -n "${{ env.VM_NAME }}" --port 80,81,443
-            
+
             # Allow time for VM initialization
             sleep 30
 
@@ -279,7 +278,7 @@ jobs:
             mkdir -p /home/obscuro/metrics
 
             cat <<EOF > /home/obscuro/metrics/promtail-config.yaml
-            
+
             server:
               http_listen_port: 9080
               grpc_listen_port: 0
@@ -316,7 +315,7 @@ jobs:
 
             docker stop promtail || true
             docker rm promtail || true
-            
+
             docker run -d --name promtail \
             --network node_network \
             -e HOSTNAME="${{ env.VM_NAME }}" \
@@ -402,13 +401,13 @@ jobs:
             -v /dev/disk/:/dev/disk:ro \
             gcr.io/cadvisor/cadvisor:latest
             # Promtail Integration End
-            
+
             docker volume create "TENGateway-${{ github.event.inputs.testnet_type }}-data" || true
 
             # Stop and remove existing container if it exists
             docker stop "${{ env.VM_NAME }}" || true
             docker rm "${{ env.VM_NAME }}" || true
-            
+
             docker pull ${{ env.DOCKER_BUILD_TAG_GATEWAY }}
 
             # Start Ten Gateway Container
@@ -424,13 +423,13 @@ jobs:
             -rateLimitUserComputeTime="${{ env.GATEWAY_RATE_LIMIT_USER_COMPUTE_TIME }}" \
             -rateLimitWindow="${{ env.GATEWAY_RATE_LIMIT_WINDOW }}" \
             -maxConcurrentRequestsPerUser="${{ env.GATEWAY_MAX_CONCURRENT_REQUESTS_PER_USER }}" \
-            -keyExchangeURL="${{ env.GATEWAY_KEY_EXCHANGE_URL }}" \
+            -encryptionKeySource="${{ env.GATEWAY_ENCRYPTION_KEY_SOURCE }}" \
             -insideEnclave=true \
             -enableTLS=true \
             -tlsDomain="${{ env.GATEWAY_TLS_DOMAIN }}" \
             -encryptingCertificateEnabled="${{ env.GATEWAY_ENCRYPTING_CERTIFICATE_ENABLED }}" \
             -disableCaching="${{ env.GATEWAY_DISABLE_CACHING }}"
-            
+
             docker exec "${{ env.VM_NAME }}" sh -c "
                 echo \"Checking volume mount...\";
                 df -h | grep /data;

--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	RateLimitMaxConcurrentRequests int
 
 	InsideEnclave                bool // Indicates if the program is running inside an enclave
-	KeyExchangeURL               string
+	EncryptionKeySource          string
 	EnableTLS                    bool
 	TLSDomain                    string
 	EncryptingCertificateEnabled bool

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -53,49 +53,9 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		return nil, nil
 	}
 
-	if config.EncryptionKeySource != "" {
-		var encryptionKey []byte
-		var err error
-
-		// If the "new" keyword is used for the encryptionKeySource, we first check if there is an existing encryption key
-		// that can be unsealed and used. If no such key is found, we proceed to generate a new random encryption key.
-		// This ensures that we do not overwrite an existing key unless necessary, and a new key is only generated when
-		// there is no existing key available.
-		if config.EncryptionKeySource == "new" {
-			logger.Info("encryptionKeySource set to 'new' -> checking if there is an existing encryption key that we can use")
-			var found bool
-			encryptionKey, found, _ = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
-			if !found {
-				logger.Info("No existing encryption key found, generating new random encryption key")
-				encryptionKey, err = common.GenerateRandomKey()
-				if err != nil {
-					logger.Crit("unable to generate random encryption key", log.ErrKey, err)
-					return nil, err
-				}
-			}
-		} else {
-			// Attempt to perform key exchange with the specified key provider.
-			// This step is crucial, and the process should fail if the key exchange is not successful.
-			logger.Info(fmt.Sprintf("encryptionKeySource set to '%s', trying to get encryption key from key provider", config.EncryptionKeySource))
-			encryptionKey, err = HandleKeyExchange(config, logger)
-			if err != nil {
-				logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)
-				return nil, err
-			}
-		}
-
-		// Seal the key that we generated / got from the key exchange from another enclave
-		err = trySealKey(encryptionKey, encryptionKeyFile, config.InsideEnclave)
-		if err != nil {
-			logger.Crit("unable to seal encryption key", log.ErrKey, err)
-			return nil, err
-		}
-		logger.Info("sealed new encryption key")
-
-		return encryptionKey, nil
-	} else {
-		// If no encryptionKeySource is provided, attempt to unseal an existing encryption key and fail if no key is found
-		// (in this case operator needs to provide a source for the encryption key or decide to generate a new one)
+	// If no encryptionKeySource is provided, attempt to unseal an existing encryption key and fail if no key is found
+	// (in this case operator needs to provide a source for the encryption key or decide to generate a new one)
+	if config.EncryptionKeySource == "" {
 		logger.Info("no key exchange url set, try to unseal existing encryption key")
 		encryptionKey, found, err := tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
 		if !found {
@@ -105,6 +65,46 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		logger.Info("unsealed existing encryption key")
 		return encryptionKey, nil
 	}
+
+	var encryptionKey []byte
+	var err error
+
+	// If the "new" keyword is used for the encryptionKeySource, we first check if there is an existing encryption key
+	// that can be unsealed and used. If no such key is found, we proceed to generate a new random encryption key.
+	// This ensures that we do not overwrite an existing key unless necessary, and a new key is only generated when
+	// there is no existing key available.
+	if config.EncryptionKeySource == "new" {
+		logger.Info("encryptionKeySource set to 'new' -> checking if there is an existing encryption key that we can use")
+		var found bool
+		encryptionKey, found, _ = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
+		if !found {
+			logger.Info("No existing encryption key found, generating new random encryption key")
+			encryptionKey, err = common.GenerateRandomKey()
+			if err != nil {
+				logger.Crit("unable to generate random encryption key", log.ErrKey, err)
+				return nil, err
+			}
+		}
+	} else {
+		// Attempt to perform key exchange with the specified key provider.
+		// This step is crucial, and the process should fail if the key exchange is not successful.
+		logger.Info(fmt.Sprintf("encryptionKeySource set to '%s', trying to get encryption key from key provider", config.EncryptionKeySource))
+		encryptionKey, err = HandleKeyExchange(config, logger)
+		if err != nil {
+			logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)
+			return nil, err
+		}
+	}
+
+	// Seal the key that we generated / got from the key exchange from another enclave
+	err = trySealKey(encryptionKey, encryptionKeyFile, config.InsideEnclave)
+	if err != nil {
+		logger.Crit("unable to seal encryption key", log.ErrKey, err)
+		return nil, err
+	}
+	logger.Info("sealed new encryption key")
+
+	return encryptionKey, nil
 }
 
 // tryUnsealKey attempts to unseal an encryption key from disk

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -65,7 +65,7 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 				return nil, err
 			}
 		} else {
-			logger.Info("keyExchangeUrl set to a specific url, trying to get encryption key from key provider")
+			logger.Info(fmt.Sprintf("keyExchangeUrl set to '%s', trying to get encryption key from key provider", config.KeyExchangeURL))
 			encryptionKey, err = HandleKeyExchange(config, logger)
 			if err != nil {
 				logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -58,11 +58,16 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		var err error
 
 		if config.KeyExchangeURL == "new" {
-			logger.Info("ketExchangeUrl set to 'new', generating new encryption key")
-			encryptionKey, err = common.GenerateRandomKey()
-			if err != nil {
-				logger.Crit("unable to generate random encryption key", log.ErrKey, err)
-				return nil, err
+			logger.Info("keyExchangeUrl set to 'new' -> checking if there is an existing encryption key that we can use")
+			var found bool
+			encryptionKey, found, err = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
+			if !found {
+				logger.Info("No existing encryption key found, generating new random encryption key")
+				encryptionKey, err = common.GenerateRandomKey()
+				if err != nil {
+					logger.Crit("unable to generate random encryption key", log.ErrKey, err)
+					return nil, err
+				}
 			}
 		} else {
 			logger.Info(fmt.Sprintf("keyExchangeUrl set to '%s', trying to get encryption key from key provider", config.KeyExchangeURL))

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -92,7 +92,6 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		logger.Info("unsealed existing encryption key")
 		return encryptionKey, nil
 	}
-
 }
 
 // tryUnsealKey attempts to unseal an encryption key from disk

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -40,12 +40,12 @@ type KeyExchangeResponse struct {
 	EncryptedKey string `json:"encrypted_key"` // Base64 encoded encrypted encryption key
 }
 
-// GetEncryptionKey returns encryption key for the database
-// 1.) If we use an SQLite database, no encryption key is needed as SQLite typically runs in development or testing environments.
-// 2.) If a key exchange URL is provided, attempt to obtain the encryption key from the specified URL.
-// 3.) If the key exchange URL is set to "new", generate a new encryption key.
-// 4.) If no key exchange URL is provided, attempt to unseal an existing encryption key.
-// 5.) If a new key is generated or obtained, seal it for future use.
+// GetEncryptionKey returns the encryption key for the database
+// - If we use an SQLite database, no encryption key is needed as SQLite typically runs in development or testing environments.
+// - If a key exchange URL is provided, attempt to obtain the encryption key from the specified URL.
+// - If the key exchange URL is set to "new", check for an existing encryption key and generate a new one if not found.
+// - If no key exchange URL is provided, attempt to unseal an existing encryption key.
+// - If a new key is generated or obtained, seal it for future use.
 func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, error) {
 	// check if we are using sqlite database and no encryption key needed
 	if config.DBType == "sqlite" {
@@ -60,7 +60,7 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		if config.EncryptionKeySource == "new" {
 			logger.Info("encryptionKeySource set to 'new' -> checking if there is an existing encryption key that we can use")
 			var found bool
-			encryptionKey, found, err = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
+			encryptionKey, found, _ = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
 			if !found {
 				logger.Info("No existing encryption key found, generating new random encryption key")
 				encryptionKey, err = common.GenerateRandomKey()

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -41,10 +41,10 @@ type KeyExchangeResponse struct {
 }
 
 // GetEncryptionKey returns encryption key for the database
-// If we use sqlite database we don't need to do anything since sqlite does not need encryption and is usually running in dev environments / for testing
-// By default, we try to read from the sealed key
-// If KeyExchangeURL equals "new" we generate a new key
-// If KeyExchangeURL is a URL we try to perform key exchange
+// 1.) If we use sqlite database we don't need to do anything since sqlite does not need encryption and is usually running in dev environments / for testing
+// 2.) We need to check if the key is already sealed and unseal it if so
+// 3.) If there is a URL to exchange the key with another enclave we need to get the key from there and seal it on this enclave
+// 4.) If the key is not sealed and we don't have the URL to exchange the key we need to generate a new one and seal it
 func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, error) {
 	// 1.) check if we are using sqlite database and no encryption key needed
 	if config.DBType == "sqlite" {
@@ -53,13 +53,11 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 	}
 
 	var encryptionKey []byte
-	var err error
 
-	// 2.) Try to read from sealed key by default
+	// 2.) Check if we have a sealed encryption key and try to unseal it
 	encryptionKey, found, err := tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
 	if err != nil {
-		logger.Error("unable to unseal encryption key", log.ErrKey, err)
-		return nil, fmt.Errorf("failed to unseal encryption key: %w", err)
+		logger.Info("unable to unseal encryption key", log.ErrKey, err)
 	}
 	// If we found a sealed key we can return it
 	if found {
@@ -67,34 +65,34 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		return encryptionKey, nil
 	}
 
-	// 3.) If KeyExchangeURL is "new", generate a new key
-	if config.KeyExchangeURL == "new" {
-		encryptionKey, err = common.GenerateRandomKey()
-		if err != nil {
-			logger.Error("unable to generate random encryption key", log.ErrKey, err)
-			return nil, fmt.Errorf("failed to generate random encryption key: %w", err)
-		}
-		logger.Info("generated new encryption key")
-	} else if config.KeyExchangeURL != "" {
-		// 4.) If KeyExchangeURL is a URL, try to perform key exchange
+	// 3.) We have to exchange the key with another enclave if we have a key exchange url set
+	if config.KeyExchangeURL != "" {
 		encryptionKey, err = HandleKeyExchange(config, logger)
 		if err != nil {
-			logger.Error("unable to exchange key", log.ErrKey, err)
-			return nil, fmt.Errorf("failed to exchange key: %w", err)
+			logger.Crit("unable to exchange key", log.ErrKey, err)
+		} else {
+			logger.Info("successfully exchanged key with another enclave")
 		}
-		logger.Info("successfully exchanged key with another enclave")
-	} else {
-		// If no key was found and no action specified, return error
-		return nil, fmt.Errorf("no encryption key found and no action specified (use 'new' to generate a new key or provide a key exchange URL)")
 	}
 
-	// Seal the key that we generated / got from the key exchange
+	// 4.) If we don't have a key we need to generate a new one
+	if len(encryptionKey) == 0 {
+		encryptionKey, err = common.GenerateRandomKey()
+		if err != nil {
+			logger.Crit("unable to generate random encryption key", log.ErrKey, err)
+			return nil, err
+		} else {
+			logger.Info("Successfully generated random encryption key")
+		}
+	}
+
+	// Seal the key that we generated / got from the key exchange from another enclave
 	err = trySealKey(encryptionKey, encryptionKeyFile, config.InsideEnclave)
 	if err != nil {
-		logger.Error("unable to seal encryption key", log.ErrKey, err)
-		return nil, fmt.Errorf("failed to seal encryption key: %w", err)
+		logger.Crit("unable to seal encryption key", log.ErrKey, err)
+		return nil, err
 	}
-	logger.Info("sealed encryption key")
+	logger.Info("sealed new encryption key")
 
 	return encryptionKey, nil
 }

--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -53,12 +53,12 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		return nil, nil
 	}
 
-	if config.KeyExchangeURL != "" {
+	if config.EncryptionKeySource != "" {
 		var encryptionKey []byte
 		var err error
 
-		if config.KeyExchangeURL == "new" {
-			logger.Info("keyExchangeUrl set to 'new' -> checking if there is an existing encryption key that we can use")
+		if config.EncryptionKeySource == "new" {
+			logger.Info("encryptionKeySource set to 'new' -> checking if there is an existing encryption key that we can use")
 			var found bool
 			encryptionKey, found, err = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
 			if !found {
@@ -70,7 +70,7 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 				}
 			}
 		} else {
-			logger.Info(fmt.Sprintf("keyExchangeUrl set to '%s', trying to get encryption key from key provider", config.KeyExchangeURL))
+			logger.Info(fmt.Sprintf("encryptionKeySource set to '%s', trying to get encryption key from key provider", config.EncryptionKeySource))
 			encryptionKey, err = HandleKeyExchange(config, logger)
 			if err != nil {
 				logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)
@@ -178,7 +178,7 @@ func HandleKeyExchange(config common.Config, logger gethlog.Logger) ([]byte, err
 	}
 
 	// Step 8: Send the message to KeyProvider via HTTP POST
-	resp, err := http.Post(config.KeyExchangeURL+"/v1"+common.PathKeyExchange, "application/json", bytes.NewBuffer(messageBytesRequester))
+	resp, err := http.Post(config.EncryptionKeySource+"/v1"+common.PathKeyExchange, "application/json", bytes.NewBuffer(messageBytesRequester))
 	if err != nil {
 		logger.Error("KeyRequester: Failed to send message to KeyProvider", "error", err)
 		return nil, fmt.Errorf("failed to send message to KeyProvider: %w", err)

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -77,9 +77,9 @@ const (
 	insideEnclaveFlagDefault = false
 	insideEnclaveFlagUsage   = "Flag to indicate if the program is running inside an enclave. Default: false"
 
-	keyExchangeURLFlagName    = "keyExchangeURL"
-	keyExchangeURLFlagDefault = ""
-	keyExchangeURLFlagUsage   = "URL to exchange the key with another enclave. If set to 'new', a new key will be generated. If empty, it will try to read from sealed key. Default: empty"
+	encryptionKeySourceFlagName    = "encryptionKeySource"
+	encryptionKeySourceFlagDefault = ""
+	encryptionKeySourceFlagUsage   = "Source of the encryption key for the gateway database. It can be set to empty (read from the sealed key), URL of another gateway with which we can exchange the key or 'new' to generate a new key (but only if sealed key is not present). Default: empty"
 
 	enableTLSFlagName    = "enableTLS"
 	enableTLSFlagDefault = false
@@ -116,7 +116,7 @@ func parseCLIArgs() wecommon.Config {
 	rateLimitWindow := flag.Duration(rateLimitWindowName, rateLimitWindowDefault, rateLimitWindowUsage)
 	rateLimitMaxConcurrentRequests := flag.Int(rateLimitMaxConcurrentRequestsName, rateLimitMaxConcurrentRequestsDefault, rateLimitMaxConcurrentRequestsUsage)
 	insideEnclaveFlag := flag.Bool(insideEnclaveFlagName, insideEnclaveFlagDefault, insideEnclaveFlagUsage)
-	keyExchangeURL := flag.String(keyExchangeURLFlagName, keyExchangeURLFlagDefault, keyExchangeURLFlagUsage)
+	encryptionKeySource := flag.String(encryptionKeySourceFlagName, encryptionKeySourceFlagDefault, encryptionKeySourceFlagUsage)
 	enableTLSFlag := flag.Bool(enableTLSFlagName, enableTLSFlagDefault, enableTLSFlagUsage)
 	tlsDomainFlag := flag.String(tlsDomainFlagName, tlsDomainFlagDefault, tlsDomainFlagUsage)
 	encryptingCertificateEnabled := flag.Bool(encryptingCertificateEnabledFlagName, encryptingCertificateEnabledFlagDefault, encryptingCertificateEnabledFlagUsage)
@@ -140,7 +140,7 @@ func parseCLIArgs() wecommon.Config {
 		RateLimitWindow:                *rateLimitWindow,
 		RateLimitMaxConcurrentRequests: *rateLimitMaxConcurrentRequests,
 		InsideEnclave:                  *insideEnclaveFlag,
-		KeyExchangeURL:                 *keyExchangeURL,
+		EncryptionKeySource:            *encryptionKeySource,
 		EnableTLS:                      *enableTLSFlag,
 		TLSDomain:                      *tlsDomainFlag,
 		EncryptingCertificateEnabled:   *encryptingCertificateEnabled,


### PR DESCRIPTION
### Why this change is needed

It was confusing which value was read and there were some issues in the recent version of the code preventing gateway to get the keys we wanted.

### What changes were made as part of this PR

### 1. Renamed Configuration Parameter
- Changed `KeyExchangeURL` to `EncryptionKeySource` for better clarity of purpose
- The new parameter name better reflects its role in the key management process

### 2. Enhanced Key Source Logic
The `EncryptionKeySource` parameter now supports three distinct modes:

#### a) Empty String (`""`)
- Attempts to unseal an existing encryption key
- If no key is found, fails with a clear error message
- Requires operator intervention to either:
  - Provide a key source
  - Generate a new key

#### b) "new" Value
- First checks for an existing sealed key
- Only generates a new key if no existing key is found
- Prevents unnecessary key regeneration
- Preserves existing keys when possible

#### c) URL Value
- Performs secure key exchange with the specified gateway
- Fails explicitly if key exchange is unsuccessful

### 3. Improved Error Handling



### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


