### PR TITLE
Make UnrenouncableOwnable2Step upgradable

### DIFF
--- a/contracts/src/common/UnrenouncableOwnable2Step.sol
+++ b/contracts/src/common/UnrenouncableOwnable2Step.sol
@@ -2,9 +2,30 @@
 pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
+/**
+ * @title UnrenouncableOwnable2Step
+ * @dev Contract that extends Ownable2StepUpgradeable but prevents renouncing ownership
+ */
 contract UnrenouncableOwnable2Step is Ownable2StepUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
 
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     * @param initialOwner The address that will be the initial owner
+     */
+    function __UnrenouncableOwnable2Step_init(address initialOwner) internal onlyInitializing {
+        __Ownable2Step_init();  // Initialize Ownable2StepUpgradeable without owner
+        _transferOwnership(initialOwner);  // Set the owner explicitly
+    }
+
+    /**
+     * @dev Prevents renouncing ownership
+     */
     function renounceOwnership() public view override onlyOwner {
         revert("UnrenouncableOwnable2Step: cannot renounce ownership");
     }

--- a/contracts/src/cross_chain_messaging/common/MessageBus.sol
+++ b/contracts/src/cross_chain_messaging/common/MessageBus.sol
@@ -16,18 +16,18 @@ import "../../common/UnrenouncableOwnable2Step.sol";
  * Manages message publishing, verification, and value transfers between L1 and L2.
  */
 contract MessageBus is IMessageBus, Initializable, UnrenouncableOwnable2Step {
-
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _transferOwnership(msg.sender);
+        _disableInitializers();
     }
 
-     /**
+    /**
      * @dev Initializes the contract with an owner and fees contract
      * @param caller The address to set as the owner
      * @param feesAddress The address of the fees contract
      */
     function initialize(address caller, address feesAddress) public virtual initializer {
-        __Ownable_init(caller);
+        __UnrenouncableOwnable2Step_init(caller);  // Initialize UnrenouncableOwnable2Step
         fees = IFees(feesAddress);
     }
 

--- a/contracts/src/l1_management/contracts/CrossChain.sol
+++ b/contracts/src/l1_management/contracts/CrossChain.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import "../interfaces/ICrossChain.sol";
 import * as MessageBus from "../../cross_chain_messaging/common/MessageBus.sol";
@@ -33,8 +35,9 @@ contract CrossChain is ICrossChain, Initializable, UnrenouncableOwnable2Step, Re
     MessageBus.IMessageBus public messageBus;
     MerkleTreeMessageBus.IMerkleTreeMessageBus public merkleMessageBus;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _transferOwnership(msg.sender);
