### PR TITLE
Fix performance on personal txs query

### DIFF
--- a/go/enclave/rpc/GetPersonalTransactions.go
+++ b/go/enclave/rpc/GetPersonalTransactions.go
@@ -28,6 +28,12 @@ func GetPersonalTransactionsValidate(reqParams []any, builder *CallBuilder[commo
 		builder.Err = fmt.Errorf("unable to extract query - %w", err)
 		return nil
 	}
+
+	if builder.Param.ShowAllPublicTxs || builder.Param.ShowSyntheticTxs {
+		builder.Err = errors.New("public or synthetic transactions not supported yet")
+		return nil
+	}
+
 	addr := privateCustomQuery.Address
 	builder.From = &addr
 	builder.Param = privateCustomQuery

--- a/go/enclave/storage/enclavedb/batch.go
+++ b/go/enclave/storage/enclavedb/batch.go
@@ -421,16 +421,8 @@ func MarkBatchAsUnexecuted(ctx context.Context, dbTx *sqlx.Tx, seqNo *big.Int) e
 	return err
 }
 
-func GetTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint64, pagination *common.QueryPagination, showPublic bool, showSynthetic bool) ([]*core.InternalReceipt, error) {
-	params := []any{}
-	where := " "
-
-	if !showSynthetic {
-		where += " AND curr_tx.is_synthetic=? "
-		params = append(params, showSynthetic)
-	}
-
-	receipts, err := loadPersonalTxs(ctx, db, address, showPublic, where, params, " ORDER BY b.sequence DESC LIMIT ? OFFSET ?", []any{pagination.Size, pagination.Offset})
+func GetTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint64, pagination *common.QueryPagination, _ bool, _ bool) ([]*core.InternalReceipt, error) {
+	receipts, err := loadPersonalTxs(ctx, db, address, pagination)
 	if err != nil {
 		return nil, err
 	}
@@ -453,23 +445,83 @@ func GetTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint64
 	return receipts, nil
 }
 
