### PR TITLE
add "sendTransaction" functionality via "getStorageAt" to bypass the …

### DIFF
--- a/go/common/custom_query_types.go
+++ b/go/common/custom_query_types.go
@@ -25,6 +25,7 @@ const (
 	DeactivateSessionKeyCQMethod    = "0x0000000000000000000000000000000000000005"
 	DeleteSessionKeyCQMethod        = "0x0000000000000000000000000000000000000006"
 	ListSessionKeyCQMethod          = "0x0000000000000000000000000000000000000007"
+	SendUnsignedTxCQMethod          = "0x0000000000000000000000000000000000000008"
 )
 
 type ListPrivateTransactionsQueryParams struct {

--- a/tools/walletextension/rpcapi/transaction_api.go
+++ b/tools/walletextension/rpcapi/transaction_api.go
@@ -125,7 +125,7 @@ func (s *TransactionAPI) SendTransaction(ctx context.Context, args gethapi.Trans
 		return common.Hash{}, err
 	}
 
-	return s.sendRawTx(ctx, blob)
+	return SendRawTx(ctx, s.we, blob)
 }
 
 type SignTransactionResult struct {
@@ -160,15 +160,7 @@ func (s *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.B
 		}
 	}
 
-	return s.sendRawTx(ctx, signedTxBlob)
-}
-
-func (s *TransactionAPI) sendRawTx(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
-	txRec, err := ExecAuthRPC[common.Hash](ctx, s.we, &AuthExecCfg{tryAll: true, timeout: sendTransactionDuration}, tenrpc.ERPCSendRawTransaction, input)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	return *txRec, err
+	return SendRawTx(ctx, s.we, signedTxBlob)
 }
 
 func (s *TransactionAPI) PendingTransactions() ([]*rpc.RpcTransaction, error) {

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	tencommonrpc "github.com/ten-protocol/go-ten/go/common/rpc"
+
 	"github.com/ten-protocol/go-ten/tools/walletextension/common"
 
 	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
@@ -51,6 +54,14 @@ type AuthExecCfg struct {
 	adjustArgs func(acct *common.GWAccount) []any
 	cacheCfg   *cache.Cfg
 	timeout    time.Duration
+}
+
+func SendRawTx(ctx context.Context, w *services.Services, input hexutil.Bytes) (gethcommon.Hash, error) {
+	txRec, err := ExecAuthRPC[gethcommon.Hash](ctx, w, &AuthExecCfg{tryAll: true, timeout: sendTransactionDuration}, tencommonrpc.ERPCSendRawTransaction, input)
+	if err != nil {
+		return gethcommon.Hash{}, err
+	}
+	return *txRec, err
 }
 
 func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services, cfg *cache.Cfg, method string, args ...any) (*R, error) {


### PR DESCRIPTION
### Why this change is needed

Add "sendTransaction" functionality via "getStorageAt" to bypass the wallet provider.
Metamask requires transactions sent via "sendTransaction" to be signed.

### What changes were made as part of this PR

 - introduce a new `getStorageAt` address which receives a base64 encoded unsigned transaction

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