+        _disableInitializers();
     }
 
     /**
@@ -42,7 +45,7 @@ contract CrossChain is ICrossChain, Initializable, UnrenouncableOwnable2Step, Re
      * @param owner Address that will own the contract
      */
     function initialize(address owner) public initializer {
-        __Ownable_init(owner);
+        __UnrenouncableOwnable2Step_init(owner);
         __ReentrancyGuard_init();
         merkleMessageBus = new MerkleTreeMessageBus.MerkleTreeMessageBus();
         merkleMessageBus.initialize(owner, address(this));

--- a/contracts/src/l1_management/contracts/DataAvailabilityRegistry.sol
+++ b/contracts/src/l1_management/contracts/DataAvailabilityRegistry.sol
@@ -40,8 +40,9 @@ contract DataAvailabilityRegistry is IDataAvailabilityRegistry, Initializable, U
     IMerkleTreeMessageBus public merkleMessageBus;
     INetworkEnclaveRegistry public enclaveRegistry;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _transferOwnership(msg.sender);
+        _disableInitializers();
     }
 
     /**
@@ -55,7 +56,7 @@ contract DataAvailabilityRegistry is IDataAvailabilityRegistry, Initializable, U
         address _enclaveRegistry,
         address _owner
     ) public initializer {
-        __Ownable_init(_owner);
+        __UnrenouncableOwnable2Step_init(_owner);
         merkleMessageBus = IMerkleTreeMessageBus(_merkleMessageBus);
         enclaveRegistry = INetworkEnclaveRegistry(_enclaveRegistry);
         lastBatchSeqNo = 0;

--- a/contracts/src/l1_management/contracts/NetworkConfig.sol
+++ b/contracts/src/l1_management/contracts/NetworkConfig.sol
@@ -102,14 +102,18 @@ contract NetworkConfig is Initializable, UnrenouncableOwnable2Step {
         string indexed forkName
     );
 
-    /**
-     * @dev Initializes the contract
-     * @param _addresses The fixed addresses
-     * @param owner The owner of the contract
-     */
-    function initialize( NetworkConfig.FixedAddresses memory _addresses, address owner) public initializer {
-        __Ownable_init(owner);
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
 
+    /**
+     * @dev Initializes the contract with addresses and owner
+     * @param _addresses The fixed addresses
+     * @param _owner Address of the contract owner
+     */
+    function initialize(NetworkConfig.FixedAddresses memory _addresses, address _owner) public initializer {
+        __UnrenouncableOwnable2Step_init(_owner);  // Initialize UnrenouncableOwnable2Step
         Storage.setAddress(CROSS_CHAIN_SLOT, _addresses.crossChain);
         Storage.setAddress(MESSAGE_BUS_SLOT, _addresses.messageBus);
         Storage.setAddress(NETWORK_ENCLAVE_REGISTRY_SLOT, _addresses.networkEnclaveRegistry);

--- a/contracts/src/l1_management/contracts/NetworkEnclaveRegistry.sol
+++ b/contracts/src/l1_management/contracts/NetworkEnclaveRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -34,16 +34,17 @@ contract NetworkEnclaveRegistry is INetworkEnclaveRegistry, Initializable, Unren
      */
     mapping(address sequencerID => bool isSequencer) private sequencerEnclave;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _transferOwnership(msg.sender);
+        _disableInitializers();
     }
 
     /**
-     * @dev Initializes the contract
-     * @param owner The owner of the contract
+     * @dev Initializes the contract with the owner
+     * @param _owner Address of the contract owner
      */
-    function initialize(address owner) public initializer {
-        __Ownable_init(owner);
+    function initialize(address _owner) public initializer {
+        __UnrenouncableOwnable2Step_init(_owner);  // Initialize UnrenouncableOwnable2Step
         networkSecretInitialized = false;
     }
 

--- a/contracts/src/system/contracts/Fees.sol
+++ b/contracts/src/system/contracts/Fees.sol
@@ -11,22 +11,25 @@ import "../../common/UnrenouncableOwnable2Step.sol";
  * 
  * TODO stefan to add explanation
  */
-contract Fees is Initializable, UnrenouncableOwnable2Step, IFees {
+contract Fees is IFees, Initializable, UnrenouncableOwnable2Step {
 
     uint256 private _messageFee;
 
     event FeeChanged(uint256 oldFee, uint256 newFee);
     event FeeWithdrawn(uint256 amount);
 
-    // Constructor disables initializer;
-    // Only owner functions will not be callable on implementation
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
-    // initialization function to be used by the proxy.
+    /**
+     * @dev Initializes the contract with fees and owner
+     * @param flatFee Initial message fee
+     * @param eoaOwner Address that will own the contract
+     */
     function initialize(uint256 flatFee, address eoaOwner) public initializer {
-        __Ownable_init(eoaOwner);
+        __UnrenouncableOwnable2Step_init(eoaOwner);
         _messageFee = flatFee;
         emit FeeChanged(0, flatFee);
     }


### PR DESCRIPTION
### Why this change is needed

Audit changes introduced new UnrenouncableOwnable2Step that isn't currently upgradable. 

### What changes were made as part of this PR

* Made UnrenouncableOwnable2Step upgradable by adding initialize method 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


