### PR TITLE
Enable funds recovery for new bridge

### DIFF
--- a/contracts/deployment_scripts/testnet/recoverfunds/001_recover_funds.ts
+++ b/contracts/deployment_scripts/testnet/recoverfunds/001_recover_funds.ts
@@ -19,14 +19,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     });
 
     // For 1.1 use this. Hardcoded to gnosis safe:
-    const messageBusAddress = response.data.result.L1MessageBus;
-    const messageBusContract = (await hre.ethers.getContractFactory('MessageBus')).attach(messageBusAddress) as MessageBus;
-    const tx = await messageBusContract.retrieveAllFunds("0xeA052c9635F1647A8a199c2315B9A66ce7d1e2a7");
+    // const messageBusAddress = response.data.result.L1MessageBus;
+    // const messageBusContract = (await hre.ethers.getContractFactory('MessageBus')).attach(messageBusAddress) as MessageBus;
+    // const tx = await messageBusContract.retrieveAllFunds("0xeA052c9635F1647A8a199c2315B9A66ce7d1e2a7");
 
-    // After 1.2 has been released:
-    // const bridgeContractAddress = response.data.result.L1Bridge;
-    // const bridgeContract = (await hre.ethers.getContractFactory('TenBridge')).attach(bridgeContractAddress) as TenBridge;
-    // const tx = await bridgeContract.retrieveAllFunds();
+    // After >1.2 has been released:
+    const bridgeContractAddress = response.data.result.L1Bridge;
+    const bridgeContract = (await hre.ethers.getContractFactory('TenBridge')).attach(bridgeContractAddress) as TenBridge;
+    const tx = await bridgeContract.retrieveAllFunds();
 
     const receipt = await tx.wait();
     if (receipt && receipt.status === 1) {

--- a/contracts/deployment_scripts/testnet/recoverfunds/001_recover_funds.ts
+++ b/contracts/deployment_scripts/testnet/recoverfunds/001_recover_funds.ts
@@ -18,12 +18,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         headers: { 'Content-Type': 'application/json' }
     });
 
-    // For 1.1 use this. Hardcoded to gnosis safe:
-    // const messageBusAddress = response.data.result.L1MessageBus;
-    // const messageBusContract = (await hre.ethers.getContractFactory('MessageBus')).attach(messageBusAddress) as MessageBus;
-    // const tx = await messageBusContract.retrieveAllFunds("0xeA052c9635F1647A8a199c2315B9A66ce7d1e2a7");
-
-    // After >1.2 has been released:
+    // recover funds from the new bridge contract
     const bridgeContractAddress = response.data.result.L1Bridge;
     const bridgeContract = (await hre.ethers.getContractFactory('TenBridge')).attach(bridgeContractAddress) as TenBridge;
     const tx = await bridgeContract.retrieveAllFunds();


### PR DESCRIPTION
### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

Funds are recovered on the new bridge contract, not the message bus.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


