### PR TITLE
fix the timestamp delta formula

### DIFF
--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -334,7 +334,7 @@ func (rc *RollupCompression) createIncompleteBatches(ctx context.Context, header
 			currentHeight = currentHeight + 1
 		}
 
-		transactions := batchTransactions.Txs(uint64(currentTime))
+		transactions := batchTransactions.Txs()
 		// calculate the hash of the txs
 		var txHash gethcommon.Hash
 		var payloadHash gethcommon.Hash

--- a/go/enclave/core/batch.go
+++ b/go/enclave/core/batch.go
@@ -92,7 +92,7 @@ func ToBatch(extBatch *common.ExtBatch, transactionBlobCrypto *crypto.DAEncrypti
 	}
 	return &Batch{
 		Header:       extBatch.Header,
-		Transactions: txs.Txs(extBatch.Header.Time),
+		Transactions: txs.Txs(),
 	}, nil
 }
 


### PR DESCRIPTION
### Why this change is needed

The tx timestamp delta formula used for serialising the transactions was incorrect.

### What changes were made as part of this PR

we had: `delta=txTime+adjustment-blockTime`
and now we have:  `delta=blockTime + adjustment - txTime`

The txs arrive before the block is created

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


