### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/integration/simulation/validate_chain.go
+++ b/integration/simulation/validate_chain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -771,10 +772,8 @@ func assertRelevantLogsOnly(t *testing.T, owner string, receivedLog types.Log) {
 		return
 	}
 
-	for _, addr := range userAddrs {
-		if addr == owner {
-			return
-		}
+	if slices.Contains(userAddrs, owner) {
+		return
 	}
 
 	// If we've fallen through to here, it means the log was not relevant.

--- a/lib/gethfork/node/node.go
+++ b/lib/gethfork/node/node.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -229,12 +230,7 @@ func (n *Node) openEndpoints() error {
 
 // containsLifecycle checks if 'lfs' contains 'l'.
 func containsLifecycle(lfs []Lifecycle, l Lifecycle) bool {
-	for _, obj := range lfs {
-		if obj == l {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(lfs, l)
 }
 
 // stopServices terminates running services, RPC and p2p networking.

--- a/lib/gethfork/rpc/http.go
+++ b/lib/gethfork/rpc/http.go
@@ -27,6 +27,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -356,10 +357,8 @@ func (s *Server) validateRequest(r *http.Request) (int, error) {
 	}
 	// Check content-type
 	if mt, _, err := mime.ParseMediaType(r.Header.Get("content-type")); err == nil {
-		for _, accepted := range acceptedContentTypes {
-			if accepted == mt {
-				return 0, nil
-			}
+		if slices.Contains(acceptedContentTypes, mt) {
+			return 0, nil
 		}
 	}
 	// Invalid content-type


### PR DESCRIPTION
### Why this change is needed

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [x] PR checks reviewed and performed 


