### PR TITLE
DB: fix migration config update to upsert

### DIFF
--- a/go/enclave/storage/enclavedb/config.go
+++ b/go/enclave/storage/enclavedb/config.go
@@ -29,7 +29,7 @@ const (
 	attSelectSequencers = "select enclave_id from attestation where node_type = ?"
 )
 
-func WriteConfigToTx(ctx context.Context, dbtx *sqlx.Tx, key string, value any) error {
+func InsertOrUpdateConfig(ctx context.Context, dbtx *sqlx.Tx, key string, value any) error {
 	var exists bool
 	// check if it exists then insert or update - this keeps it agnostic to the type of sql database
 	err := dbtx.GetContext(ctx, &exists, cfgExists, key)

--- a/go/enclave/storage/enclavedb/config.go
+++ b/go/enclave/storage/enclavedb/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 
@@ -13,7 +14,9 @@ import (
 )
 
 const (
+	cfgExists = "select exists(select 1 from config where ky = ?)"
 	cfgInsert = "insert into config values (?,?)"
+	cfgUpdate = "update config set val = ? where ky = ?"
 	cfgSelect = "select val from config where ky=?"
 )
 
@@ -26,8 +29,27 @@ const (
 	attSelectSequencers = "select enclave_id from attestation where node_type = ?"
 )
 
-func WriteConfigToTx(ctx context.Context, dbtx *sqlx.Tx, key string, value any) (sql.Result, error) {
-	return dbtx.ExecContext(ctx, cfgInsert, key, value)
+func WriteConfigToTx(ctx context.Context, dbtx *sqlx.Tx, key string, value any) error {
+	var exists bool
+	// check if it exists then insert or update - this keeps it agnostic to the type of sql database
+	err := dbtx.GetContext(ctx, &exists, cfgExists, key)
+	if err != nil {
+		return fmt.Errorf("failed to check existence of config key %q: %w", key, err)
+	}
+
+	if exists {
+		_, err = dbtx.ExecContext(ctx, cfgUpdate, value, key)
+		if err != nil {
+			return fmt.Errorf("failed to update config key %q: %w", key, err)
+		}
+	} else {
+		_, err = dbtx.ExecContext(ctx, cfgInsert, key, value)
+		if err != nil {
+			return fmt.Errorf("failed to insert config key %q: %w", key, err)
+		}
+	}
+
+	return nil
 }
 
 func WriteConfig(ctx context.Context, db *sqlx.Tx, key string, value []byte) (sql.Result, error) {

--- a/go/enclave/storage/init/migration/db_migration.go
+++ b/go/enclave/storage/init/migration/db_migration.go
@@ -80,7 +80,7 @@ func executeMigration(db *sqlx.DB, content string, migrationOrder int64) error {
 		}
 	}
 
-	_, err = enclavedb.WriteConfigToTx(context.Background(), tx, currentMigrationVersionKey, big.NewInt(migrationOrder).Bytes())
+	err = enclavedb.WriteConfigToTx(context.Background(), tx, currentMigrationVersionKey, big.NewInt(migrationOrder).Bytes())
 	if err != nil {
 		return err
 	}

--- a/go/enclave/storage/init/migration/db_migration.go
+++ b/go/enclave/storage/init/migration/db_migration.go
@@ -80,7 +80,7 @@ func executeMigration(db *sqlx.DB, content string, migrationOrder int64) error {
 		}
 	}
 
-	err = enclavedb.WriteConfigToTx(context.Background(), tx, currentMigrationVersionKey, big.NewInt(migrationOrder).Bytes())
+	err = enclavedb.InsertOrUpdateConfig(context.Background(), tx, currentMigrationVersionKey, big.NewInt(migrationOrder).Bytes())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Why this change is needed

We try to insert the migration version value but that fails after the first time because key already exists, so we should so an update if present.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


