### PR TITLE
Check for registered postgres driver

### DIFF
--- a/go/host/storage/init/postgres/postgres.go
+++ b/go/host/storage/init/postgres/postgres.go
@@ -85,6 +85,15 @@ func CreatePostgresDBConnection(baseURL string, dbName string, logger gethlog.Lo
 func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 	// we need the actual driver name so sqlx can replace queries with the correct placeholder
 	driverName := "postgres"
+	// check if driver is already registered
+	drivers := sql.Drivers()
+	for _, driver := range drivers {
+		if driver == driverName {
+			logger.Info("PostgreSQL driver already registered, skipping")
+			return driverName
+		}
+	}
+	// register if it not already present
 	sql.Register(driverName,
 		storage.NewPanicOnDBErrorDriver(
 			&pq.Driver{},


### PR DESCRIPTION
### Why this change is needed

`panic: sql: Register called twice for driver postgres` error on dev

### What changes were made as part of this PR

* Check for presence of postgres driver before attempting to register, do nothing if already registered

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


