### PR TITLE
Set blob TX retry wait to half the rollup interval

### DIFF
--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -413,6 +413,7 @@ jobs:
                -batch_interval=${{ vars.L2_BATCH_INTERVAL }} \
                -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
                -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
+               -rollup_retry_interval=${{ vars.L1_ROLLUP_RETRY_INTERVAL }} \
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
                -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
                -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -272,6 +272,7 @@ jobs:
                -batch_interval=${{ vars.L2_BATCH_INTERVAL }} \
                -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
                -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
+               -rollup_retry_interval=${{ vars.L1_ROLLUP_RETRY_INTERVAL }} \
                -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
                -postgres_db_host=postgres://tenuser:${{ secrets.TEN_POSTGRES_USER_PWD }}@postgres-ten-${{  github.event.inputs.testnet_type }}.postgres.database.azure.com:5432/ \
                start'

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -201,6 +201,7 @@ jobs:
               -batch_interval=${{ vars.L2_BATCH_INTERVAL }} \
               -max_batch_interval=${{ vars.L2_MAX_BATCH_INTERVAL }} \
               -rollup_interval=${{ vars.L2_ROLLUP_INTERVAL }} \
+              -rollup_retry_interval=${{ vars.L1_ROLLUP_RETRY_INTERVAL }} \
               -l1_chain_id=${{ vars.L1_CHAIN_ID }} \
               -l1_beacon_url=${{ vars.L1_BEACON_URL }} \
               -l1_blob_archive_url=${{ vars.L1_BLOB_ARCHIVE_URL }} \

--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -22,6 +22,7 @@ network:
   l1:
     chainId: 1337
     blockTime: 15s
+    rollupRetryDelay: 60s
     startHash: 0x0 # hash of the L1 block that Ten can safely start processing from to get entire L2 history
     contracts:
       networkConfig: 0x0 # L1 address of the Ten network config contract

