### PR TITLE
Dev: fix faucet funding and test config

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -238,7 +238,7 @@ jobs:
               DEPLOY_L2_RPCADDRESS: ${{ needs.read-l1-config.outputs.TESTNET_SHORT_NAME }}-validator-01.ten.xyz
               DEPLOY_L2_HTTPPORT: 80
               DEPLOY_L2_WSPORT: 81
-              DEPLOY_L2_FAUCETFUNDS: ${{ vars.FAUCET_INITIAL_FUNDS }}
+              DEPLOY_L2_FAUCETPREFUND: ${{ vars.FAUCET_INITIAL_FUNDS }}
               NETWORK_L1_CONTRACTS_NETWORKCONFIG: ${{ needs.read-l1-config.outputs.network_config }}
               NETWORK_L1_CONTRACTS_MESSAGEBUS: ${{ needs.read-l1-config.outputs.message_bus }}
               NETWORK_L1_CONTRACTS_ROLLUP: ${{ needs.read-l1-config.outputs.rollup }}

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -35,7 +35,7 @@ func UATTestnet(opts ...TestnetEnvOption) networktest.Environment {
 	connector := newTestnetConnector(
 		"http://uat-sequencer.ten.xyz:80",
 		[]string{"http://uat-validator-01.ten.xyz:80"},
-		"https://uat-faucet.tenscan.io/fund/eth",
+		"https://uat-faucet.ten.xyz/fund/eth",
 		"wss://ethereum-sepolia-rpc.publicnode.com",
 		"https://rpc.uat-gw-testnet.ten.xyz",
 		"wss://rpc.uat-gw-testnet.ten.xyz:81",
@@ -47,7 +47,7 @@ func DevTestnet(opts ...TestnetEnvOption) networktest.Environment {
 	connector := newTestnetConnector(
 		"http://erpc.dev-testnet.ten.xyz:80", // this is actually a validator...
 		[]string{"http://erpc.dev-testnet.ten.xyz:80"},
-		"http://dev-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
+		"https://dev-faucet.ten.xyz/fund/eth",
 		"ws://dev-testnet-eth2network.uksouth.cloudapp.azure.com:9000",
 		"https://rpc.dev-testnet.ten.xyz",
 		"wss://rpc.dev-testnet.ten.xyz:81",


### PR DESCRIPTION
### Why this change is needed

Typo-ed the faucet prefunding config field so dev-testnet faucet not getting funded at deploy time.

Also update faucet addresses in network tests cfg.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


