### PR TITLE
Revert port default ports change

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -162,7 +162,7 @@ jobs:
                DEPLOY_DOCKERIMAGE: ${{ vars.DOCKER_BUILD_TAG_L2_HARDHAT_DEPLOYER }}
                DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
                DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
-               DEPLOY_L2_SEQUENCERURL: http://${{ needs.read-l1-config.outputs.TESTNET_SHORT_NAME }}-sequencer.ten.xyz:8085
+               DEPLOY_L2_SEQUENCERURL: http://${{ needs.read-l1-config.outputs.TESTNET_SHORT_NAME }}-sequencer.ten.xyz:80
                NETWORK_L1_CONTRACTS_ENCLAVEREGISTRY: ${{ needs.read-l1-config.outputs.enclave_registry }}
 
             run: |
@@ -236,8 +236,8 @@ jobs:
               DEPLOY_L1_RPCADDRESS: ${{ secrets.L1_HTTP_URL }}
               DEPLOY_L2_DEPLOYERPK: ${{ secrets.L2_DEPLOYER_KEY }}
               DEPLOY_L2_RPCADDRESS: ${{ needs.read-l1-config.outputs.TESTNET_SHORT_NAME }}-validator-01.ten.xyz
-              DEPLOY_L2_HTTPPORT: 8085
-              DEPLOY_L2_WSPORT: 8089
+              DEPLOY_L2_HTTPPORT: 80
+              DEPLOY_L2_WSPORT: 81
               DEPLOY_L2_FAUCETFUNDS: ${{ vars.FAUCET_INITIAL_FUNDS }}
               NETWORK_L1_CONTRACTS_NETWORKCONFIG: ${{ needs.read-l1-config.outputs.network_config }}
               NETWORK_L1_CONTRACTS_MESSAGEBUS: ${{ needs.read-l1-config.outputs.message_bus }}

--- a/.github/workflows/runner-scripts/wait-node-healthy.sh
+++ b/.github/workflows/runner-scripts/wait-node-healthy.sh
@@ -27,7 +27,7 @@ start_path="$(cd "$(dirname "${0}")" && pwd)"
 testnet_path="${start_path}"
 
 # Defaults
-port=8085
+port=80
 timeout=5*60
 
 # Fetch options

--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -104,8 +104,8 @@ deploy:
     challengePeriod: 1 # challenge period for rollups in seconds
   l2:
     rpcAddress: "localhost" # L2 RPC address for deploying contracts
-    httpPort: 8085 # L2 RPC port for deploying contracts
-    wsPort: 8089 # L2 RPC port for deploying contracts
+    httpPort: 80 # L2 RPC port for deploying contracts
+    wsPort: 81 # L2 RPC port for deploying contracts
     deployerPK: 0x0 # private key for the deployer account
     faucetPrefund: 0 # amount of ETH to pre-fund the faucet account (for non-sepolia testnets)
     sequencerURL: "" # sequencer URL to fetch its HA enclave IDs

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -33,8 +33,8 @@ func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
 
 func UATTestnet(opts ...TestnetEnvOption) networktest.Environment {
 	connector := newTestnetConnector(
-		"http://uat-sequencer.ten.xyz:8085",
-		[]string{"http://uat-validator-01.ten.xyz:8085"},
+		"http://uat-sequencer.ten.xyz:80",
+		[]string{"http://uat-validator-01.ten.xyz:80"},
 		"http://uat-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
 		"wss://ethereum-sepolia-rpc.publicnode.com",
 		"https://rpc.uat-testnet.ten.xyz",


### PR DESCRIPTION
### Why this change is needed

Krish decided to revert the RPC default ports change back to 80/81 so when we deploy to sepolia there are no config updates required for downstream services.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


