### PR TITLE
return session key address in list endpoint

### DIFF
--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -564,6 +564,12 @@ func getMessageRequestHandler(walletExt *services.Services, conn UserConn) {
 }
 
 func listSKRequestHandler(walletExt *services.Services, conn UserConn) {
+	withUser(walletExt, conn, func(user *common.GWUser) ([]byte, error) {
+		if user.SessionKey == nil {
+			return []byte{}, nil
+		}
+		return []byte(hexutils.BytesToHex(user.SessionKey.Account.Address.Bytes())), nil
+	})
 }
 
 func createSKRequestHandler(walletExt *services.Services, conn UserConn) {


### PR DESCRIPTION
### Why this change is needed

To get session key address if we didn't store it.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


