### PR TITLE
implement key-value nil check

### DIFF
--- a/go/enclave/storage/enclavedb/enclave_sql_db.go
+++ b/go/enclave/storage/enclavedb/enclave_sql_db.go
@@ -77,6 +77,12 @@ func (sqlDB *enclaveDB) Get(key []byte) ([]byte, error) {
 }
 
 func (sqlDB *enclaveDB) Put(key []byte, value []byte) error {
+	if key == nil {
+		return errors.New("key cannot be nil")
+	}
+	if value == nil {
+		return fmt.Errorf("value cannot be nil. key: %x", key)
+	}
 	ctx, cancelCtx := context.WithTimeout(context.Background(), sqlDB.config.RPCTimeout)
 	defer cancelCtx()
 	return Put(ctx, sqlDB.sqldb, key, value)


### PR DESCRIPTION
### Why this change is needed

We had a weird error on the testnet where the "value" was nil. It failed at db "commit" time, because it violated the NULL db constraint

### What changes were made as part of this PR

- check for nil early to fail the offending transaction

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


