### PR TITLE
Config: default faucet prefunding to zero

### DIFF
--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -107,5 +107,5 @@ deploy:
     httpPort: 8085 # L2 RPC port for deploying contracts
     wsPort: 8089 # L2 RPC port for deploying contracts
     deployerPK: 0x0 # private key for the deployer account
-    faucetPrefund: 10000 # amount of ETH to pre-fund the faucet account
+    faucetPrefund: 0 # amount of ETH to pre-fund the faucet account (for non-sepolia testnets)
     sequencerURL: "" # sequencer URL to fetch its HA enclave IDs


### PR DESCRIPTION
### Why this change is needed

It seems we have an issue with overriding config to a zero value, so any value that could be zero should use zero as its default ideally so we have full control.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


