### PR TITLE
Deploy: fix typo in k8s GH action script

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -69,7 +69,8 @@ jobs:
                 else
                   # strip the -testnet suffix from testnet environments
                   short_name=${TESTNET_TYPE%-testnet}
-                fi               echo "TESTNET_SHORT_NAME=$short_name" >> $GITHUB_OUTPUT
+                fi
+                echo "TESTNET_SHORT_NAME=$short_name" >> $GITHUB_OUTPUT
 
          # checkout *this* repo (so subsequent steps can still see it)
          -  uses: actions/checkout@v4


### PR DESCRIPTION
### Why this change is needed

Fix `line 7: syntax error near unexpected token `echo'` errors in k8s after deployment (L2 deployment) script runs.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


