### PR TITLE
Host: fix minor logging issues

### DIFF
--- a/go/enclave/storage/storage.go
+++ b/go/enclave/storage/storage.go
@@ -585,7 +585,7 @@ func (s *storageImpl) StoreNewEnclave(ctx context.Context, enclaveId common.Encl
 	compressedKey := gethcrypto.CompressPubkey(key)
 	if alreadyExists {
 		// this should be unusual, log it for visibility
-		s.logger.Warn("Updating existing attestation key", "enclaveId")
+		s.logger.Warn("Updating existing attestation key", "enclaveId", enclaveId)
 		_, err = enclavedb.UpdateAttestationKey(ctx, dbTx, enclaveId, compressedKey)
 	} else {
 		_, err = enclavedb.WriteAttestation(ctx, dbTx, enclaveId, compressedKey, common.Validator)


### PR DESCRIPTION
### Why this change is needed

Fix couple of logging niggles we saw in recent issues:

`WARN [07-21|11:28:00.862] Updating existing attestation key        node_id=0 cmp=enclave enclaveId=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil`

and this gets spammed at startup:
`WARN [07-21|10:50:45.325] could not get enclave ID                 node_id=0xEEd55Ff2853b004A82D2b4CE97B038D712216dCa cmp=host err="rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.2.0.162:11001: connect: connection refused`

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


