### PR TITLE
Tenscan FE fixes

### DIFF
--- a/tools/tenscan/frontend/api/batches.ts
+++ b/tools/tenscan/frontend/api/batches.ts
@@ -56,3 +56,12 @@ export const fetchBatchTransactions = async (
     searchParams: options,
   });
 };
+
+export const fetchBatchBySequence = async (
+  sequence: string
+): Promise<ResponseDataInterface<Batch>> => {
+  return await httpRequest<ResponseDataInterface<Batch>>({
+    method: "get",
+    url: pathToUrl(apiRoutes.getBatchBySequence, { seq: sequence }),
+  });
+};

--- a/tools/tenscan/frontend/pages/batch/sequence/[sequence].tsx
+++ b/tools/tenscan/frontend/pages/batch/sequence/[sequence].tsx
@@ -1,4 +1,4 @@
-import { fetchBatchByHeight } from "@/api/batches";
+import { fetchBatchBySequence } from "@/api/batches";
 import Layout from "@/src/components/layouts/default-layout";
 import { BatchDetailsComponent } from "@/src/components/modules/batches/batch-details";
 import LoadingState from "@repo/ui/components/common/loading-state";
@@ -12,13 +12,14 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
-export default function Batch() {
+export default function BatchSequenceDetails() {
   const router = useRouter();
-  const { height } = router.query;
+  const { sequence } = router.query;
 
   const { data, isLoading } = useQuery({
-    queryKey: ["batchHeight", height],
-    queryFn: () => fetchBatchByHeight(height as string),
+    queryKey: ["batchSequenceDetails", sequence],
+    queryFn: () => fetchBatchBySequence(sequence as string),
+    enabled: !!sequence,
   });
 
   const batchDetails = data?.item;
@@ -30,9 +31,9 @@ export default function Batch() {
       ) : batchDetails ? (
         <Card className="col-span-3">
           <CardHeader>
-            <CardTitle>Batch #{Number(batchDetails?.header?.number)}</CardTitle>
+            <CardTitle>Batch #{Number(sequence)}</CardTitle>
             <CardDescription>
-              Overview of the batch #{Number(batchDetails?.header?.number)}
+              Overview of the Batch with sequence #{Number(sequence)}
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/tools/tenscan/frontend/src/components/main-nav.tsx
+++ b/tools/tenscan/frontend/src/components/main-nav.tsx
@@ -46,8 +46,13 @@ const NavItem = ({ navLink }: { navLink: NavLink }) => {
           <DropdownMenuGroup>
             {navLink.subNavLinks &&
               navLink.subNavLinks.map((subNavLink: NavLink) => (
-                <DropdownMenuItem key={subNavLink.label}>
-                  <NavItem navLink={subNavLink} />
+                <DropdownMenuItem key={subNavLink.label} asChild>
+                  <Link
+                    href={subNavLink.href || ""}
+                    className="text-sm font-medium transition-colors hover:text-primary w-full"
+                  >
+                    {subNavLink.label}
+                  </Link>
                 </DropdownMenuItem>
               ))}
           </DropdownMenuGroup>

--- a/tools/tenscan/frontend/src/components/modules/batches/batch-details.tsx
+++ b/tools/tenscan/frontend/src/components/modules/batches/batch-details.tsx
@@ -28,7 +28,7 @@ import {
 import { pageLinks } from "@/src/routes";
 import { pathToUrl } from "@/src/routes/router";
 
-export function BatchHeightDetailsComponent({
+export function BatchDetailsComponent({
   batchDetails,
 }: {
   batchDetails: Batch;
@@ -39,7 +39,7 @@ export function BatchHeightDetailsComponent({
     <div className="space-y-8">
       <KeyValueList>
         <KeyValueItem
-          label="Batch Height"
+          label="Height"
           value={"#" + Number(batchDetails?.height)}
         />
         <KeyValueItem
@@ -166,9 +166,9 @@ export function BatchHeightDetailsComponent({
         <KeyValueItem
           label="No. of Transactions"
           value={
-            batchDetails?.txHashes.length > 0 ? (
+            batchDetails?.txHashes && batchDetails.txHashes.length > 0 ? (
               <span>
-                {batchDetails?.txHashes.length}{" "}
+                {batchDetails.txHashes.length}{" "}
                 <Link
                   href={pathToUrl(pageLinks.batchTransactions, {
                     hash: batchDetails?.header?.hash,
@@ -179,7 +179,7 @@ export function BatchHeightDetailsComponent({
                 </Link>
               </span>
             ) : (
-              batchDetails?.txHashes.length || "-"
+              "0"
             )
           }
           isLastItem

--- a/tools/tenscan/frontend/src/components/modules/batches/batch-hash-details.tsx
+++ b/tools/tenscan/frontend/src/components/modules/batches/batch-hash-details.tsx
@@ -66,7 +66,7 @@ export function BatchHashDetailsComponent({
     <div className="space-y-8">
       <KeyValueList>
         <KeyValueItem
-          label="Batch Height"
+          label="Height"
           value={
             <Link
               href={pathToUrl(pageLinks.batchByHeight, {
@@ -75,6 +75,19 @@ export function BatchHashDetailsComponent({
               className="text-primary"
             >
               {"#" + Number(batchDetails?.header?.number)}
+            </Link>
+          }
+        />
+        <KeyValueItem
+          label="Sequence"
+          value={
+            <Link
+              href={pathToUrl(pageLinks.batchBySequence, {
+                sequence: +batchDetails?.header?.sequencerOrderNo,
+              })}
+              className="text-primary"
+            >
+              {"#" + Number(batchDetails?.header?.sequencerOrderNo.toString())}
             </Link>
           }
         />
@@ -249,5 +262,5 @@ export function BatchHashDetailsComponent({
         />
       </KeyValueList>
     </div>
-  );
+  )
 }

--- a/tools/tenscan/frontend/src/components/modules/batches/columns.tsx
+++ b/tools/tenscan/frontend/src/components/modules/batches/columns.tsx
@@ -130,14 +130,14 @@ export const columns: ColumnDef<Batch>[] = [
     cell: ({ row }) => {
       return (
         <Link
-          href={pathToUrl(pageLinks.rollupByBatchSequence, {
+          href={pathToUrl(pageLinks.batchBySequence, {
             sequence: row.original.sequence,
           })}
           className="text-primary"
         >
           {row.original.sequence}
         </Link>
-      );
+      )
     },
     enableSorting: false,
     enableHiding: false,
@@ -148,18 +148,18 @@ export const columns: ColumnDef<Batch>[] = [
       <DataTableColumnHeader column={column} title="Tx Count" />
     ),
     cell: ({ row }) => {
-      return row.original.txCount > 0 ? (
+      return row.original.txHashes.length > 0 ? (
         <Link
           href={pathToUrl(pageLinks.batchTransactions, {
             hash: row.original.fullHash,
           })}
           className="text-primary"
         >
-          {row.original.txCount}
+          {row.original.txHashes.length}
         </Link>
       ) : (
-        <span>{row.original.txCount}</span>
-      );
+        <span>{row.original.txHashes.length}</span>
+      )
     },
     enableSorting: false,
     enableHiding: false,

--- a/tools/tenscan/frontend/src/components/modules/rollups/rollup-details.tsx
+++ b/tools/tenscan/frontend/src/components/modules/rollups/rollup-details.tsx
@@ -29,24 +29,12 @@ export function RollupDetailsComponent({
           }
         />
         <KeyValueItem
-          label="Full Hash"
+          label="Hash"
           value={
             <TruncatedAddress
               address={rollupDetails?.Hash}
               link={pathToUrl(pageLinks.rollupByHash, {
                 hash: rollupDetails?.Hash,
-              })}
-              showFullLength
-            />
-          }
-        />
-        <KeyValueItem
-          label="Rollup Header Hash"
-          value={
-            <TruncatedAddress
-              address={rollupDetails?.Header?.hash}
-              link={pathToUrl(pageLinks.rollupByHash, {
-                hash: rollupDetails?.Header?.hash,
               })}
               showFullLength
             />
@@ -59,10 +47,10 @@ export function RollupDetailsComponent({
           }
         />
         <KeyValueItem
-          label="First Batch Seq No."
+          label="First Batch Sequence Number"
           value={
             <Link
-              href={pathToUrl(pageLinks.rollupByBatchSequence, {
+              href={pathToUrl(pageLinks.batchBySequence, {
                 sequence: rollupDetails?.FirstSeq,
               })}
               className="text-primary"
@@ -72,10 +60,10 @@ export function RollupDetailsComponent({
           }
         />
         <KeyValueItem
-          label="Last Batch Seq No."
+          label="Last Batch Sequence Number"
           value={
             <Link
-              href={pathToUrl(pageLinks.rollupByBatchSequence, {
+              href={pathToUrl(pageLinks.batchBySequence, {
                 sequence: rollupDetails?.LastSeq,
               })}
               className="text-primary"
@@ -150,5 +138,5 @@ export function RollupDetailsComponent({
         />
       </KeyValueList>
     </div>
-  );
+  )
 }

--- a/tools/tenscan/frontend/src/components/modules/transactions/columns.tsx
+++ b/tools/tenscan/frontend/src/components/modules/transactions/columns.tsx
@@ -22,12 +22,12 @@ export const columns: ColumnDef<Transaction>[] = [
     ),
     cell: ({ row }) => {
       return (
-          <ClickableLink
-              label={row.getValue("BatchHeight")}
-              link={pathToUrl(pageLinks.batchByHeight, {
-                  hash: row.original.TransactionHash,
-              })}
-          />
+                  <ClickableLink
+            label={row.getValue("BatchHeight")}
+            link={pathToUrl(pageLinks.batchByHeight, {
+                height: row.getValue("BatchHeight"),
+            })}
+        />
       );
     },
     filterFn: (row, id, value) => {


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/5023

### What changes were made as part of this PR

* Used common batch details component for both get batch by height and get batch by sequence 
* In the rollups page when you click the batch number it now navigates to the batch details instead of just showing the same rollup 
* 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


