### PR TITLE
Deploy: remove gas multiplier

### DIFF
--- a/testnet/launcher/directupgrade/docker.go
+++ b/testnet/launcher/directupgrade/docker.go
@@ -41,7 +41,6 @@ func (s *DirectUpgrade) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
-				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,

--- a/testnet/launcher/fundsrecovery/docker.go
+++ b/testnet/launcher/fundsrecovery/docker.go
@@ -38,14 +38,13 @@ func (n *FundsRecovery) Start() error {
 {
         "layer1" : {
             "url" : "%s",
-            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
-            "deploy": [ 
+            "deploy": [
                 "deployment_scripts/testnet/recoverfunds"
             ],
-            "accounts": [ 
+            "accounts": [
                 "%s"
             ]
         }

--- a/testnet/launcher/l1challengeperiod/docker.go
+++ b/testnet/launcher/l1challengeperiod/docker.go
@@ -37,10 +37,9 @@ func (s *SetChallengePeriod) Start() error {
 	}
 
 	envs := map[string]string{
-		"NETWORK_JSON": fmt.Sprintf(`{ 
+		"NETWORK_JSON": fmt.Sprintf(`{
             "layer1": {
                 "url": "%s",
-                "gasMultiplier": 1.2,
                 "useGateway": false,
                 "live": false,
                 "saveDeployments": true,

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -46,14 +46,13 @@ func (n *ContractDeployer) Start() error {
 		"SEQUENCER_HOST_ADDRESS": n.cfg.SequencerHostAddress,
 		"ETHERSCAN_API_KEY":      n.cfg.EtherscanAPIKey,
 		"NETWORK_JSON": fmt.Sprintf(`
-{ 
+{
         "layer1" : {
             "url" : "%s",
-            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
-            "deploy": [ 
+            "deploy": [
                 "deployment_scripts/core",
 				"deployment_scripts/testnet/layer1"
             ],

--- a/testnet/launcher/l1grantsequencers/docker.go
+++ b/testnet/launcher/l1grantsequencers/docker.go
@@ -49,10 +49,9 @@ func (s *GrantSequencers) Start() error {
 	}
 
 	envs := map[string]string{
-		"NETWORK_JSON": fmt.Sprintf(`{ 
+		"NETWORK_JSON": fmt.Sprintf(`{
             "layer1": {
                 "url": "%s",
-                "gasMultiplier": 1.2,
                 "useGateway": false,
                 "live": false,
                 "saveDeployments": true,

--- a/testnet/launcher/l1upgrade/docker.go
+++ b/testnet/launcher/l1upgrade/docker.go
@@ -41,7 +41,6 @@ func (s *UpgradeContracts) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
-				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,

--- a/testnet/launcher/l2contractdeployer/docker.go
+++ b/testnet/launcher/l2contractdeployer/docker.go
@@ -51,15 +51,14 @@ func (n *ContractDeployer) Start() error {
 {
         "layer1" : {
             "url" : "%s",
-            "gasMultiplier" : 1.2,
             "useGateway" : false,
             "live" : false,
             "saveDeployments" : true,
-            "deploy": [ 
+            "deploy": [
                 "deployment_scripts/core",
                 "deployment_scripts/testnet/layer1"
             ],
-            "accounts": [ 
+            "accounts": [
                 "%s"
             ]
         },
@@ -69,12 +68,12 @@ func (n *ContractDeployer) Start() error {
             "live" : false,
             "saveDeployments" : true,
             "companionNetworks" : { "layer1" : "layer1" },
-            "deploy": [ 
+            "deploy": [
 				"deployment_scripts/funding/layer1",
                 "deployment_scripts/bridge/",
                 "deployment_scripts/testnet/layer2/"
             ],
-            "accounts": [ 
+            "accounts": [
                 "%s"
             ]
         }

--- a/testnet/launcher/multisigsetup/docker.go
+++ b/testnet/launcher/multisigsetup/docker.go
@@ -41,7 +41,6 @@ func (s *MultisigSetup) Start() error {
 		{
 			"layer1": {
 				"url": "%s",
-				"gasMultiplier": 1.2,
 				"useGateway": false,
 				"live": false,
 				"saveDeployments": true,


### PR DESCRIPTION
### Why this change is needed

`gasMultiplier` doesn't work how I thought it did, was to do with gas limit rather than fee.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


