### PR TITLE
Broken documentation links in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,19 @@ curl -X POST 127.0.0.1:80  -H 'Content-Type: application/json' \
 
 ## Community 
 Development is discussed by the team and the community on [discord](https://discord.com/invite/tenprotocol)
+
+##Broken documentation links in README and docs
+## Description
+While reviewing the documentation, I noticed that some external links are broken or outdated.  
+For example:
+- The [EdglessDB link](https://github.com/edgelesssys/edgelessdb) no longer resolves correctly.  
+- A few other references point to resources that no longer exist.
+
+## Suggested Fix
+- Update the broken links to the correct ones.  
+- If resources are deprecated, replace them with archived or alternative docs.  
+
+## Environment
+Repo: go-ten  
+Branch: main  
+Date checked: September 6, 2025


### PR DESCRIPTION
## Description
While reviewing the documentation, I noticed that some external links are broken or outdated.   For example:
- The [EdglessDB link](https://github.com/edgelesssys/edgelessdb) no longer resolves correctly.  
- A few other references point to resources that no longer exist.

## Suggested Fix
- Update the broken links to the correct ones.  
- If resources are deprecated, replace them with archived or alternative docs.  

## Environment
Repo: go-ten  
Branch: main  
Date checked: September 6, 2025

### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


