### PR TITLE
Tenscan Search API

### DIFF
--- a/go/common/query_types.go
+++ b/go/common/query_types.go
@@ -20,6 +20,11 @@ type TransactionListingResponse struct {
 	Total            uint64
 }
 
+type SearchResponse struct {
+	TransactionsData []SearchResult
+	Total            uint64
+}
+
 type BatchListingResponse struct {
 	BatchesData []PublicBatch
 	Total       uint64
@@ -54,6 +59,15 @@ type PublicBatch struct {
 	TxCount          *big.Int              `json:"txCount"`
 	Header           *BatchHeader          `json:"header"`
 	EncryptedTxBlob  EncryptedTransactions `json:"encryptedTxBlob"`
+}
+
+type SearchResult struct {
+	Type      string                 `json:"type"`      // "rollup", "batch", "transaction"
+	Hash      string                 `json:"hash"`      // For rollups, batches, transactions
+	Height    *big.Int               `json:"height"`    // For batches
+	Sequence  *big.Int               `json:"sequence"`  // For batches
+	Timestamp uint64                 `json:"timestamp"` // Common field
+	ExtraData map[string]interface{} `json:"extraData"` // Type-specific data
 }
 
 // TODO (@will) remove when tenscan UI has been updated

--- a/go/host/rpc/clientapi/client_api_scan.go
+++ b/go/host/rpc/clientapi/client_api_scan.go
@@ -117,3 +117,7 @@ func (s *ScanAPI) GetRollupBatches(rollupHash gethcommon.Hash) (*common.BatchLis
 func (s *ScanAPI) GetBatchTransactions(batchHash gethcommon.Hash) (*common.TransactionListingResponse, error) {
 	return s.host.Storage().FetchBatchTransactions(batchHash)
 }
+
+func (s *ScanAPI) Search(query string, pagination *common.QueryPagination) (*common.SearchResponse, error) {
+	return s.host.Storage().Search(query, pagination)
+}

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	selectBatch         = "SELECT sequence, hash, height, ext_batch FROM batch_host"
+	selectBatch         = "SELECT sequence, hash, height, ext_batch FROM batch_host b"
 	selectExtBatch      = "SELECT ext_batch FROM batch_host"
 	selectLatestBatch   = "SELECT sequence, hash, height, ext_batch FROM batch_host ORDER BY sequence DESC LIMIT 1"
 	selectTxsAndBatch   = "SELECT t.hash FROM transaction_host t JOIN batch_host b ON t.b_sequence = b.sequence WHERE b.hash = "

--- a/go/host/storage/hostdb/search.go
+++ b/go/host/storage/hostdb/search.go
@@ -1,0 +1,150 @@
+package hostdb
+
+import (
+	"math/big"
+	"strconv"
+	"strings"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ten-protocol/go-ten/go/common"
+)
+
+// todo (@will) add pagination if results are large
+func Search(db HostDB, query string) (*common.SearchResponse, error) {
+	// First try to identify what type of input we have
+	inputType := identifyInputType(query)
+
+	var results []*common.SearchResult
+
+	switch inputType {
+	case "hash":
+		// Could be rollup, batch, or transaction hash
+		results = append(results, searchByHash(db, query)...)
+	case "number":
+		// Could be batch height or sequence
+		results = append(results, searchByNumber(db, query)...)
+	default:
+		// Try all searches
+		results = append(results, searchByHash(db, query)...)
+		results = append(results, searchByNumber(db, query)...)
+	}
+
+	// Convert pointers to values for the response
+	searchResults := make([]common.SearchResult, len(results))
+	for i, result := range results {
+		searchResults[i] = *result
+	}
+
+	return &common.SearchResponse{
+		TransactionsData: searchResults,
+		Total:            uint64(len(results)),
+	}, nil
+}
+
+func identifyInputType(query string) string {
+	query = strings.TrimPrefix(query, "0x")
+
+	if len(query) == 64 {
+		return "hash"
+	}
+
+	if len(query) == 40 {
+		return "address"
+	}
+
+	if _, err := strconv.ParseInt(query, 10, 64); err == nil {
+		return "number"
+	}
+
+	return "unknown"
+}
+
+func searchByHash(db HostDB, hash string) []*common.SearchResult {
+	var results []*common.SearchResult
+	
+	// Trim 0x prefix for consistency
+	trimmedHash := strings.TrimPrefix(hash, "0x")
+
+	// Search rollups
+	rollup, err := GetRollupByHash(db, gethcommon.HexToHash(hash))
+	if err == nil {
+		println("ROLLUP found with hash: ", hash)
+		results = append(results, &common.SearchResult{
+			Type:      "rollup",
+			Hash:      trimmedHash,
+			Timestamp: rollup.Timestamp,
+			ExtraData: map[string]interface{}{
+				"rollup": rollup,
+			},
+		})
+	}
+
+	// Search batches
+	batch, err := GetPublicBatch(db, gethcommon.HexToHash(hash))
+	if err == nil {
+		println("BATCH found with hash: ", hash)
+		results = append(results, &common.SearchResult{
+			Type:      "batch",
+			Hash:      trimmedHash,
+			Height:    batch.Height,
+			Sequence:  batch.SequencerOrderNo,
+			Timestamp: batch.Header.Time,
+			ExtraData: map[string]interface{}{
+				"batch": batch,
+			},
+		})
+	}
+
+	// Search transactions
+	tx, err := GetTransaction(db, gethcommon.HexToHash(hash))
+	if err == nil {
+		println("TX found with hash: ", hash)
+		results = append(results, &common.SearchResult{
+			Type:      "transaction",
+			Hash:      trimmedHash,
+			Timestamp: tx.BatchTimestamp,
+			ExtraData: map[string]interface{}{
+				"transaction": tx,
+			},
+		})
+	}
+
+	return results
+}
+
+func searchByNumber(db HostDB, number string) []*common.SearchResult {
+	var results []*common.SearchResult
+	num, _ := strconv.ParseInt(number, 10, 64)
+
+	// Try as batch height
+	batch, err := GetBatchByHeight(db, big.NewInt(num))
+	if err == nil {
+		results = append(results, &common.SearchResult{
+			Type:      "batch",
+			Hash:      batch.FullHash.Hex(),
+			Height:    batch.Height,
+			Sequence:  batch.SequencerOrderNo,
+			Timestamp: batch.Header.Time,
+			ExtraData: map[string]interface{}{
+				"batch": batch,
+			},
+		})
+	}
+
+	// Try as batch sequence
+	batch, err = GetPublicBatchBySequenceNumber(db, uint64(num))
+	if err == nil {
+		results = append(results, &common.SearchResult{
+			Type:      "batch",
+			Hash:      batch.FullHash.Hex(),
+			Height:    batch.Height,
+			Sequence:  batch.SequencerOrderNo,
+			Timestamp: batch.Header.Time,
+			ExtraData: map[string]interface{}{
+				"batch": batch,
+			},
+		})
+	}
+
+	return results
+}

--- a/go/host/storage/hostdb/search_test.go
+++ b/go/host/storage/hostdb/search_test.go
@@ -1,0 +1,289 @@
+package hostdb
+
+import (
+	"strings"
+	"testing"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ten-protocol/go-ten/go/common"
+)
+
+func TestIdentifyInputType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "hash"},
+		{"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "hash"},
+		{"12345", "number"},
+		{"0", "number"},
+		{"invalid", "unknown"},
+		{"", "unknown"},
+	}
+
+	for _, test := range tests {
+		result := identifyInputType(test.input)
+		if result != test.expected {
+			t.Errorf("identifyInputType(%s) = %s, expected %s", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestSearchByRollupAndBatchHash(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	metadata := createRollupMetadata(batchNumber - 10)
+	rollup := createRollup(batchNumber)
+	block := types.NewBlock(&types.Header{}, nil, nil, nil)
+	dbtx, _ := db.NewDBTransaction()
+	err = AddBlock(dbtx.Tx, db.GetSQLStatement(), block.Header())
+	if err != nil {
+		t.Errorf("could not store block. Cause: %s", err)
+	}
+	dbtx.Write()
+	dbtx, _ = db.NewDBTransaction()
+	err = AddRollup(dbtx, db.GetSQLStatement(), &rollup, &common.ExtRollupMetadata{}, &metadata, block.Header())
+	if err != nil {
+		t.Errorf("could not store rollup. Cause: %s", err)
+	}
+	dbtx.Write()
+
+	// Create and store a batch
+	txHashes := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne"))}
+	batch := CreateBatch(batchNumber, txHashes)
+	dbtx, _ = db.NewDBTransaction()
+	err = AddBatch(dbtx, db.GetSQLStatement(), &batch)
+	if err != nil {
+		t.Errorf("could not store batch. Cause: %s", err)
+	}
+	dbtx.Write()
+
+	// Test search by rollup hash
+	rollupHash := rollup.Header.Hash().Hex()
+	searchResponse, err := Search(db, rollupHash)
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 1 {
+		t.Errorf("expected 1 result, got %d", searchResponse.Total)
+	}
+
+	if len(searchResponse.TransactionsData) != 1 {
+		t.Errorf("expected 1 result in TransactionsData, got %d", len(searchResponse.TransactionsData))
+	}
+
+	result := searchResponse.TransactionsData[0]
+	if result.Type != "rollup" {
+		t.Errorf("expected type 'rollup', got '%s'", result.Type)
+	}
+
+	trimmedRollupHash := strings.TrimPrefix(rollupHash, "0x")
+	if result.Hash != trimmedRollupHash {
+		t.Errorf("expected hash %s, got %s", trimmedRollupHash, result.Hash)
+	}
+
+	// Test search by batch hash
+	batchHash := batch.Header.Hash().Hex()
+	searchResponse, err = Search(db, batchHash)
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 1 {
+		t.Errorf("expected 1 result, got %d", searchResponse.Total)
+	}
+
+	result = searchResponse.TransactionsData[0]
+	if result.Type != "batch" {
+		t.Errorf("expected type 'batch', got '%s'", result.Type)
+	}
+
+	trimmedBatchHash := strings.TrimPrefix(batchHash, "0x")
+	if result.Hash != trimmedBatchHash {
+		t.Errorf("expected hash %s, got %s", trimmedBatchHash, result.Hash)
+	}
+}
+
+func TestSearchByTransactionHash(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	// Create and store a batch with a transaction
+	txHash := gethcommon.BytesToHash([]byte("magicStringOne"))
+	txHashes := []common.L2TxHash{txHash}
+	batch := CreateBatch(batchNumber, txHashes)
+	dbtx, _ := db.NewDBTransaction()
+	err = AddBatch(dbtx, db.GetSQLStatement(), &batch)
+	if err != nil {
+		t.Errorf("could not store batch. Cause: %s", err)
+	}
+	dbtx.Write()
+
+	// Test search by transaction hash
+	txHashStr := txHash.Hex()
+	searchResponse, err := Search(db, txHashStr)
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 1 {
+		t.Errorf("expected 1 result, got %d", searchResponse.Total)
+	}
+
+	if len(searchResponse.TransactionsData) != 1 {
+		t.Errorf("expected 1 result in TransactionsData, got %d", len(searchResponse.TransactionsData))
+	}
+
+	result := searchResponse.TransactionsData[0]
+	if result.Type != "transaction" {
+		t.Errorf("expected type 'transaction', got '%s'", result.Type)
+	}
+
+	trimmedTxHash := strings.TrimPrefix(txHashStr, "0x")
+
+	if result.Hash != trimmedTxHash {
+		t.Errorf("expected hash %s, got %s", trimmedTxHash, result.Hash)
+	}
+
+	// Verify the transaction data is in ExtraData
+	if result.ExtraData == nil {
+		t.Errorf("expected ExtraData to contain transaction information")
+	}
+}
+
+func TestSearchByNumber(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	// Create and store a batch
+	txHashes := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne"))}
+	batch := CreateBatchWithDiffHeight(batchNumber, batchNumber+100, txHashes)
+	dbtx, _ := db.NewDBTransaction()
+	err = AddBatch(dbtx, db.GetSQLStatement(), &batch)
+	if err != nil {
+		t.Errorf("could not store batch. Cause: %s", err)
+	}
+	dbtx.Write()
+
+	// search by height
+	heightStr := batch.Header.Number.String()
+	searchResponse, err := Search(db, heightStr)
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 1 {
+		t.Errorf("expected 2 result, got %d", searchResponse.Total)
+	}
+
+	result := searchResponse.TransactionsData[0]
+	if result.Type != "batch" {
+		t.Errorf("expected type 'batch', got '%s'", result.Type)
+	}
+
+	if result.Height.Cmp(batch.Header.Number) != 0 {
+		t.Errorf("expected height %s, got %s", batch.Header.Number.String(), result.Height.String())
+	}
+
+	// search by sequence
+	seqStr := batch.SeqNo().String()
+	searchResponse, err = Search(db, seqStr)
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 1 {
+		t.Errorf("expected 1 result, got %d", searchResponse.Total)
+	}
+
+	result = searchResponse.TransactionsData[0]
+	if result.Type != "batch" {
+		t.Errorf("expected type 'batch', got '%s'", result.Type)
+	}
+
+	if result.Sequence.Cmp(batch.SeqNo()) != 0 {
+		t.Errorf("expected sequence %s, got %s", batch.SeqNo().String(), result.Sequence.String())
+	}
+}
+
+func TestAmbiguousSearch(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	// Create and store a batch with height 100
+	txHashes := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne"))}
+	batch := CreateBatchWithDiffHeight(batchNumber, 100, txHashes)
+	dbtx, _ := db.NewDBTransaction()
+	err = AddBatch(dbtx, db.GetSQLStatement(), &batch)
+	if err != nil {
+		t.Errorf("could not store batch. Cause: %s", err)
+	}
+	dbtx.Write()
+
+	// Test search with a number that could match both height and sequence
+	// In this case, we're searching for "100" which could be both height and sequence
+	searchResponse, err := Search(db, "100")
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	// Should find at least 1 result (the batch by height)
+	if searchResponse.Total < 1 {
+		t.Errorf("expected at least 1 result, got %d", searchResponse.Total)
+	}
+
+	// Verify we have a batch result
+	hasBatch := false
+	for _, result := range searchResponse.TransactionsData {
+		if result.Type == "batch" {
+			hasBatch = true
+			break
+		}
+	}
+
+	if !hasBatch {
+		t.Errorf("expected to find batch in search results")
+	}
+}
+
+func TestSearchEmptyResults(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	// Test search with non-existent hash
+	searchResponse, err := Search(db, "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 0 {
+		t.Errorf("expected 0 results, got %d", searchResponse.Total)
+	}
+
+	if len(searchResponse.TransactionsData) != 0 {
+		t.Errorf("expected 0 results in TransactionsData, got %d", len(searchResponse.TransactionsData))
+	}
+
+	// Test search with non-existent number
+	searchResponse, err = Search(db, "999999")
+	if err != nil {
+		t.Errorf("search failed: %s", err)
+	}
+
+	if searchResponse.Total != 0 {
+		t.Errorf("expected 0 results, got %d", searchResponse.Total)
+	}
+}

--- a/go/host/storage/hostdb/utils.go
+++ b/go/host/storage/hostdb/utils.go
@@ -37,6 +37,20 @@ func CreateBatch(batchNum int64, txHashes []common.L2BatchHash) common.ExtBatch 
 	return batch
 }
 
+func CreateBatchWithDiffHeight(seqNo int64, height int64, txHashes []common.L2BatchHash) common.ExtBatch {
+	header := common.BatchHeader{
+		SequencerOrderNo: big.NewInt(seqNo),
+		Number:           big.NewInt(height),
+		Time:             uint64(time.Now().Unix()),
+	}
+	batch := common.ExtBatch{
+		Header:   &header,
+		TxHashes: txHashes,
+	}
+
+	return batch
+}
+
 func bytesToHexString(bytes []byte) string {
 	return fmt.Sprintf("0x%s", hex.EncodeToString(bytes))
 }

--- a/go/host/storage/interfaces.go
+++ b/go/host/storage/interfaces.go
@@ -12,6 +12,7 @@ import (
 type Storage interface {
 	BatchResolver
 	BlockResolver
+	SearchResolver
 	io.Closer
 }
 
@@ -76,4 +77,9 @@ type BlockResolver interface {
 	FetchRollupBySeqNo(seqNo uint64) (*common.PublicRollup, error)
 	// FetchRollupBatches returns a list of public batch data within a given rollup hash
 	FetchRollupBatches(rollupHash gethcommon.Hash) (*common.BatchListingResponse, error)
+}
+
+// SearchResolver interface
+type SearchResolver interface {
+	Search(query string, pagination *common.QueryPagination) (*common.SearchResponse, error)
 }

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -237,6 +237,10 @@ func (s *storageImpl) EstimateRollupSize(fromSeqNo *big.Int) (uint64, error) {
 	return hostdb.EstimateRollupSize(s.db, fromSeqNo)
 }
 
+func (s *storageImpl) Search(query string, pagination *common.QueryPagination) (*common.SearchResponse, error) {
+	return hostdb.Search(s.db, query, pagination)
+}
+
 func (s *storageImpl) Close() error {
 	return s.db.GetSQLDB().Close()
 }

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -268,3 +268,13 @@ func (oc *ObsClient) GetConfig() (*common.TenNetworkInfo, error) {
 	}
 	return &result, nil
 }
+
+// Search TODO
+func (oc *ObsClient) Search(query string, pagination *common.QueryPagination) (*common.SearchResponse, error) {
+	var result common.SearchResponse
+	err := oc.rpcClient.Call(&result, rpc.Search, query, pagination)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -45,6 +45,7 @@ const (
 	GetRollupBySeqNo        = "scan_getRollupBySeqNo"
 	GetBatchTransactions    = "scan_getBatchTransactions"
 	GetPersonalTransactions = "scan_getPersonalTransactions"
+	Search                  = "scan_search"
 )
 
 // Client is used by client applications to interact with the TEN node

--- a/tools/tenscan/backend/obscuroscan_backend.go
+++ b/tools/tenscan/backend/obscuroscan_backend.go
@@ -161,3 +161,6 @@ func (b *Backend) GetBatchTransactions(hash gethcommon.Hash) (*common.Transactio
 func (b *Backend) GetConfig() (*common.TenNetworkInfo, error) {
 	return b.obsClient.GetConfig()
 }
+func (b *Backend) Search(query string, pagination *common.QueryPagination) (*common.SearchResponse, error) {
+	return b.obsClient.Search(query, pagination)
+}

--- a/tools/tenscan/backend/webserver/webserver_routes_items.go
+++ b/tools/tenscan/backend/webserver/webserver_routes_items.go
@@ -35,6 +35,9 @@ func routeItems(r *gin.Engine, server *WebServer) {
 	r.GET("/items/transaction/:hash", server.getTransaction)
 	r.GET("/items/transactions/count", server.getTotalTxCount)
 	r.GET("/items/blocks/", server.getBlockListing) // Deprecated
+
+	// search
+	r.Get("/items/search/", server.search)
 }
 
 func (w *WebServer) getHealthStatus(c *gin.Context) {
@@ -311,4 +314,16 @@ func (w *WebServer) getConfig(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"item": config})
+}
+
+func (w *WebServer) search(c *gin.Context) {
+	query := c.Query("query")
+
+	publicTxs, err := w.backend.GetPublicTransactions(offset, size)
+	if err != nil {
+		errorHandler(c, fmt.Errorf("unable to execute getPublicTransactions request %w", err), w.logger)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"result": publicTxs})
 }


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/3345

### What changes were made as part of this PR

* Search for hashes (rollup, batch or tx) 
* Search by number (batch height or sequence number) 
* Identifies the query by length of the input and trims any 0x prefixes
* No fuzzy searching - none of the other explorers have this

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


