### PR TITLE
Temporarily bump l1 deployer timeout

### DIFF
--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -76,7 +76,8 @@ func (n *ContractDeployer) RetrieveL1ContractAddresses() (*node.NetworkConfig, e
 	defer cli.Close()
 
 	// make sure the container has finished execution (10 minutes allows time for L1 transactions to be mined)
-	err = docker.WaitForContainerToFinish(n.containerID, 10*time.Minute)
+	// FIXME temporarily bump to 20 to see if the node is slow 
+	err = docker.WaitForContainerToFinish(n.containerID, 20*time.Minute)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Why this change is needed

Need to see if the node is running slow

### What changes were made as part of this PR

* Timeout increased from 10m to 20m temporarily

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


