### PR TITLE
Remove sacred "failed" from logs

### DIFF
--- a/integration/tengateway/tengateway_test.go
+++ b/integration/tengateway/tengateway_test.go
@@ -410,7 +410,7 @@ func testSessionKeysSendTransaction(t *testing.T, _ int, httpURL, wsURL string, 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "session key address")
 	require.Contains(t, err.Error(), "not found")
-	t.Logf("✓ eth_sendTransaction correctly failed with non-session key address")
+	t.Logf("✓ eth_sendTransaction correctly rejected with non-session key address")
 
 	// 5) Delete the session key via getStorageAt (CQ 0x...0004)
 	delParamsObj := map[string]string{


### PR DESCRIPTION
### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

* test log had `fail` in it which flags when searching for failed tests

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


