### PR TITLE
remove tx signing with SK on `SendRawTransaction`

### DIFF
--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -309,7 +309,6 @@ func healthRequestHandler(walletExt *services.Services, conn UserConn) {
 		response := []byte(common.SuccessMsg)
 		return &response, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting health status", log.ErrKey, err)
 		return
@@ -364,7 +363,6 @@ func networkHealthRequestHandler(walletExt *services.Services, userConn UserConn
 
 		return &data, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting network health status", log.ErrKey, err)
 		return
@@ -444,7 +442,6 @@ func networkConfigRequestHandler(walletExt *services.Services, userConn UserConn
 
 		return &data, nil
 	})
-
 	if err != nil {
 		walletExt.Logger().Error("error getting network config", log.ErrKey, err)
 		return

--- a/tools/walletextension/rpcapi/transaction_api.go
+++ b/tools/walletextension/rpcapi/transaction_api.go
@@ -114,7 +114,6 @@ func (s *TransactionAPI) SendTransaction(ctx context.Context, args gethapi.Trans
 		return common.Hash{}, fmt.Errorf("please activate session key")
 	}
 
-	// todo - check whether the from is the sk
 	// when there is an active Session Key, sign all incoming transactions with that SK
 	signedTx, err := s.we.SKManager.SignTx(ctx, user, args.ToTransaction())
 	if err != nil {
@@ -139,29 +138,7 @@ func (s *TransactionAPI) FillTransaction(ctx context.Context, args gethapi.Trans
 }
 
 func (s *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
-	user, err := extractUserForRequest(ctx, s.we)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	signedTxBlob := input
-	// when there is an active Session Key, sign all incoming transactions with that SK
-	if user.ActiveSK && user.SessionKey != nil {
-		tx := new(types.Transaction)
-		if err = tx.UnmarshalBinary(input); err != nil {
-			return common.Hash{}, err
-		}
-		signedTx, err := s.we.SKManager.SignTx(ctx, user, tx)
-		if err != nil {
-			return common.Hash{}, err
-		}
-		signedTxBlob, err = signedTx.MarshalBinary()
-		if err != nil {
-			return common.Hash{}, err
-		}
-	}
-
-	return SendRawTx(ctx, s.we, signedTxBlob)
+	return SendRawTx(ctx, s.we, input)
 }
 
 func (s *TransactionAPI) PendingTransactions() ([]*rpc.RpcTransaction, error) {


### PR DESCRIPTION
### Why this change is needed

To remove confusing behaviour.
`SendRawTransaction` already sends a signed transaction.

### What changes were made as part of this PR

- remove sk logic from `SendRawTransaction`

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


