### PR TITLE
EDB connect: set enclave image debug=false

### DIFF
--- a/tools/edbconnect/main/edb-enclave.json
+++ b/tools/edbconnect/main/edb-enclave.json
@@ -1,7 +1,7 @@
 {
   "exe": "main",
   "key": "testnet.pem",
-  "debug": true,
+  "debug": false,
   "heapSize": 1024,
   "executableHeap": true,
   "productID": 1,


### PR DESCRIPTION
### Why this change is needed

Main enclave now has debug=false so this needs to match it to be able to unseal the credentials correctly.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