-func CountTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint64, showPublic bool, showSynthetic bool) (uint64, error) {
+func loadPersonalTxs(ctx context.Context, db *sqlx.DB, requestingAccountId *uint64, pagination *common.QueryPagination) ([]*core.InternalReceipt, error) {
+	if requestingAccountId == nil {
+		return nil, fmt.Errorf("you have to specify requestingAccount")
+	}
+	var queryParams []any
+	unionQuery, unionParams := createReceiptIdQuery(*requestingAccountId)
+
+	innerQuery := "SELECT u.id  FROM (" + unionQuery + ") AS u ORDER BY u.id DESC LIMIT ? OFFSET ?"
+
+	query := "select b.hash, b.height, curr_tx.hash, curr_tx.idx, rec.post_state, rec.status, rec.gas_used, rec.effective_gas_price, rec.created_contract_address, tx_sender.address, tx_contr.address, curr_tx.type "
+	query += " from receipt rec " +
+		"left join receipt_viewer rv on rec.id=rv.receipt " +
+		"join batch b on rec.batch=b.sequence " +
+		"join tx curr_tx on rec.tx=curr_tx.id " +
+		"   join externally_owned_account tx_sender on curr_tx.sender_address=tx_sender.id " +
+		"   left join contract tx_contr on curr_tx.contract=tx_contr.id "
+
+	query += " WHERE rec.id IN (" + innerQuery + ") "
+
+	queryParams = append(queryParams, unionParams...)
+	queryParams = append(queryParams, pagination.Size, pagination.Offset)
+
+	rows, err := db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	receipts := make([]*core.InternalReceipt, 0)
+
+	empty := true
+	for rows.Next() {
+		empty = false
+		r, err := onRowWithReceipt(rows)
+		if err != nil {
+			return nil, err
+		}
+		receipts = append(receipts, r)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	if empty {
+		return nil, errutil.ErrNotFound
+	}
+	return receipts, nil
+}
+
+func onRowWithReceipt(rows *sql.Rows) (*core.InternalReceipt, error) {
+	r := core.InternalReceipt{}
+
+	var txIndex *uint
+	var blockHash, transactionHash *gethcommon.Hash
+	var blockNumber *uint64
+	res := []any{&blockHash, &blockNumber, &transactionHash, &txIndex, &r.PostState, &r.Status, &r.GasUsed, &r.EffectiveGasPrice, &r.CreatedContract, &r.From, &r.To, &r.TxType}
+
+	err := rows.Scan(res...)
+	if err != nil {
+		return nil, fmt.Errorf("could not load receipt from db: %w", err)
+	}
+
+	r.BlockHash = *blockHash
+	r.BlockNumber = big.NewInt(int64(*blockNumber))
+	r.TxHash = *transactionHash
+	r.TransactionIndex = *txIndex
+
+	r.Logs = make([]*types.Log, 0)
+	return &r, nil
+}
+
+func CountTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint64, _ bool, _ bool) (uint64, error) {
 	var count uint64
 
-	cond := personalTxCondition
-	if showPublic {
-		cond = personalTxConditionPublic
-	}
+	unionQuery, params := createReceiptIdQuery(*address)
 
-	query := "select count(1) " + baseReceiptJoinWithViewer + " WHERE " + cond
-
-	var params []any
-	params = append(params, *address, *address, *address)
-
-	if !showSynthetic {
-		query += " AND curr_tx.is_synthetic=? "
-		params = append(params, showSynthetic)
-	}
+	query := "SELECT count(DISTINCT u.id)  FROM (" + unionQuery + ") AS u "
 
 	err := db.QueryRowContext(ctx, query, params...).Scan(&count)
 	if err != nil {
@@ -477,6 +529,18 @@ func CountTransactionsPerAddress(ctx context.Context, db *sqlx.DB, address *uint
 	}
 
 	return count, nil
+}
+
+func createReceiptIdQuery(address uint64) (string, []any) {
+	senderQuery := "select rec.id from tx curr_tx join receipt rec on rec.tx=curr_tx.id WHERE curr_tx.sender_address=? AND curr_tx.is_synthetic=?"
+	receiverQuery := "select rec.id from tx curr_tx join receipt rec on rec.tx=curr_tx.id WHERE curr_tx.to_eoa=? AND curr_tx.is_synthetic=?"
+	eventsQuery := "select rec.id from tx curr_tx join receipt rec on rec.tx=curr_tx.id join receipt_viewer rv on rec.id=rv.receipt WHERE rv.eoa=? AND curr_tx.is_synthetic=?"
+
+	unionQuery := senderQuery + " UNION " + receiverQuery + " UNION " + eventsQuery
+
+	var params []any
+	params = append(params, address, false, address, false, address, false)
+	return unionQuery, params
 }
 
 func FetchConvertedBatchHash(ctx context.Context, db *sqlx.DB, seqNo uint64) (gethcommon.Hash, error) {

--- a/go/enclave/storage/init/edgelessdb/002_init.sql
+++ b/go/enclave/storage/init/edgelessdb/002_init.sql
@@ -1,0 +1,2 @@
+drop index receipt on tendb.receipt_viewer;
+CREATE INDEX receipt ON tendb.receipt_viewer (eoa, receipt);

--- a/go/enclave/storage/init/sqlite/002_init.sql
+++ b/go/enclave/storage/init/sqlite/002_init.sql
@@ -1,0 +1,2 @@
+DROP INDEX IDX_REC_VIEW;
+CREATE INDEX IDX_REC_VIEW ON receipt_viewer (eoa, receipt);

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -309,7 +309,6 @@ func healthRequestHandler(walletExt *services.Services, conn UserConn) {
 		response := []byte(common.SuccessMsg)
 		return &response, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting health status", log.ErrKey, err)
 		return
@@ -364,7 +363,6 @@ func networkHealthRequestHandler(walletExt *services.Services, userConn UserConn
 
 		return &data, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting network health status", log.ErrKey, err)
 		return
@@ -444,7 +442,6 @@ func networkConfigRequestHandler(walletExt *services.Services, userConn UserConn
 
 		return &data, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting network config", log.ErrKey, err)
 		return


### PR DESCRIPTION
### Why this change is needed

The personal txs query is slow

### What changes were made as part of this PR

- change the index on "receipt_viewer"
- rewrite the count and select queries as UNIONS
- remove the "isPublic" and "isTransparent" capabilities for now


