### PR TITLE
Ziga/change key exchange url default

### DIFF
--- a/tools/walletextension/keymanager/keymanager.go
+++ b/tools/walletextension/keymanager/keymanager.go
@@ -44,10 +44,11 @@ type KeyExchangeResponse struct {
 
 // GetEncryptionKey returns the encryption key for the database
 // - If we use an SQLite database, no encryption key is needed as SQLite typically runs in development or testing environments.
-// - If no encryptionKeySource is provided, attempt to unseal an existing encryption key.
-// - If the encryptionKeySource is set to "new", check for an existing encryption key and generate a new one if not found.
-// - If an encryptionKeySource is a URL, first try to unseal an existing encryption key, and only perform key exchange if unsealing fails.
-// - If a new key is generated or obtained, seal it for future use (existing key will be backed up with timestamp).
+// - First try to unseal the existing key if there is one
+//
+// - If no existing key is available, we look at `encryptionKeySource`, if it is `new` we generate a new one, if it is a URL we attempt to perform key exchange
+//
+// - Finally, we seal the key (and if there was an existing key file that could not be unsealed, we store it as a backup)
 func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, error) {
 	// check if we are using sqlite database and no encryption key needed
 	if config.DBType == "sqlite" {
@@ -55,58 +56,43 @@ func GetEncryptionKey(config common.Config, logger gethlog.Logger) ([]byte, erro
 		return nil, nil
 	}
 
-	// If no encryptionKeySource is provided, attempt to unseal an existing encryption key and fail if no key is found
-	// (in this case operator needs to provide a source for the encryption key or decide to generate a new one)
-	if config.EncryptionKeySource == "" {
-		logger.Info("no key exchange url set, try to unseal existing encryption key")
-		encryptionKey, found, err := tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
-		if !found {
-			logger.Crit("no sealed encryption key found", log.ErrKey, err)
-			return nil, fmt.Errorf("no sealed encryption key found: %w", err)
-		}
-		logger.Info("unsealed existing encryption key")
+	// First try to unseal an existing encryption key before attempting key exchange
+	var encryptionKey []byte
+	var found bool
+	var err error
+
+	encryptionKey, found, err = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
+	if err != nil {
+		logger.Warn("failed to unseal existing encryption key", "error", err)
+	}
+
+	if found {
+		logger.Info("successfully unsealed existing encryption key")
 		return encryptionKey, nil
 	}
 
-	var encryptionKey []byte
-	var err error
+	// If no existing key is available, we look at `encryptionKeySource`
+	// If no encryptionKeySource is provided, fail since we couldn't unseal an existing key
+	if config.EncryptionKeySource == "" {
+		logger.Crit("no sealed encryption key found and no key source provided", log.ErrKey, err)
+		return nil, fmt.Errorf("no sealed encryption key found: %w", err)
+	}
 
-	// If the "new" keyword is used for the encryptionKeySource, we first check if there is an existing encryption key
-	// that can be unsealed and used. If no such key is found, we proceed to generate a new random encryption key.
-	// This ensures that we do not overwrite an existing key unless necessary, and a new key is only generated when
-	// there is no existing key available.
+	// If the "new" keyword is used for the encryptionKeySource, generate a new random encryption key
 	if config.EncryptionKeySource == "new" {
-		logger.Info("encryptionKeySource set to 'new' -> checking if there is an existing encryption key that we can use")
-		var found bool
-		encryptionKey, found, _ = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
-		logger.Info("Encryption key status", "found", found, "error", err)
-		if !found {
-			logger.Info("No existing encryption key found, generating new random encryption key")
-			encryptionKey, err = common.GenerateRandomKey()
-			if err != nil {
-				logger.Crit("unable to generate random encryption key", log.ErrKey, err)
-				return nil, err
-			}
+		logger.Info("encryptionKeySource set to 'new' -> generating new random encryption key")
+		encryptionKey, err = common.GenerateRandomKey()
+		if err != nil {
+			logger.Crit("unable to generate random encryption key", log.ErrKey, err)
+			return nil, err
 		}
 	} else {
-		// First try to unseal an existing encryption key before attempting key exchange
-		logger.Info(fmt.Sprintf("encryptionKeySource set to '%s', first trying to unseal existing encryption key", config.EncryptionKeySource))
-		var found bool
-		encryptionKey, found, err = tryUnsealKey(encryptionKeyFile, config.InsideEnclave)
+		// If encryptionKeySource is a URL, attempt to perform key exchange with the specified key provider
+		logger.Info(fmt.Sprintf("encryptionKeySource set to '%s', trying to get encryption key from key provider", config.EncryptionKeySource))
+		encryptionKey, err = HandleKeyExchange(config, logger)
 		if err != nil {
-			logger.Warn("failed to unseal existing encryption key", "error", err)
-		}
-		if found {
-			logger.Info("successfully unsealed existing encryption key")
-		} else {
-			// Attempt to perform key exchange with the specified key provider.
-			// This step is crucial, and the process should fail if the key exchange is not successful.
-			logger.Info(fmt.Sprintf("no existing encryption key found, trying to get encryption key from key provider at '%s'", config.EncryptionKeySource))
-			encryptionKey, err = HandleKeyExchange(config, logger)
-			if err != nil {
-				logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)
-				return nil, err
-			}
+			logger.Crit("unable to get encryption key from key provider", log.ErrKey, err)
+			return nil, err
 		}
 	}
 
@@ -180,7 +166,7 @@ func copyFile(src, dst string) error {
 
 // trySealKey attempts to seal an encryption key to disk
 // Only seals if running in an SGX enclave
-// If an existing key file exists, it will be backed up before overwriting
+// If an existing key file exists but failed to be unsealed, then it will be backed up before overwriting
 func trySealKey(key []byte, keyPath string, isEnclave bool, logger gethlog.Logger) error {
 	// Only attempt sealing if we're in an SGX enclave
 	if !isEnclave {


### PR DESCRIPTION
### Why this change is needed

With current implementation it can be easy to lose the encryption key if we are not careful.
With new changes we will keep old encryption keys in separate files and always use existing key before trying to replace them.
To generate a new key or do a key exchange and you already have existing encryption key you will need to delete/move it first.

### What changes were made as part of this PR

- trying to unseal the key before doing key exchange
- moving existing enc key to a new file before generating a new one (and overriding it)

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


