### PR TITLE
L1 deploy timeout bump

### DIFF
--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -75,7 +75,7 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (*node.NetworkConfig, e
 	defer cli.Close()
 
 	// make sure the container has finished execution (5 minutes allows time for L1 transactions to be mined)
-	err = docker.WaitForContainerToFinish(n.containerID, 5*time.Minute)
+	err = docker.WaitForContainerToFinish(n.containerID, 10*time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -74,7 +74,7 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (*node.NetworkConfig, e
 	}
 	defer cli.Close()
 
-	// make sure the container has finished execution (5 minutes allows time for L1 transactions to be mined)
+	// make sure the container has finished execution (10 minutes allows time for L1 transactions to be mined)
 	err = docker.WaitForContainerToFinish(n.containerID, 10*time.Minute)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Why this change is needed

We keep seeing timeout failures on the L1 deployment stage for UAT (against sepolia).

The last two successful passes took 4min 35sec and 4min 53sec so we're clearly bumping up against the limit. I think it has crept up over time as we've grown the amount of L1 contracts.

### What changes were made as part of this PR

Timeout from 5mins -> 10mins.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


