### PR TITLE
L1 deploy: set useGateway false to avoid triggering TEN plugin

### DIFF
--- a/testnet/launcher/directupgrade/docker.go
+++ b/testnet/launcher/directupgrade/docker.go
@@ -41,6 +41,7 @@ func (s *DirectUpgrade) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,
 				"accounts": ["%s"]

--- a/testnet/launcher/fundsrecovery/docker.go
+++ b/testnet/launcher/fundsrecovery/docker.go
@@ -38,6 +38,7 @@ func (n *FundsRecovery) Start() error {
 {
         "layer1" : {
             "url" : "%s",
+            "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
             "deploy": [ 

--- a/testnet/launcher/l1challengeperiod/docker.go
+++ b/testnet/launcher/l1challengeperiod/docker.go
@@ -40,6 +40,7 @@ func (s *SetChallengePeriod) Start() error {
 		"NETWORK_JSON": fmt.Sprintf(`{ 
             "layer1": {
                 "url": "%s",
+                "useGateway": false,
                 "live": false,
                 "saveDeployments": true,
                 "accounts": [ "%s" ]

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -49,6 +49,7 @@ func (n *ContractDeployer) Start() error {
 { 
         "layer1" : {
             "url" : "%s",
+            "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
             "deploy": [ 

--- a/testnet/launcher/l1grantsequencers/docker.go
+++ b/testnet/launcher/l1grantsequencers/docker.go
@@ -52,6 +52,7 @@ func (s *GrantSequencers) Start() error {
 		"NETWORK_JSON": fmt.Sprintf(`{ 
             "layer1": {
                 "url": "%s",
+                "useGateway": false,
                 "live": false,
                 "saveDeployments": true,
                 "accounts": [ "%s" ]

--- a/testnet/launcher/l1upgrade/docker.go
+++ b/testnet/launcher/l1upgrade/docker.go
@@ -41,6 +41,7 @@ func (s *UpgradeContracts) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,
 				"accounts": ["%s"]

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -51,6 +51,7 @@ func (n *ContractDeployer) Start() error {
 {
         "layer1" : {
             "url" : "%s",
+            "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
             "deploy": [ 

--- a/testnet/launcher/multisigsetup/docker.go
+++ b/testnet/launcher/multisigsetup/docker.go
@@ -41,6 +41,7 @@ func (s *MultisigSetup) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,
 				"accounts": ["%s"]


### PR DESCRIPTION
### Why this change is needed

Some of our L1 nodes have a URL format that triggers the TEN plugin URL matcher, causing it to try to authenticate against the L1 node as if it was a gateway.

### What changes were made as part of this PR

Set `useGateway: false` for all L1 network deployments.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


