### PR TITLE
Deploy: remove azure faucet deployment for k8s

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -259,21 +259,12 @@ jobs:
                  deploy-l2-contracts.out
               retention-days: 7
 
-   deploy-faucet:
-      name: 'Trigger Faucet deployment for dev- / testnet on a new deployment'
-      uses: ./.github/workflows/manual-deploy-testnet-faucet.yml
-      with:
-         testnet_type: ${{ github.event.inputs.testnet_type }}
-      secrets: inherit
-      needs:
-         - grant-sequencer-enclaves
-
    obscuro-test-repository-dispatch:
       runs-on: ubuntu-latest
       environment:
          name: ${{ github.event.inputs.testnet_type }}
       needs:
-         - deploy-faucet
+         - grant-sequencer-enclaves
       steps:
          - name: 'Send a repository dispatch to obscuro-test on deployment of dev-testnet'
            if: ${{ (github.event.inputs.testnet_type == 'dev-testnet') }}


### PR DESCRIPTION
### Why this change is needed

Faucet is now part of the k8s deployment and redeploying it when testnet is wiped will be responsibility of argoCD infra.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


