### PR TITLE
Host: be more realistic on rollup compressed size estimate

### DIFF
--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -287,10 +287,9 @@ func (e *Service) tryPromoteNewSequencer() {
 	e.activeSequencerID.Store(_noActiveSequencer)
 }
 
-// getFailoverCandidates returns a list of guardians that are not the active sequencer that seem healthy
-// it is used to check if failing over to a new active sequencer is possible
-
-const batchCompressionFactor = 0.85
+// This compression factor is based on data we've seen in production where the rollups is typically
+// 10-15% the size of the raw batch txs. This still allows some buffer so the rollup should rarely be completely full
+const batchCompressionFactor = 0.25
 
 // managePeriodicRollups is a background goroutine that periodically produces a rollup
 // where possible it will prefer to use a non-active sequencer enclave to avoid disrupting the production of batches


### PR DESCRIPTION
### Why this change is needed

We were publishing rollups before max interval that were <20kb when we have a max size of 128kb. This was because the compressed size estimate was way off.

### What changes were made as part of this PR

Tweak the compression rate (which is applied to the raw txs size) to match what we've seen in sepolia. It doesn't matter too much if it's way over or under but we should keep an eye on publish rates, useful if it's realistic.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


