### PR TITLE
Config: fix field that could not be marshaled

### DIFF
--- a/go/common/node_type.go
+++ b/go/common/node_type.go
@@ -1,6 +1,9 @@
 package common
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const (
 	sequencer = "sequencer"
@@ -34,6 +37,22 @@ func (n *NodeType) UnmarshalText(text []byte) error {
 	nodeType, err := ToNodeType(string(text))
 	if err != nil {
 		return err
+	}
+	*n = nodeType
+	return nil
+}
+
+func (n NodeType) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, n.String())), nil
+}
+func (n *NodeType) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("unmarshalling NodeType: %w", err)
+	}
+	nodeType, err := ToNodeType(s)
+	if err != nil {
+		return fmt.Errorf("unmarshalling NodeType: %w", err)
 	}
 	*n = nodeType
 	return nil


### PR DESCRIPTION
### Why this change is needed

Instead of pretty printing config we are seeing this in the logs:
`Error deserializing config: json: cannot unmarshal number into Go struct field NodeConfig.Node.NodeType of type common.NodeType`

This is because we json marshal for a deep copy (common pattern in go) but NodeType field needed marshaling method.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


