### PR TITLE
Ziga/gw backend http cookie

### DIFF
--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -17,6 +17,7 @@ const (
 const (
 	PathReady                     = "/ready/"
 	PathJoin                      = "/join/"
+	PathToken                     = "/token/"
 	PathGetMessage                = "/getmessage/"
 	PathAuthenticate              = "/authenticate/"
 	PathQuery                     = "/query/"

--- a/tools/walletextension/common/constants.go
+++ b/tools/walletextension/common/constants.go
@@ -17,7 +17,8 @@ const (
 const (
 	PathReady                     = "/ready/"
 	PathJoin                      = "/join/"
-	PathToken                     = "/token/"
+	PathGetToken                  = "/get-token/"
+	PathSetToken                  = "/set-token/"
 	PathGetMessage                = "/getmessage/"
 	PathAuthenticate              = "/authenticate/"
 	PathQuery                     = "/query/"

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -188,11 +188,20 @@ func getTokenRequestHandler(walletExt *services.Services, conn UserConn) {
 		return
 	}
 
-	// Convert hex string back to bytes for validation
-	userIDBytes := hexutils.HexToBytes(userID)
+	// Validate the token format (should be hex)
+	userIDBytes, err := hex.DecodeString(userID)
+	if err != nil {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid token format: %w", err))
+		return
+	}
+
+	if len(userIDBytes) == 0 {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("token cannot be empty"))
+		return
+	}
 
 	// Verify the user exists in the database
-	_, err := walletExt.Storage.GetUser(userIDBytes)
+	_, err = walletExt.Storage.GetUser(userIDBytes)
 	if err != nil {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("user not found in database"))
 		return
@@ -232,9 +241,14 @@ func setTokenRequestHandler(walletExt *services.Services, conn UserConn) {
 	}
 
 	// Validate the token format (should be hex)
-	userIDBytes := hexutils.HexToBytes(req.Token)
+	userIDBytes, err := hex.DecodeString(req.Token)
+	if err != nil {
+		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid token format: %w", err))
+		return
+	}
+
 	if len(userIDBytes) == 0 {
-		handleError(conn, walletExt.Logger(), fmt.Errorf("invalid token format"))
+		handleError(conn, walletExt.Logger(), fmt.Errorf("token cannot be empty"))
 		return
 	}
 

--- a/tools/walletextension/httpapi/user_conn.go
+++ b/tools/walletextension/httpapi/user_conn.go
@@ -14,6 +14,7 @@ type UserConn interface {
 	ReadRequest() ([]byte, error)
 	ReadRequestParams() map[string]string
 	WriteResponse(msg []byte) error
+	SetCookie(cookie *http.Cookie) error
 	SupportsSubscriptions() bool
 	IsClosed() bool
 	GetHTTPRequest() *http.Request
@@ -60,6 +61,11 @@ func (h *userConnHTTP) ReadRequestParams() map[string]string {
 
 func (h *userConnHTTP) GetHTTPRequest() *http.Request {
 	return h.req
+}
+
+func (h *userConnHTTP) SetCookie(cookie *http.Cookie) error {
+	http.SetCookie(h.resp, cookie)
+	return nil
 }
 
 func getQueryParams(query url.Values) map[string]string {


### PR DESCRIPTION
### Why this change is needed

Currently we store `userID` in localStorage which vulnerable to xss attacks and and javascript can access the session keys.
There are also some issues with the localStorage after we redeploy the networks etc. and it needs to be replaced:

https://github.com/ten-protocol/ten-internal/pull/5439

### What changes were made as part of this PR

- secure cookie support to the UserConn interface with a new SetCookie method
- /join endpoint to automatically set a secure gateway_token cookie when creating new users
- /get-token endpoint to retrieve the current session token from the cookie
- /set-token endpoint for manual token imports and session restoration



We can test that in the command line:
```
# Create user + set cookie
curl -c cookies.txt -X POST http://127.0.0.1:3000/v1/join/

# Get current token
curl -b cookies.txt -X GET http://127.0.0.1:3000/v1/get-token/

# Set token manually
curl -c cookies.txt -X POST http://127.0.0.1:3000/v1/set-token/ -H "Content-Type: application/json" -d '{"token": "YOUR_TOKEN"}'

# Get current token
curl -b cookies.txt -X GET http://127.0.0.1:3000/v1/get-token/

# Test error handling (won't crash)
curl -X POST http://127.0.0.1:3000/v1/set-token/ -H "Content-Type: application/json" -d '{"token": "INVALID"}'
```

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


