### PR TITLE
add createdAt to the sessionKey

### DIFF
--- a/tools/walletextension/common/types.go
+++ b/tools/walletextension/common/types.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ten-protocol/go-ten/go/common/viewingkey"
 	"golang.org/x/exp/maps"
@@ -17,6 +19,7 @@ const (
 type GWSessionKey struct {
 	Account    *GWAccount
 	PrivateKey *ecies.PrivateKey // the private key corresponding to the account
+	CreatedAt  time.Time         // timestamp when the session key was created
 }
 
 type GWAccount struct {

--- a/tools/walletextension/services/sk_manager.go
+++ b/tools/walletextension/services/sk_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -113,6 +114,7 @@ func (m *skManager) createSK(user *common.GWUser) (*common.GWSessionKey, error) 
 			Signature:     sig,
 			SignatureType: viewingkey.EIP712Signature,
 		},
+		CreatedAt: time.Now(),
 	}, nil
 }
 

--- a/tools/walletextension/storage/database/common/db_types.go
+++ b/tools/walletextension/storage/database/common/db_types.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -31,6 +32,7 @@ type GWAccountDB struct {
 type GWSessionKeyDB struct {
 	PrivateKey []byte      `json:"privateKey"`
 	Account    GWAccountDB `json:"account"`
+	CreatedAt  time.Time   `json:"createdAt"`
 }
 
 func (userDB *GWUserDB) ToGWUser() (*wecommon.GWUser, error) {
@@ -70,6 +72,7 @@ func (userDB *GWUserDB) ToGWUser() (*wecommon.GWUser, error) {
 				SignatureType: viewingkey.SignatureType(acc.SignatureType),
 			},
 			PrivateKey: eciesPrivateKey,
+			CreatedAt:  sessionKeyDB.CreatedAt,
 		}
 	}
 

--- a/tools/walletextension/storage/database/cosmosdb/cosmosdb.go
+++ b/tools/walletextension/storage/database/cosmosdb/cosmosdb.go
@@ -153,6 +153,7 @@ func (c *CosmosDB) AddSessionKey(userID []byte, key wecommon.GWSessionKey) error
 				Signature:      key.Account.Signature,
 				SignatureType:  int(key.Account.SignatureType),
 			},
+			CreatedAt: key.CreatedAt,
 		}
 		return nil
 	})

--- a/tools/walletextension/storage/database/sqlite/sqlite.go
+++ b/tools/walletextension/storage/database/sqlite/sqlite.go
@@ -162,6 +162,7 @@ func (s *SqliteDB) AddSessionKey(userID []byte, key wecommon.GWSessionKey) error
 				Signature:      key.Account.Signature,
 				SignatureType:  int(key.Account.SignatureType),
 			},
+			CreatedAt: key.CreatedAt,
 		}
 		return s.updateUser(dbTx, user)
 	})


### PR DESCRIPTION
### Why this change is needed

In the future we will add expiration to the sessionKeys. It will be much easier to update it, if we already have createdAt field in the database.

### What changes were made as part of this PR

Added CreatedAt to each session key.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


