### PR TITLE
Ziga/improve gw build gh workflow

### DIFF
--- a/.github/workflows/build-gateway-images.yml
+++ b/.github/workflows/build-gateway-images.yml
@@ -41,7 +41,6 @@ on:
           Tenscan URL for frontend build
           Examples by environment:
           • Dev: https://dev-testnet-tenscan.io
-
           • UAT: https://uat-testnet-tenscan.io
           • Sepolia: https://tenscan.io
         required: false


### PR DESCRIPTION
### Why this change is needed

Gateway frontend requires 3 build time parameters, previously we had to create separate branches & change the values and then build the images.
Now we can set them when we trigger the action as seen on image below.

<img width="321" height="667" alt="image" src="https://github.com/user-attachments/assets/766e7bfa-d930-4cb8-aa91-2fa0b64cd9ce" />


### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


