### PR TITLE
Enclave: err rather than crit when produce rollup called too early

### DIFF
--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -296,7 +296,7 @@ func (e *enclaveAdminService) CreateBatch(ctx context.Context, skipBatchIfEmpty 
 
 func (e *enclaveAdminService) CreateRollup(ctx context.Context, fromSeqNo uint64) (*common.CreateRollupResult, common.SystemError) {
 	if e.getNodeType(ctx) != common.Sequencer {
-		e.logger.Crit("Only a permissioned sequencer can create rollups")
+		return nil, responses.ToInternalError(fmt.Errorf("only a permissioned sequencer can create rollups"))
 	}
 	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateRollup call ended", &core.RelaxedThresholds)
 


### PR DESCRIPTION
### Why this change is needed

There's a race where backup enclave will crit if host asks it to create rollup too early. There's no need to crit though, it can just return an error and the host will try the other enclave or try again later.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


