### PR TITLE
Tx Timestamp

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -8,10 +8,8 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/ten-protocol/go-ten/go/common/compression"
-
 	gethcore "github.com/ethereum/go-ethereum/core"
-
+	"github.com/ten-protocol/go-ten/go/common/compression"
 	"github.com/ten-protocol/go-ten/go/enclave/limiters"
 
 	"github.com/ethereum/go-ethereum/trie"
@@ -726,6 +724,7 @@ func (executor *batchExecutor) executeTx(ec *BatchExecutionContext, tx *common.L
 	ethHeader := *ec.EthHeader
 	before := ethHeader.MixDigest
 	ethHeader.MixDigest = executor.entropyService.TxEntropy(before.Bytes(), offset)
+	ethHeader.Difficulty = big.NewInt(tx.Tx.Time().UnixMilli())
 
 	// if the tx fails, it handles the revert
 	txResult := executor.evmFacade.ExecuteTx(tx, ec.stateDB, &ethHeader, ec.GasPool, ec.usedGas, offset, noBaseFee)

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	enclaveconfig "github.com/ten-protocol/go-ten/go/enclave/config"
 
@@ -102,6 +103,23 @@ type batchFromRollup struct {
 	header *common.BatchHeader // for reorgs
 }
 
+type txAndTimeStamp struct {
+	Tx   *common.L2Tx
+	Time *big.Int
+}
+
+func transactions(txs [][]*txAndTimeStamp) [][]*common.L2Tx {
+	txsOnly := make([][]*common.L2Tx, len(txs))
+	for i, batchTxs := range txs {
+		txsOnly[i] = make([]*common.L2Tx, len(batchTxs))
+		for i2, tx := range batchTxs {
+			txsOnly[i][i2] = tx.Tx
+			txsOnly[i][i2].SetTime(time.UnixMilli(tx.Time.Int64()))
+		}
+	}
+	return txsOnly
+}
+
 // CreateExtRollup - creates a compressed and encrypted External rollup from the internal data structure
 func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup) (*common.ExtRollup, error) {
 	header, err := rc.createRollupHeader(ctx, r)
@@ -113,9 +131,15 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 		return nil, err
 	}
 
-	transactions := make([][]*common.L2Tx, len(r.Batches))
+	transactions := make([][]*txAndTimeStamp, len(r.Batches))
 	for i, batch := range r.Batches {
-		transactions[i] = batch.Transactions
+		transactions[i] = make([]*txAndTimeStamp, len(batch.Transactions))
+		for i2 := range transactions[i] {
+			transactions[i][i2] = &txAndTimeStamp{
+				Tx:   batch.Transactions[i2],
+				Time: big.NewInt(batch.Transactions[i2].Time().UnixMilli()),
+			}
+		}
 	}
 	encryptedTransactions, err := rc.serialiseCompressAndEncrypt(transactions)
 	if err != nil {
@@ -131,7 +155,7 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 
 // ProcessExtRollup - given an External rollup, responsible with checking and saving all batches found inside
 func (rc *RollupCompression) ProcessExtRollup(ctx context.Context, rollup *common.ExtRollup, calldataRollupHeader *common.CalldataRollupHeader) error {
-	transactionsPerBatch := make([][]*common.L2Tx, 0)
+	transactionsPerBatch := make([][]*txAndTimeStamp, 0)
 	err := rc.DecryptDecompressAndDeserialise(rollup.BatchPayloads, &transactionsPerBatch)
 	if err != nil {
 		return err
@@ -140,7 +164,7 @@ func (rc *RollupCompression) ProcessExtRollup(ctx context.Context, rollup *commo
 	// The recreation of batches is a 2-step process:
 
 	// 1. calculate fields like: sequence, height, time, l1Proof, from the implicit and explicit information from the metadata
-	incompleteBatches, err := rc.createIncompleteBatches(ctx, rollup.Header, calldataRollupHeader, transactionsPerBatch, rollup.Header.CompressionL1Head)
+	incompleteBatches, err := rc.createIncompleteBatches(ctx, rollup.Header, calldataRollupHeader, transactions(transactionsPerBatch), rollup.Header.CompressionL1Head)
 	if err != nil {
 		return err
 	}

--- a/go/enclave/components/txpool.go
+++ b/go/enclave/components/txpool.go
@@ -181,6 +181,12 @@ func (t *TxPool) SubmitTx(transaction *common.L2Tx) (error, error) {
 	if t.validateOnly.Load() {
 		return t.validate(transaction)
 	}
+
+	// this code runs only on the sequencer
+	// it sets the time of entry into the mempool
+	// so it can be checked in the smart contract
+	transaction.SetTime(time.Now())
+
 	return t.add(transaction), nil
 }
 


### PR DESCRIPTION
### Why this change is needed

Every transaction will have a precise timestamp - the moment it was received by the sequencer.
The timestamp is exposed to the smart contract as `block.difficulty`

### What changes were made as part of this PR

- set the time to the "Time" field of the Transaction
- serialise/deserialize the time in the batch
- serialise/deserialize the time in the rollup
- expose the time as "difficulty" to the evm

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


