### PR TITLE
Set enclave debug=false

### DIFF
--- a/go/enclave/main/enclave.json
+++ b/go/enclave/main/enclave.json
@@ -1,7 +1,7 @@
 {
   "exe": "main",
   "key": "testnet.pem",
-  "debug": true,
+  "debug": false,
   "heapSize": 4096,
   "executableHeap": true,
   "productID": 1,


### PR DESCRIPTION
### Why this change is needed

The enclave debug=true setting is not secure for prod



