### PR TITLE
Ziga/fix gateway connectivity and caching when not connected properly

### DIFF
--- a/tools/walletextension/cache/RistrettoCache.go
+++ b/tools/walletextension/cache/RistrettoCache.go
@@ -61,6 +61,10 @@ func (c *ristrettoCache) DisableShortLiving() {
 	c.shortLivingEnabled.Store(false)
 }
 
+func (c *ristrettoCache) IsShortLivingEnabled() bool {
+	return c.shortLivingEnabled.Load()
+}
+
 func (c *ristrettoCache) IsEvicted(key []byte, originalTTL time.Duration) bool {
 	if !c.shortLivingEnabled.Load() {
 		return true

--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -39,7 +39,7 @@ const (
 	LongLiving  Strategy = iota
 
 	longCacheTTL  = 5 * time.Hour
-	shortCacheTTL = 1 * time.Second
+	shortCacheTTL = 2 * time.Second
 )
 
 type Cfg struct {

--- a/tools/walletextension/cache/cache.go
+++ b/tools/walletextension/cache/cache.go
@@ -36,7 +36,7 @@ const (
 	LongLiving  Strategy = iota
 
 	longCacheTTL  = 5 * time.Hour
-	shortCacheTTL = 1 * time.Minute
+	shortCacheTTL = 1 * time.Second
 )
 
 type Cfg struct {


### PR DESCRIPTION
### Why this change is needed
The gateway was serving stale eth_blockNumber responses (& other cached responses which depend on new batch) for up to 60 seconds when the NewHeads subscription connection was lost. While the cache
  disable mechanism (DisableShortLiving()) was correctly triggered after 5 seconds of no new heads, the underlying Ristretto cache continued serving cached values.

This caused users to receive the same block number for extended periods (up to 1 minute), and the e2e tests were failing.


### What changes were made as part of this PR

Fixed cache bypass logic for disconnected subscriptions:
  - Added IsShortLivingEnabled() method to the Cache interface to check subscription status
  - Modified WithCache() function to completely bypass cache when LatestBatch strategy is used and short living is disabled
  - Implemented the new interface method in both ristrettoCache and noOpCache
  - changed shortTimeTTL to 2s (batches are used to evict the data anyway so no point of having TTL for longer)

  Previous behavior: Cache marked as "evicted" but still served stale data from underlying Ristretto cacheNew behavior: Cache completely bypassed when subscription is down, ensuring fresh data is always fetched

In the future it would be good to have health endpoint which will reflect also when the last batch was received & if the current connection is working - creating ticket for that (but not required for Phase 1)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


