### PR TITLE
Clean GH runner workflow

### DIFF
--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -1,0 +1,35 @@
+name: '[S] Clean gh-runner-01'
+run-name: Cleaning runner 01 (${{ github.event_name }})
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'  #2 hours
+  workflow_dispatch:
+
+jobs:
+  clean-ten-persistence:
+    runs-on: [self-hosted, Linux, X64, ten-gh-runner-01]
+    steps:
+      - name: 'Clean /tmp/ten-persistence (keep newest only)'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET="/tmp/ten-persistence"
+          [[ -d "$TARGET" ]] || exit 0
+
+          cd "$TARGET"
+
+          # List immediate subdirs newest→oldest; keep the first, delete the rest.
+          # If 0–1 dirs exist, nothing happens.
+          mapfile -t SORTED < <(ls -1t -d */ 2>/dev/null || true)
+          if (( ${#SORTED[@]} <= 1 )); then
+            echo "Nothing to delete (found ${#SORTED[@]} dir(s))."
+            exit 0
+          fi
+
+          TO_DELETE=("${SORTED[@]:1}")
+          echo "Keeping newest: ${SORTED[0]}"
+          echo "Deleting ${#TO_DELETE[@]} older dir(s):"
+          printf ' - %s\n' "${TO_DELETE[@]}"
+
+          sudo rm -rf -- "${TO_DELETE[@]}"


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/5534

### What changes were made as part of this PR

New script which runs every 2 hours. It clears everything in the `/tmp/ten-persistence/` directory except the most recently added dir which should prevent any in-progress runs. 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


