### PR TITLE
Host: more visibility when L1 unavailable

### DIFF
--- a/go/ethadapter/geth_rpc_client.go
+++ b/go/ethadapter/geth_rpc_client.go
@@ -39,7 +39,7 @@ type gethRPCClient struct {
 
 // NewEthClientFromURL instantiates a new ethadapter.EthClient that connects to an ethereum node
 func NewEthClientFromURL(rpcURL string, timeout time.Duration, logger gethlog.Logger) (EthClient, error) {
-	client, err := connect(rpcURL, timeout)
+	client, err := connect(rpcURL, timeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to the eth node (%s) - %w", rpcURL, err)
 	}
@@ -237,7 +237,7 @@ func (e *gethRPCClient) ReconnectIfClosed() error {
 	}
 	e.client.Close()
 
-	client, err := connect(e.rpcURL, e.timeout)
+	client, err := connect(e.rpcURL, e.timeout, e.logger)
 	if err != nil {
 		return fmt.Errorf("unable to connect to the eth node (%s) - %w", e.rpcURL, err)
 	}
@@ -257,14 +257,16 @@ func (e *gethRPCClient) Alive() bool {
 	return true
 }
 
-func connect(rpcURL string, connectionTimeout time.Duration) (*ethclient.Client, error) {
+func connect(rpcURL string, connectionTimeout time.Duration, logger gethlog.Logger) (*ethclient.Client, error) {
 	var err error
 	var c *ethclient.Client
-	for start := time.Now(); time.Since(start) < connectionTimeout; time.Sleep(time.Second) {
+	retryInterval := 1 * time.Second
+	for start := time.Now(); time.Since(start) < connectionTimeout; time.Sleep(retryInterval) {
 		c, err = ethclient.Dial(rpcURL)
 		if err == nil {
 			break
 		}
+		logger.Warn("Unable to connect to ethereum node", "ethNodeURL", rpcURL, "err", err, "retryAfter", retryInterval)
 	}
 
 	return c, err


### PR DESCRIPTION
### Why this change is needed

We had an issue where the L1 url was unavailable and it took a long time for us to understand what wasn't working. This can also happen if L1 url is misconfigured. (See https://github.com/ten-protocol/ten-internal/issues/4672)

I was planning to fail fast but we use the same logic for initial connect and reconnect and having the host CRIT and restart isn't especially helpful, realised what we actually wanted was some acknowledgement of what was happening in the logs.

### What changes were made as part of this PR

Extra logging if L1 client is failing to connect.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