--- a/go/config/network.go
+++ b/go/config/network.go
@@ -53,9 +53,10 @@ type GasConfig struct {
 //
 //	yaml: `network.l1`
 type L1Config struct {
-	ChainID   int64           `mapstructure:"chainId"`   // chainID for the L1 network
-	BlockTime time.Duration   `mapstructure:"blockTime"` // average expected block time for the L1 network
-	StartHash gethcommon.Hash `mapstructure:"startHash"` // hash of the first block on the L1 network relevant to the Ten network
+	ChainID          int64           `mapstructure:"chainId"`          // chainID for the L1 network
+	BlockTime        time.Duration   `mapstructure:"blockTime"`        // average expected block time for the L1 network
+	RollupRetryDelay time.Duration   `mapstructure:"rollupRetryDelay"` // delay rollup publishing when gas price spikes
+	StartHash        gethcommon.Hash `mapstructure:"startHash"`        // hash of the first block on the L1 network relevant to the Ten network
 
 	L1Contracts *L1Contracts `mapstructure:"contracts"`
 }

--- a/go/host/config/config.go
+++ b/go/host/config/config.go
@@ -37,6 +37,8 @@ type HostConfig struct {
 	MaxRollupSize uint64
 	// The expected time between blocks on the L1 network
 	L1BlockTime time.Duration
+	// Delay for retrying rollups to handle blob gas spikes
+	L1RollupRetryDelay time.Duration
 	// CrossChainInterval - The interval at which the host will check for new cross chain data to submit
 	CrossChainInterval time.Duration
 
@@ -120,6 +122,7 @@ func HostConfigFromTenConfig(tenCfg *config.TenConfig) *HostConfig {
 
 		L1StartHash:          tenCfg.Network.L1.StartHash,
 		L1BlockTime:          tenCfg.Network.L1.BlockTime,
+		L1RollupRetryDelay:   tenCfg.Network.L1.RollupRetryDelay,
 		SequencerP2PAddress:  tenCfg.Network.Sequencer.P2PAddress,
 		NetworkConfigAddress: tenCfg.Network.L1.L1Contracts.NetworkConfigContract,
 

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -102,9 +102,9 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo)
-	maxWaitForL1Receipt := 6 * config.L1BlockTime            // wait ~10 blocks to see if tx gets published before retrying
-	retryIntervalForL1Receipt := config.L1BlockTime          // retry ~every block
-	retryIntervalForBlobReceipt := config.RollupInterval / 4 // 25% the rollup interval to allow time for blob gas prices to drop
+	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying
+	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
+	retryIntervalForBlobReceipt := config.L1RollupRetryDelay
 	l1ChainCfg := common.GetL1ChainConfig(uint64(config.L1ChainID))
 	l1Publisher := l1.NewL1Publisher(
 		hostIdentity,

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -102,8 +102,9 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo)
-	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying
-	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
+	maxWaitForL1Receipt := 6 * config.L1BlockTime      // wait ~10 blocks to see if tx gets published before retrying
+	retryIntervalForL1Receipt := config.L1BlockTime    // retry ~every block
+	blobRetryWaitInterval := config.RollupInterval / 2 // half the rollup interval to allow time for blob gas prices to drop
 	l1ChainCfg := common.GetL1ChainConfig(uint64(config.L1ChainID))
 	l1Publisher := l1.NewL1Publisher(
 		hostIdentity,
@@ -116,6 +117,7 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 		logger,
 		maxWaitForL1Receipt,
 		retryIntervalForL1Receipt,
+		blobRetryWaitInterval,
 		hostStorage,
 		l1ChainCfg,
 	)

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -102,9 +102,9 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
 	hostServices.RegisterService(hostcommon.P2PName, p2p)
 	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo)
-	maxWaitForL1Receipt := 6 * config.L1BlockTime      // wait ~10 blocks to see if tx gets published before retrying
-	retryIntervalForL1Receipt := config.L1BlockTime    // retry ~every block
-	blobRetryWaitInterval := config.RollupInterval / 2 // half the rollup interval to allow time for blob gas prices to drop
+	maxWaitForL1Receipt := 6 * config.L1BlockTime            // wait ~10 blocks to see if tx gets published before retrying
+	retryIntervalForL1Receipt := config.L1BlockTime          // retry ~every block
+	retryIntervalForBlobReceipt := config.RollupInterval / 4 // 25% the rollup interval to allow time for blob gas prices to drop
 	l1ChainCfg := common.GetL1ChainConfig(uint64(config.L1ChainID))
 	l1Publisher := l1.NewL1Publisher(
 		hostIdentity,
@@ -117,7 +117,7 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 		logger,
 		maxWaitForL1Receipt,
 		retryIntervalForL1Receipt,
-		blobRetryWaitInterval,
+		retryIntervalForBlobReceipt,
 		hostStorage,
 		l1ChainCfg,
 	)

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -410,7 +410,7 @@ func (p *Publisher) waitForReceipt(signedTx *types.Transaction, isBlobTx bool) (
 
 	// for blob transactions, use longer timeouts since they're not time-critical
 	if isBlobTx {
-		maxWait = p.retryIntervalForBlobReceipt * 2
+		maxWait = p.retryIntervalForBlobReceipt * 4
 		retryInterval = p.retryIntervalForBlobReceipt
 	}
 

--- a/go/host/l1/publisher.go
+++ b/go/host/l1/publisher.go
@@ -48,9 +48,9 @@ type Publisher struct {
 
 	hostStopper *stopcontrol.StopControl
 
-	maxWaitForL1Receipt       time.Duration
-	retryIntervalForL1Receipt time.Duration
-	blobRetryWaitInterval     time.Duration
+	maxWaitForL1Receipt         time.Duration
+	retryIntervalForL1Receipt   time.Duration
+	retryIntervalForBlobReceipt time.Duration
 
 	// we only allow one transaction in-flight at a time to avoid nonce conflicts
 	// We also have a context to cancel the tx if host stops
@@ -70,25 +70,25 @@ func NewL1Publisher(
 	logger gethlog.Logger,
 	maxWaitForL1Receipt time.Duration,
 	retryIntervalForL1Receipt time.Duration,
-	blobRetryWaitInterval time.Duration,
+	retryIntervalForBlobReceipt time.Duration,
 	storage storage.Storage,
 	l1ChainCfg *params.ChainConfig,
 ) *Publisher {
 	sendingCtx, cancelSendingCtx := context.WithCancel(context.Background())
 	return &Publisher{
-		hostData:                  hostData,
-		hostWallet:                hostWallet,
-		ethClient:                 client,
-		contractRegistry:          contractRegistry,
-		repository:                repository,
-		blobResolver:              blobResolver,
-		hostStopper:               hostStopper,
-		logger:                    logger,
-		maxWaitForL1Receipt:       maxWaitForL1Receipt,
-		retryIntervalForL1Receipt: retryIntervalForL1Receipt,
-		blobRetryWaitInterval:     blobRetryWaitInterval,
-		storage:                   storage,
-		l1ChainCfg:                l1ChainCfg,
+		hostData:                    hostData,
+		hostWallet:                  hostWallet,
+		ethClient:                   client,
+		contractRegistry:            contractRegistry,
+		repository:                  repository,
+		blobResolver:                blobResolver,
+		hostStopper:                 hostStopper,
+		logger:                      logger,
+		maxWaitForL1Receipt:         maxWaitForL1Receipt,
+		retryIntervalForL1Receipt:   retryIntervalForL1Receipt,
+		retryIntervalForBlobReceipt: retryIntervalForBlobReceipt,
+		storage:                     storage,
+		l1ChainCfg:                  l1ChainCfg,
 
 		importantAddressesMutex: sync.RWMutex{},
 		importantAddresses:      &common.NetworkConfigAddresses{},
@@ -374,6 +374,7 @@ func (p *Publisher) publishBlobTxWithRetry(tx types.TxData) error {
 			// even if there was an error we expect pricedTx to be populated for common failures
 			return retry.FailFast(fmt.Errorf("could not price transaction. Cause: %w", err))
 		}
+
 		if err != nil {
 			if retryCount > maxRetries {
 				blobTx, ok := pricedTx.(*types.BlobTx)
@@ -395,13 +396,41 @@ func (p *Publisher) publishBlobTxWithRetry(tx types.TxData) error {
 
 		// success, we're done
 		return nil
-	}, retry.NewBackoffAndRetryForeverStrategy([]time.Duration{0, 30 * time.Second}, p.blobRetryWaitInterval)) // instant retry, 30s wait then config wait interval to avoid blob pool filling up
+	}, retry.NewBackoffAndRetryForeverStrategy([]time.Duration{0, 0}, 1*time.Second)) // couple of instant retries then 1sec intervals
 
 	return err
 }
 
-// executeTransaction handles the common flow of pricing, signing, sending and waiting for receipt. Returns the priced
-// transaction so we can log the values in the event we exceed the maximum number of retries.
+// waitForReceipt waits for a transaction receipt with appropriate timeout based on transaction type
+func (p *Publisher) waitForReceipt(signedTx *types.Transaction, isBlobTx bool) (*types.Receipt, error) {
+	var receipt *types.Receipt
+
+	maxWait := p.maxWaitForL1Receipt
+	retryInterval := p.retryIntervalForL1Receipt
+
+	// for blob transactions, use longer timeouts since they're not time-critical
+	if isBlobTx {
+		maxWait = p.retryIntervalForBlobReceipt * 2
+		retryInterval = p.retryIntervalForBlobReceipt
+	}
+
+	err := retry.Do(
+		func() error {
+			if p.hostStopper.IsStopping() {
+				return retry.FailFast(errors.New("host is stopping or context canceled"))
+			}
+			var err error
+			receipt, err = p.ethClient.TransactionReceipt(signedTx.Hash())
+			if err != nil {
+				return fmt.Errorf("could not get receipt publishing tx for L1 tx=%s: %w", signedTx.Hash(), err)
+			}
+			return err
+		},
+		retry.NewTimeoutStrategy(maxWait, retryInterval),
+	)
+	return receipt, err
+}
+
 func (p *Publisher) executeTransaction(tx types.TxData, nonce uint64, retryNum int) (types.TxData, error) {
 	// Set gas prices and create transaction
 	pricedTx, err := ethadapter.SetTxGasPrice(p.sendingContext, p.ethClient, tx, p.hostWallet.Address(), nonce, retryNum, p.l1ChainCfg, p.logger)
@@ -424,8 +453,10 @@ func (p *Publisher) executeTransaction(tx types.TxData, nonce uint64, retryNum i
 		return pricedTx, errors.Wrap(err, "could not broadcast L1 tx")
 	}
 
+	_, isBlobTx := tx.(*types.BlobTx)
+
 	// Wait for receipt
-	receipt, err := p.waitForReceipt(signedTx)
+	receipt, err := p.waitForReceipt(signedTx, isBlobTx)
 	if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
 		return pricedTx, fmt.Errorf("receipt not received for tx: %s ", signedTx.Hash().Hex()) // Return hash for MaxRetriesError
 	}
@@ -433,26 +464,6 @@ func (p *Publisher) executeTransaction(tx types.TxData, nonce uint64, retryNum i
 	p.logger.Debug("L1 transaction successful receipt found.", log.TxKey, signedTx.Hash(),
 		log.BlockHeightKey, receipt.BlockNumber, log.BlockHashKey, receipt.BlockHash)
 	return pricedTx, nil
-}
-
-// Helper functions to reduce duplication
-func (p *Publisher) waitForReceipt(signedTx *types.Transaction) (*types.Receipt, error) {
-	var receipt *types.Receipt
-	err := retry.Do(
-		func() error {
-			if p.hostStopper.IsStopping() {
-				return retry.FailFast(errors.New("host is stopping or context canceled"))
-			}
-			var err error
-			receipt, err = p.ethClient.TransactionReceipt(signedTx.Hash())
-			if err != nil {
-				return fmt.Errorf("could not get receipt publishing tx for L1 tx=%s: %w", signedTx.Hash(), err)
-			}
-			return err
-		},
-		retry.NewTimeoutStrategy(p.maxWaitForL1Receipt, p.retryIntervalForL1Receipt),
-	)
-	return receipt, err
 }
 
 // waitForBlockAfter waits until the current block number is greater than the target block number

--- a/go/node/cmd/cli.go
+++ b/go/node/cmd/cli.go
@@ -55,6 +55,7 @@ type NodeConfigCLI struct {
 	batchInterval           string // format like 500ms or 2s (any time parsable by time.ParseDuration())
 	maxBatchInterval        string // format like 500ms or 2s (any time parsable by time.ParseDuration())
 	rollupInterval          string // format like 500ms or 2s (any time parsable by time.ParseDuration())
+	rollupRetryInterval     string // format like 500ms or 2s (any time parsable by time.ParseDuration())
 	l1ChainID               int
 	postgresDBHost          string
 	l1BeaconUrl             string
@@ -99,6 +100,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	batchInterval := flag.String(batchIntervalFlag, "1s", flagUsageMap[batchIntervalFlag])
 	maxBatchInterval := flag.String(maxBatchIntervalFlag, "1s", flagUsageMap[maxBatchIntervalFlag])
 	rollupInterval := flag.String(rollupIntervalFlag, "3s", flagUsageMap[rollupIntervalFlag])
+	rollupRetryInterval := flag.String(rollupRetryIntervalFlag, "120s", flagUsageMap[rollupRetryIntervalFlag])
 	l1ChainID := flag.Int(l1ChainIDFlag, 1337, flagUsageMap[l1ChainIDFlag])
 	postgresDBHost := flag.String(postgresDBHostFlag, "dd", flagUsageMap[postgresDBHostFlag])
 	l1BeaconUrl := flag.String(l1BeaconUrlFlag, "eth2network:126000", flagUsageMap[l1BeaconUrlFlag])
@@ -138,6 +140,7 @@ func ParseConfigCLI() *NodeConfigCLI {
 	cfg.batchInterval = *batchInterval
 	cfg.maxBatchInterval = *maxBatchInterval
 	cfg.rollupInterval = *rollupInterval
+	cfg.rollupRetryInterval = *rollupRetryInterval
 	cfg.l1ChainID = *l1ChainID
 	cfg.postgresDBHost = *postgresDBHost
 	cfg.l1BeaconUrl = *l1BeaconUrl

--- a/go/node/cmd/cli_flags.go
+++ b/go/node/cmd/cli_flags.go
@@ -35,6 +35,7 @@ const (
 	batchIntervalFlag           = "batch_interval"
 	maxBatchIntervalFlag        = "max_batch_interval"
 	rollupIntervalFlag          = "rollup_interval"
+	rollupRetryIntervalFlag     = "rollup_retry_interval"
 	l1ChainIDFlag               = "l1_chain_id"
 	postgresDBHostFlag          = "postgres_db_host"
 	l1BeaconUrlFlag             = "l1_beacon_url"
@@ -78,6 +79,7 @@ func getFlagUsageMap() map[string]string {
 		batchIntervalFlag:           "Duration between each batch. Can be formatted like 500ms or 1s",
 		maxBatchIntervalFlag:        "Max interval between batches, if greater than batchInterval then some empty batches will be skipped. Can be formatted like 500ms or 1s",
 		rollupIntervalFlag:          "Duration between each rollup. Can be formatted like 500ms or 1s",
+		rollupRetryIntervalFlag:     "Duration to wait before retrying publishing a rollup. Can be formatted like 500ms or 1s",
 		l1ChainIDFlag:               "Chain ID of the L1 network",
 		postgresDBHostFlag:          "Host connection details for Postgres DB",
 		l1BeaconUrlFlag:             "Url for the beacon chain API",

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -111,6 +111,7 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, _ *stats.Stat
 		tenCfg.Network.GenesisJSON = genesis
 		tenCfg.Network.Sequencer.P2PAddress = fmt.Sprintf("127.0.0.1:%d", simParams.StartPort+integration.DefaultHostP2pOffset)
 		tenCfg.Network.L1.BlockTime = simParams.AvgBlockDuration
+		tenCfg.Network.L1.RollupRetryDelay = simParams.AvgBlockDuration
 		tenCfg.Network.L1.L1Contracts.NetworkConfigContract = simParams.L1TenData.NetworkConfigAddress
 		tenCfg.Network.L1.L1Contracts.DataAvailabilityRegistry = simParams.L1TenData.DataAvailabilityRegistryAddress
 		tenCfg.Network.L1.L1Contracts.EnclaveRegistryContract = simParams.L1TenData.EnclaveRegistryAddress


### PR DESCRIPTION
### Why this change is needed

If blob gas prices spike and we fill up the blobpool we have to manually unblock the transactions which will be a pita for mainnet. Given consistency is favoured over latency for rollups we can set a very conservative wait time on the blob gas retry to ensure it gets published. 

### What changes were made as part of this PR

* Add new `L1_ROLLUP_RETRY_INTERVAL` config param to set a longer retry so we don't fill the blobpool 
* Set to 4m for sepolia

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


