### PR TITLE
Host: only broadcast new batches from active seq enclave

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -652,7 +652,7 @@ func (g *Guardian) streamEnclaveData() {
 					g.logger.Crit("failed to add batch to L2 repo", log.BatchHashKey, resp.Batch.Hash(), log.ErrKey, err)
 				}
 
-				if g.hostData.IsSequencer { // if we are the sequencer we need to broadcast this new batch to the network
+				if g.state.IsEnclaveActiveSequencer() { // active sequencer enclave should broadcast the batch to peers
 					g.logger.Info("Batch produced. Sending to peers..", log.BatchHeightKey, resp.Batch.Header.Number, log.BatchHashKey, resp.Batch.Hash())
 
 					err = g.sl.P2P().BroadcastBatches([]*common.ExtBatch{resp.Batch})


### PR DESCRIPTION
### Why this change is needed

We were seeing 'Batch produced' messages twice from sequencer host for each batch and it would have sent out each batch twice on P2P broadcast because of this minor guardian bug.

Don't think either of those things were especially impacting but they caused confusion and the duplicate broadcast could potentially be a problem.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


