### PR TITLE
Deploy: always upload log artifacts even on failure

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -248,10 +248,12 @@ jobs:
               go run ./testnet/launcher/l2contractdeployer/cmd \
 
          - name: 'Save L2 deployer container logs'
+           if: ${{ always() }} # Always run this step to ensure logs are captured even if previous steps fail
            run: |
               docker logs `docker ps -aqf "name=hh-l2-deployer"` > deploy-l2-contracts.out 2>&1
 
          - name: 'Upload L2 deployer container logs'
+           if: ${{ always() }} # Always run this step to ensure logs are uploaded even if previous steps fail
            uses: actions/upload-artifact@v4
            with:
               name: deploy-l2-artifacts

--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -143,11 +143,13 @@ jobs:
 
       - name: 'Save L1 deployer container logs'
         # Wait to make sure the logs are available in the container
+        if: ${{ always() }} # Always run this step to ensure logs are captured even if previous steps fail
         run: |
           sleep 60
           docker logs `docker ps -aqf "name=hh-l1-deployer"` > deploy-l1-contracts.out 2>&1
           
       - name: 'Upload L1 deployer container logs'
+        if: ${{ always() }} # Always run this step to ensure logs are uploaded even if previous steps fail
         uses: actions/upload-artifact@v4
         with:
           name: deploy-l1-artifacts

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -133,6 +133,7 @@ jobs:
           echo "L1_START_HASH=$L1START" >> $GITHUB_OUTPUT
 
       - name: 'Save L1 deployer container logs'
+        if: ${{ always() }} # Always run this step to ensure logs are uploaded even if previous steps fail
         # Wait to make sure the logs are available in the container
         run: |
           sleep 60
@@ -164,6 +165,7 @@ jobs:
             done
 
       - name: 'Upload L1 deployer container logs'
+        if: ${{ always() }} # Always run this step to ensure logs are uploaded even if previous steps fail
         uses: actions/upload-artifact@v4
         with:
           name: deploy-l1-artifacts

--- a/testnet/launcher/l1contractdeployer/cmd/main.go
+++ b/testnet/launcher/l1contractdeployer/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 	networkConfig, err := l1ContractDeployer.RetrieveL1ContractAddresses()
 	if err != nil {
 		fmt.Printf("unable to fetch l1 contract addresses - %s", err)
-		os.Exit(0)
+		os.Exit(1)
 	}
 	fmt.Println("L1 Contracts were successfully deployed...")
 


### PR DESCRIPTION
### Why this change is needed

We were returning successful status code when L1 contract deploy failed to make sure the log artifacts always get captured.

This change allows logs to be captured even on failure so we can fail fast and not make people debug the issue when the nodes eventually fail to start up.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


