### PR TITLE
Fix L2Head > L2HeadHash

### DIFF
--- a/go/host/rpc/enclaverpc/enclave_client.go
+++ b/go/host/rpc/enclaverpc/enclave_client.go
@@ -116,7 +116,7 @@ func (c *Client) Status(ctx context.Context) (common.Status, common.SystemError)
 		StatusCode:        common.StatusCode(response.StatusCode),
 		L1Head:            gethcommon.BytesToHash(response.L1Head),
 		L2Head:            big.NewInt(0).SetBytes(response.L2Head),
-		L2HeadHash:        gethcommon.BytesToHash(response.L2Head),
+		L2HeadHash:        gethcommon.BytesToHash(response.L2HeadHash),
 		EnclaveID:         common.EnclaveID(response.EnclaveID),
 		IsActiveSequencer: response.IsActiveSequencer,
 	}, nil


### PR DESCRIPTION
### Why this change is needed

Copy pasta error

### What changes were made as part of this PR

* Set the enclave status l2 hash to the l2 head hash response

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


