### PR TITLE
L2 contract deploy: update node http port

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -116,6 +116,11 @@ jobs:
                username: testnetobscuronet
                password: ${{ secrets.REGISTRY_PASSWORD }}
 
+         -  uses: actions/checkout@v4
+
+         -  uses: actions/setup-go@v5
+            with:
+               go-version: 1.23.5
          -  name: 'Build and push obscuro node images'
             run: |
                DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }} -f tools/hardhatdeployer/Dockerfile .

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -128,7 +128,9 @@ jobs:
 
    check-obscuro-is-healthy:
       runs-on: ubuntu-latest
-      needs: build
+      needs:
+         - read-l1-config
+         - build
       environment:
          name: ${{ github.event.inputs.testnet_type }}
       steps:

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -128,7 +128,7 @@ jobs:
 
    check-obscuro-is-healthy:
       runs-on: ubuntu-latest
-      needs: read-l1-config
+      needs: build
       environment:
          name: ${{ github.event.inputs.testnet_type }}
       steps:

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -206,6 +206,7 @@ jobs:
               DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
               DEPLOY_L2_DEPLOYERPK: ${{ secrets.L2_DEPLOYER_KEY }}
               DEPLOY_L2_RPCADDRESS: ${{ needs.read-l1-config.outputs.TESTNET_SHORT_NAME }}-validator-01.ten.xyz
+              DEPLOY_L2_HTTPPORT: 8085
               DEPLOY_L2_WSPORT: 8089
               DEPLOY_L2_FAUCETFUNDS: ${{ vars.FAUCET_INITIAL_FUNDS }}
               NETWORK_L1_CONTRACTS_NETWORKCONFIG: ${{ needs.read-l1-config.outputs.network_config }}

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -98,6 +98,29 @@ jobs:
                echo "enclave_registry=$(yq -r '.l1Config.enclaveRegistry' "$CFG")"   >> $GITHUB_OUTPUT
                echo "start_hash=$(yq -r '.l1Config.starthash'             "$CFG")"   >> $GITHUB_OUTPUT
 
+   build:
+        runs-on: ubuntu-latest
+        needs: read-l1-config
+        environment:
+            name: ${{ github.event.inputs.testnet_type }}
+        steps:
+         -  name: 'Login via Azure CLI'
+            uses: azure/login@v1
+            with:
+               creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+         -  name: 'Login to Azure docker registry'
+            uses: azure/docker-login@v1
+            with:
+               login-server: testnetobscuronet.azurecr.io
+               username: testnetobscuronet
+               password: ${{ secrets.REGISTRY_PASSWORD }}
+
+         -  name: 'Build and push obscuro node images'
+            run: |
+               DOCKER_BUILDKIT=1 docker build -t ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }} -f tools/hardhatdeployer/Dockerfile .
+               docker push ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
+
    check-obscuro-is-healthy:
       runs-on: ubuntu-latest
       needs: read-l1-config

--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -104,7 +104,8 @@ deploy:
     challengePeriod: 1 # challenge period for rollups in seconds
   l2:
     rpcAddress: "localhost" # L2 RPC address for deploying contracts
-    wsPort: 8546 # L2 RPC port for deploying contracts
+    httpPort: 8085 # L2 RPC port for deploying contracts
+    wsPort: 8089 # L2 RPC port for deploying contracts
     deployerPK: 0x0 # private key for the deployer account
     faucetPrefund: 10000 # amount of ETH to pre-fund the faucet account
     sequencerURL: "" # sequencer URL to fetch its HA enclave IDs

