### PR TITLE
Deploy: add support for mainnet env

### DIFF
--- a/.github/workflows/build-gateway-images.yml
+++ b/.github/workflows/build-gateway-images.yml
@@ -20,6 +20,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
 
 jobs:
   build-and-publish:

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -19,13 +19,14 @@ on:
                - 'dev-testnet'
                - 'uat-testnet'
                - 'sepolia-testnet'
+               - 'mainnet'
          log_level:
             description: 'Log Level 1-Error 5-Trace'
             required: true
             default: 3
             type: number
          confirmation:
-            description: 'Type "confirm" if deploying sepolia'
+            description: 'Type "confirm" if deploying sepolia or mainnet'
             required: false
             type: string
 
@@ -51,8 +52,8 @@ jobs:
          # first, we check the confirmation field if deploying sepolia
          - name: 'Check confirmation'
            run: |
-            if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
-               echo "Confirmation field must say 'confirm' to deploy sepolia to avoid accidental deployments"
+            if [[ ("${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" || "${{ github.event.inputs.testnet_type }}" == "mainnet") && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+               echo "Confirmation field must say 'confirm' to deploy sepolia or mainnet to avoid accidental deployments"
                exit 1
             fi
 
@@ -62,9 +63,13 @@ jobs:
             env:
                TESTNET_TYPE: ${{ github.event.inputs.testnet_type }}
             run: |
-               # strip the -testnet suffix from the testnet type
-               short_name=${TESTNET_TYPE%-testnet}
-               echo "TESTNET_SHORT_NAME=$short_name" >> $GITHUB_OUTPUT
+                # extract the environment prefix (dev, uat, sepolia, mainnet)
+                if [[ "$TESTNET_TYPE" == "mainnet" ]]; then
+                  short_name="mainnet"
+                else
+                  # strip the -testnet suffix from testnet environments
+                  short_name=${TESTNET_TYPE%-testnet}
+                fi               echo "TESTNET_SHORT_NAME=$short_name" >> $GITHUB_OUTPUT
 
          # checkout *this* repo (so subsequent steps can still see it)
          -  uses: actions/checkout@v4

--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -19,13 +19,14 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
       log_level:
         description: 'Log Level 1-Error 5-Trace'
         required: true
         default: 3
         type: number
       confirmation:
-          description: 'Type "confirm" if deploying sepolia'
+          description: 'Type "confirm" if deploying sepolia or mainnet'
           required: false
           type: string
 
@@ -51,8 +52,8 @@ jobs:
       - name: 'Check confirmation'
         # if env is sepolia then confirmation field needs to say 'confirm'
         run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
-            echo "Confirmation field must say 'confirm' to deploy sepolia to avoid accidental deployments"
+          if [[ ("${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" || "${{ github.event.inputs.testnet_type }}" == "mainnet") && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to deploy sepolia or mainnet to avoid accidental deployments"
             exit 1
           fi
 
@@ -62,8 +63,13 @@ jobs:
         env:
           TESTNET_TYPE: ${{ github.event.inputs.testnet_type }}
         run: |
-          # strip the -testnet suffix from the testnet type
-          short_name=${TESTNET_TYPE%-testnet}
+          # extract the environment prefix (dev, uat, sepolia, mainnet)
+          if [[ "$TESTNET_TYPE" == "mainnet" ]]; then
+            short_name="mainnet"
+          else
+            # strip the -testnet suffix from testnet environments
+            short_name=${TESTNET_TYPE%-testnet}
+          fi
           echo "TESTNET_SHORT_NAME=$short_name" >> $GITHUB_OUTPUT
 
       - name: 'Print GitHub variables'

--- a/.github/workflows/manual-deploy-obscuro-gateway-database.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway-database.yml
@@ -15,6 +15,7 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/manual-deploy-obscuro-gateway.yml
+++ b/.github/workflows/manual-deploy-obscuro-gateway.yml
@@ -26,6 +26,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
       instance_type:
         description: "Instance"
         required: true

--- a/.github/workflows/manual-deploy-ten-bridge.yml
+++ b/.github/workflows/manual-deploy-ten-bridge.yml
@@ -15,6 +15,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/manual-deploy-ten-gateway-frontend.yml
+++ b/.github/workflows/manual-deploy-ten-gateway-frontend.yml
@@ -23,6 +23,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
       instance_type:
         description: "Instance"
         required: true

--- a/.github/workflows/manual-deploy-ten-scan.yml
+++ b/.github/workflows/manual-deploy-ten-scan.yml
@@ -15,6 +15,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/manual-deploy-testnet-faucet.yml
+++ b/.github/workflows/manual-deploy-testnet-faucet.yml
@@ -22,6 +22,7 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
 
   workflow_call:
     inputs:

--- a/.github/workflows/manual-deploy-testnet-l2.yml
+++ b/.github/workflows/manual-deploy-testnet-l2.yml
@@ -22,13 +22,14 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
       log_level:
         description: 'Log Level 1-Error 5-Trace'
         required: true
         default: 3
         type: number
       confirmation:
-          description: 'Type "confirm" if deploying sepolia'
+          description: 'Type "confirm" if deploying sepolia or mainnet'
           required: false
           type: string
 
@@ -53,8 +54,8 @@ jobs:
       - name: 'Check confirmation'
         # if env is sepolia then confirmation field needs to say 'confirm'
         run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
-            echo "Confirmation field must say 'confirm' to deploy sepolia to avoid accidental deployments"
+          if [[ ("${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" || "${{ github.event.inputs.testnet_type }}" == "mainnet") && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to deploy sepolia or mainnet to avoid accidental deployments"
             exit 1
           fi
 

--- a/.github/workflows/manual-deploy-testnet-validator.yml
+++ b/.github/workflows/manual-deploy-testnet-validator.yml
@@ -33,6 +33,7 @@ on:
           - "dev-testnet"
           - "uat-testnet"
           - "sepolia-testnet"
+          - "mainnet"
       log_level:
         description: "Log Level 1-Error 5-Trace"
         required: true

--- a/.github/workflows/manual-recover-network-funds.yml
+++ b/.github/workflows/manual-recover-network-funds.yml
@@ -14,6 +14,7 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
 jobs:
   recover-network-funds:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-upgrade-l1-contracts.yml
+++ b/.github/workflows/manual-upgrade-l1-contracts.yml
@@ -12,8 +12,9 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
       confirmation:
-        description: 'Type "confirm" if upgrading sepolia'
+        description: 'Type "confirm" if upgrading sepolia or mainnet'
         required: false
         type: string
 
@@ -26,8 +27,8 @@ jobs:
     steps:
       - name: 'Check confirmation'
         run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
-            echo "Confirmation field must say 'confirm' to upgrade sepolia to avoid accidental upgrades"
+          if [[ ("${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" || "${{ github.event.inputs.testnet_type }}" == "mainnet") && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to upgrade sepolia or mainnet to avoid accidental upgrades"
             exit 1
           fi
 
@@ -58,9 +59,14 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
-          # Strip the "-testnet" suffix from the input
+          # Extract the environment prefix from the input
           TESTNET_TYPE_RAW="${{ github.event.inputs.testnet_type }}"
-          TESTNET_TYPE=${TESTNET_TYPE_RAW%-testnet}
+          if [[ "$TESTNET_TYPE_RAW" == "mainnet" ]]; then
+            TESTNET_TYPE="mainnet"
+          else
+            # Strip the "-testnet" suffix from testnet environments
+            TESTNET_TYPE=${TESTNET_TYPE_RAW%-testnet}
+          fi
   
           # Run upgrade script
           go run ./testnet/launcher/l1upgrade/cmd \

--- a/.github/workflows/manual-upgrade-testnet-l2.yml
+++ b/.github/workflows/manual-upgrade-testnet-l2.yml
@@ -29,13 +29,14 @@ on:
           - 'dev-testnet'
           - 'uat-testnet'
           - 'sepolia-testnet'
+          - 'mainnet'
       log_level:
         description: 'Log Level 1-Error 5-Trace'
         required: true
         default: 3
         type: number
       confirmation:
-        description: 'Type "confirm" if upgrading sepolia'
+        description: 'Type "confirm" if upgrading sepolia or mainnet'
         required: false
         type: string
 
@@ -52,8 +53,8 @@ jobs:
       - name: 'Check confirmation'
         # if env is sepolia then confirmation field needs to say 'confirm'
         run: |
-          if [[ "${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
-            echo "Confirmation field must say 'confirm' to upgrade sepolia to avoid accidental upgrades"
+          if [[ ("${{ github.event.inputs.testnet_type }}" == "sepolia-testnet" || "${{ github.event.inputs.testnet_type }}" == "mainnet") && "${{ github.event.inputs.confirmation }}" != "confirm" ]]; then
+            echo "Confirmation field must say 'confirm' to upgrade sepolia or mainnet to avoid accidental upgrades"
             exit 1
           fi
 

--- a/.github/workflows/runner-scripts/testnet-clear-loadbalancer.sh
+++ b/.github/workflows/runner-scripts/testnet-clear-loadbalancer.sh
@@ -14,8 +14,11 @@ elif [[ $1 == "dev-testnet" ]]; then
 elif [[ $1 == "sepolia-testnet" ]]; then
   lb=sepolia-testnet-loadbalancer
   pool=sepolia-testnet-backend-pool
+elif [[ $1 == "mainnet" ]]; then
+  lb=mainnet-loadbalancer
+  pool=mainnet-backend-pool
 else
-  echo "Invalid argument. Use 'uat-testnet', 'dev-testnet', or 'sepolia-testnet'"
+  echo "Invalid argument. Use 'uat-testnet', 'dev-testnet', 'sepolia-testnet', or 'mainnet'"
   exit 1
 fi
 


### PR DESCRIPTION
### Why this change is needed

We previously just supported dev-, uat- and sepolia-testnet but now we also want to support mainnet (and require confirmation for mainnet actions).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


