### PR TITLE
Add new catastrophic error to edb

### DIFF
--- a/go/enclave/storage/init/edgelessdb/edgelessdb.go
+++ b/go/enclave/storage/init/edgelessdb/edgelessdb.go
@@ -497,7 +497,7 @@ func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 			&mysql.MySQLDriver{},
 			logger,
 			func(err error) bool {
-				return strings.Contains(err.Error(), "connection refused")
+				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "invalid connection")
 			}),
 	)
 	return driverName


### PR DESCRIPTION
### Why this change is needed

Fail the enclave on "invalid connection" to avoid the enclave entering an invalid state

### What changes were made as part of this PR



### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


