### PR TITLE
k8s deploy: upload l1 deploy logs

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -146,3 +146,11 @@ jobs:
         run: |
           sleep 60
           docker logs `docker ps -aqf "name=hh-l1-deployer"` > deploy-l1-contracts.out 2>&1
+          
+      - name: 'Upload L1 deployer container logs'
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-l1-artifacts
+          path: |
+            deploy-l1-contracts.out
+          retention-days: 7


### PR DESCRIPTION
### Why this change is needed

L1 deploy logs artifact wasn't showing up on failed builds, very hard to know what happened. I missed this step... 🫤 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


