### PR TITLE
Fix visibility config crash

### DIFF
--- a/go/enclave/evm/visibility_reader.go
+++ b/go/enclave/evm/visibility_reader.go
@@ -64,7 +64,12 @@ func (v *contractVisibilityReader) readVisibilityConfig(evm *vm.EVM, contractAdd
 	// only check the config for non-transparent contracts
 	for i := range visibilityRules.EventLogConfigs {
 		logConfig := visibilityRules.EventLogConfigs[i]
-		cfg.EventConfigs[logConfig.EventSignature] = eventCfg(logConfig)
+		eventConfig := eventCfg(logConfig)
+		valErr := eventConfig.Validate()
+		if valErr == nil {
+			// ignore invalid configs
+			cfg.EventConfigs[logConfig.EventSignature] = eventConfig
+		}
 	}
 
 	return cfg, nil


### PR DESCRIPTION
### Why this change is needed

An invalid visib config can crash the network

### What changes were made as part of this PR

Ignore invalid configs