--- a/go/config/deployment.go
+++ b/go/config/deployment.go
@@ -28,6 +28,7 @@ type L1DeployConfig struct {
 //	yaml: `deploy.l2`
 type L2DeployConfig struct {
 	RPCAddress    string `mapstructure:"rpcAddress"`    // an RPC address for the L2 network
+	HTTPPort      int    `mapstructure:"httpPort"`      // the port for the L2 network RPC (http)
 	WSPort        int    `mapstructure:"wsPort"`        // the port for the L2 network RPC websocket
 	DeployerPK    string `mapstructure:"deployerPK"`    // the private key of the L2 deployer account
 	FaucetPrefund string `mapstructure:"faucetPrefund"` // initial amount of funds to pre-fund the faucet account

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -110,7 +110,8 @@ func (t *Testnet) Start() error {
 		&l2cd.Config{
 			L1HTTPURL:              "http://eth2network:8025",
 			L2Host:                 "sequencer-host",
-			L2Port:                 81,
+			L2HTTPPort:             80,
+			L2WSPort:               81,
 			L1PrivateKey:           "f52e5418e349dccdda29b6ac8b0abe6576bb7713886aa85abea6181ba731f9bb",
 			MessageBusAddress:      networkConfig.MessageBusAddress,
 			NetworkConfigAddress:   networkConfig.NetworkConfigAddress,

--- a/testnet/launcher/l2contractdeployer/config.go
+++ b/testnet/launcher/l2contractdeployer/config.go
@@ -8,8 +8,9 @@ import (
 type Config struct {
 	L1HTTPURL              string
 	L1PrivateKey           string
-	L2Port                 int
 	L2Host                 string
+	L2HTTPPort             int
+	L2WSPort               int
 	L2PrivateKey           string
 	EnclaveRegistryAddress string
 	CrossChainAddress      string
@@ -25,7 +26,8 @@ func NewContractDeployerConfig(tenCfg *config.TenConfig) *Config {
 	return &Config{
 		L1HTTPURL:              tenCfg.Deployment.L1Deploy.RPCAddress,
 		L1PrivateKey:           tenCfg.Deployment.L1Deploy.DeployerPK,
-		L2Port:                 tenCfg.Deployment.L2Deploy.WSPort,
+		L2HTTPPort:             tenCfg.Deployment.L2Deploy.HTTPPort,
+		L2WSPort:               tenCfg.Deployment.L2Deploy.WSPort,
 		L2Host:                 tenCfg.Deployment.L2Deploy.RPCAddress,
 		L2PrivateKey:           tenCfg.Deployment.L2Deploy.DeployerPK,
 		EnclaveRegistryAddress: tenCfg.Network.L1.L1Contracts.EnclaveRegistryContract.Hex(),

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -39,7 +39,8 @@ func (n *ContractDeployer) Start() error {
 
 	envs := map[string]string{
 		"L2_HOST":               n.cfg.L2Host,
-		"L2_PORT":               strconv.Itoa(n.cfg.L2Port),
+		"L2_HTTP_PORT":          strconv.Itoa(n.cfg.L2HTTPPort),
+		"L2_WS_PORT":            strconv.Itoa(n.cfg.L2WSPort),
 		"PREFUND_FAUCET_AMOUNT": n.cfg.FaucetPrefundAmount,
 		"ENCLAVE_REGISTRY_ADDR": n.cfg.EnclaveRegistryAddress,
 		"CROSS_CHAIN_ADDR":      n.cfg.CrossChainAddress,

--- a/tools/hardhatdeployer/scripts/entrypoint.sh
+++ b/tools/hardhatdeployer/scripts/entrypoint.sh
@@ -1,3 +1,3 @@
-/home/obscuro/go-obscuro/tools/walletextension/bin/wallet_extension_linux -portWS="3001" -nodeHost="${L2_HOST}" -nodePortWS="${L2_PORT}"&
+/home/obscuro/go-obscuro/tools/walletextension/bin/wallet_extension_linux -portWS="3001" -nodeHost="${L2_HOST}" -nodePortHTTP="${L2_HTTP_PORT}" -nodePortWS="${L2_WS_PORT}"&
 
 npx hardhat "$@"


### PR DESCRIPTION
### Why this change is needed

RPC HTTP port has changed for the L2 nodes but it wasn't configurable for the L2 contract deployer script.

Unfortunately this needed wiring through in a few places so it can be set on the gateway at startup (but it looks less weird now, before it only accepted a WS port as config and assumed the HTTP port was static).

### What changes were made as part of this PR

Add flag to the script that spins up the gateway for the deployer to allow http port to be set. Wire that through to the ten config that configures the deploy script.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


