### PR TITLE
make maxRPCCallDuration configurable

### DIFF
--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -31,4 +31,5 @@ type Config struct {
 	TLSDomain                    string
 	EncryptingCertificateEnabled bool
 	DisableCaching               bool
+	MaximumRPCCallDuration       time.Duration
 }

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -96,6 +96,10 @@ const (
 	disableCachingFlagName    = "disableCaching"
 	disableCachingFlagDefault = false
 	disableCachingFlagUsage   = "Flag to disable response caching in the gateway. Default: false"
+
+	maximumRPCCallDurationName    = "maxRPCCallDuration"
+	maximumRPCCallDurationDefault = 5 * time.Second
+	maximumRPCCallDurationUsage   = "Maximum duration for RPC calls before timing out. Default: 5s"
 )
 
 // getLogLevelInt converts string log level to integer value
@@ -141,6 +145,7 @@ func parseCLIArgs() wecommon.Config {
 	tlsDomainFlag := flag.String(tlsDomainFlagName, tlsDomainFlagDefault, tlsDomainFlagUsage)
 	encryptingCertificateEnabled := flag.Bool(encryptingCertificateEnabledFlagName, encryptingCertificateEnabledFlagDefault, encryptingCertificateEnabledFlagUsage)
 	disableCaching := flag.Bool(disableCachingFlagName, disableCachingFlagDefault, disableCachingFlagUsage)
+	maximumRPCCallDuration := flag.Duration(maximumRPCCallDurationName, maximumRPCCallDurationDefault, maximumRPCCallDurationUsage)
 	flag.Parse()
 
 	return wecommon.Config{
@@ -165,5 +170,6 @@ func parseCLIArgs() wecommon.Config {
 		TLSDomain:                      *tlsDomainFlag,
 		EncryptingCertificateEnabled:   *encryptingCertificateEnabled,
 		DisableCaching:                 *disableCaching,
+		MaximumRPCCallDuration:         *maximumRPCCallDuration,
 	}
 }

--- a/tools/walletextension/rpcapi/filter_api.go
+++ b/tools/walletextension/rpcapi/filter_api.go
@@ -236,7 +236,7 @@ func (api *FilterAPI) GetLogs(ctx context.Context, crit common.FilterCriteria) (
 					var result []*types.Log
 
 					// wrap the context with a timeout to prevent long executions
-					timeoutContext, cancelCtx := context.WithTimeout(ctx, maximumRPCCallDuration)
+					timeoutContext, cancelCtx := context.WithTimeout(ctx, api.we.Config.MaximumRPCCallDuration)
 					defer cancelCtx()
 
 					err := rpcClient.CallContext(timeoutContext, &result, method, common.SerializableFilterCriteria(crit))

--- a/tools/walletextension/rpcapi/utils.go
+++ b/tools/walletextension/rpcapi/utils.go
@@ -38,7 +38,6 @@ const (
 
 	// hardcoding the maximum time for an RPC request
 	// this value will be propagated to the node and enclave and all the operations
-	maximumRPCCallDuration  = 5 * time.Second
 	sendTransactionDuration = 20 * time.Second
 )
 
@@ -79,7 +78,7 @@ func UnauthenticatedTenRPCCall[R any](ctx context.Context, w *services.Services,
 			var err error
 
 			// wrap the context with a timeout to prevent long executions
-			timeoutContext, cancelCtx := context.WithTimeout(ctx, maximumRPCCallDuration)
+			timeoutContext, cancelCtx := context.WithTimeout(ctx, w.Config.MaximumRPCCallDuration)
 			defer cancelCtx()
 
 			err = client.CallContext(timeoutContext, &resp, method, args...)
@@ -137,9 +136,9 @@ func ExecAuthRPC[R any](ctx context.Context, w *services.Services, cfg *AuthExec
 
 				// wrap the context with a timeout to prevent long executions
 				deadline := cfg.timeout
-				// if not set, use default
+				// if not set, use default from config
 				if deadline == 0 {
-					deadline = maximumRPCCallDuration
+					deadline = w.Config.MaximumRPCCallDuration
 				}
 				timeoutContext, cancelCtx := context.WithTimeout(ctx, deadline)
 				defer cancelCtx()


### PR DESCRIPTION
### Why this change is needed

During testing we occasionally experience some issues where the context expired. 
It is helpful to have an option to confiture it via cli parameter. The default is the same as previous hardcoded value.

https://discord.com/channels/916052669955727371/945360340613484684/1379802644700201063

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


