### PR TITLE
L1 deploys: 1.2 mult on gas price

### DIFF
--- a/testnet/launcher/directupgrade/docker.go
+++ b/testnet/launcher/directupgrade/docker.go
@@ -41,6 +41,7 @@ func (s *DirectUpgrade) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,

--- a/testnet/launcher/fundsrecovery/docker.go
+++ b/testnet/launcher/fundsrecovery/docker.go
@@ -38,6 +38,7 @@ func (n *FundsRecovery) Start() error {
 {
         "layer1" : {
             "url" : "%s",
+            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,

--- a/testnet/launcher/l1challengeperiod/docker.go
+++ b/testnet/launcher/l1challengeperiod/docker.go
@@ -40,6 +40,7 @@ func (s *SetChallengePeriod) Start() error {
 		"NETWORK_JSON": fmt.Sprintf(`{ 
             "layer1": {
                 "url": "%s",
+                "gasMultiplier": 1.2,
                 "useGateway": false,
                 "live": false,
                 "saveDeployments": true,

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -49,6 +49,7 @@ func (n *ContractDeployer) Start() error {
 { 
         "layer1" : {
             "url" : "%s",
+            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,

--- a/testnet/launcher/l1grantsequencers/docker.go
+++ b/testnet/launcher/l1grantsequencers/docker.go
@@ -52,6 +52,7 @@ func (s *GrantSequencers) Start() error {
 		"NETWORK_JSON": fmt.Sprintf(`{ 
             "layer1": {
                 "url": "%s",
+                "gasMultiplier": 1.2,
                 "useGateway": false,
                 "live": false,
                 "saveDeployments": true,

--- a/testnet/launcher/l1upgrade/docker.go
+++ b/testnet/launcher/l1upgrade/docker.go
@@ -41,6 +41,7 @@ func (s *UpgradeContracts) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -51,6 +51,7 @@ func (n *ContractDeployer) Start() error {
 {
         "layer1" : {
             "url" : "%s",
+            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,

--- a/testnet/launcher/multisigsetup/docker.go
+++ b/testnet/launcher/multisigsetup/docker.go
@@ -41,6 +41,7 @@ func (s *MultisigSetup) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
+				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,


### PR DESCRIPTION
### Why this change is needed

20% gas multiplier should help prevent transactions from getting stuck in the mempool during Sepolia congestion by providing a buffer above the estimated gas price. This should significantly improve deployment reliability during high network activity periods.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


