### PR TITLE
Fix DB wrapper

### DIFF
--- a/go/common/storage/driver_wrapper.go
+++ b/go/common/storage/driver_wrapper.go
@@ -8,62 +8,212 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
-// PanicOnDBErrorDriver wraps an SQL driver and panics on unexpected errors
-type PanicOnDBErrorDriver struct {
-	driver.Driver
-	logger     gethlog.Logger
-	isCritical func(error) bool
-}
+// NewPanicOnDBErrorDriver returns either a wrapped DriverContext or a Driver that panics on database errors
+// When the database is not available, we prefer to fail instead of entering an inconsistency state.
+func NewPanicOnDBErrorDriver(d driver.Driver, logger gethlog.Logger, isCritical func(error) bool) driver.Driver {
+	driverContext, isDriverContext := d.(driver.DriverContext)
+	if isDriverContext {
+		return &panicOnDBErrorDriverContext{
+			driver:     driverContext,
+			logger:     logger,
+			isCritical: isCritical,
+		}
+	}
 
-// NewPanicOnDBErrorDriver is a constructor for PanicOnDBErrorDriver
-func NewPanicOnDBErrorDriver(driver driver.Driver, logger gethlog.Logger, isCritical func(error) bool) *PanicOnDBErrorDriver {
-	return &PanicOnDBErrorDriver{
-		Driver:     driver,
+	return &panicOnDBErrorDriver{
+		driver:     d,
 		logger:     logger,
 		isCritical: isCritical,
 	}
 }
 
-// Open implements the driver.Driver interface
-func (d *PanicOnDBErrorDriver) Open(dsn string) (driver.Conn, error) {
-	conn, err := d.Driver.Open(dsn)
-	if err != nil {
-		return nil, err
-	}
-	return &panicOnErrorConn{Conn: conn, logger: d.logger, isCritical: d.isCritical}, nil
-}
-
-// panicOnErrorConn wraps a driver.Conn and panics on connection refused errors
-type panicOnErrorConn struct {
-	driver.Conn
-	driver.ExecerContext
-	driver.QueryerContext
+// panicOnDBErrorDriver
+type panicOnDBErrorDriver struct {
+	driver     driver.Driver
 	logger     gethlog.Logger
 	isCritical func(error) bool
 }
 
-func (c *panicOnErrorConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	execer, ok := c.Conn.(driver.ExecerContext)
+func (d *panicOnDBErrorDriver) Open(dsn string) (driver.Conn, error) {
+	conn, err := d.driver.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &panicOnErrorConnection{conn: conn, logger: d.logger, isCritical: d.isCritical}, nil
+}
+
+// panicOnDBErrorDriverContext
+type panicOnDBErrorDriverContext struct {
+	driver     driver.DriverContext
+	logger     gethlog.Logger
+	isCritical func(error) bool
+}
+
+func (d *panicOnDBErrorDriverContext) OpenConnector(name string) (driver.Connector, error) {
+	connector, err := d.driver.OpenConnector(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &panicOnErrorConnector{
+		connector:  connector,
+		logger:     d.logger,
+		isCritical: d.isCritical,
+	}, nil
+}
+
+func (d *panicOnDBErrorDriverContext) Open(dsn string) (driver.Conn, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// panicOnErrorConnector
+type panicOnErrorConnector struct {
+	connector  driver.Connector
+	logger     gethlog.Logger
+	isCritical func(error) bool
+}
+
+func (conn *panicOnErrorConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	connection, err := conn.connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &panicOnErrorConnection{conn: connection, logger: conn.logger, isCritical: conn.isCritical}, nil
+}
+
+func (conn *panicOnErrorConnector) Driver() driver.Driver {
+	return &panicOnDBErrorDriverContext{
+		driver:     conn.connector.Driver().(driver.DriverContext),
+		logger:     conn.logger,
+		isCritical: conn.isCritical,
+	}
+}
+
+// panicOnErrorConnection wraps a driver.Conn and panics on connection refused errors
+type panicOnErrorConnection struct {
+	conn       driver.Conn
+	logger     gethlog.Logger
+	isCritical func(error) bool
+}
+
+func (c *panicOnErrorConnection) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	execer, ok := c.conn.(driver.ExecerContext)
 	if !ok {
-		return nil, driver.ErrSkip
+		return nil, fmt.Errorf("underlying connection does not implement ExecContext")
 	}
 
 	result, err := execer.ExecContext(ctx, query, args)
 	if err != nil && c.isCritical(err) {
-		c.logger.Crit(fmt.Sprintf("Database operation failed with connection refused: %v", err))
+		c.logger.Crit(fmt.Sprintf("Database operation failed with critical error: %v", err))
 	}
 	return result, err
 }
 
-func (c *panicOnErrorConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	queryer, ok := c.Conn.(driver.QueryerContext)
+func (c *panicOnErrorConnection) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	queryer, ok := c.conn.(driver.QueryerContext)
 	if !ok {
-		return nil, driver.ErrSkip
+		return nil, fmt.Errorf("underlying connection does not implement QueryContext")
 	}
 
 	rows, err := queryer.QueryContext(ctx, query, args)
 	if err != nil && c.isCritical(err) {
-		c.logger.Crit(fmt.Sprintf("Database query failed with connection refused: %v", err))
+		c.logger.Crit(fmt.Sprintf("Database query failed with critical error: %v", err))
 	}
 	return rows, err
 }
+
+func (c *panicOnErrorConnection) Exec(query string, args []driver.Value) (driver.Result, error) {
+	execer, ok := c.conn.(driver.Execer)
+	if !ok {
+		return nil, fmt.Errorf("underlying connection does not implement Exec")
+	}
+
+	result, err := execer.Exec(query, args)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database operation failed with critical error: %v", err))
+	}
+	return result, err
+}
+
+func (c *panicOnErrorConnection) Query(query string, args []driver.Value) (driver.Rows, error) {
+	queryer, ok := c.conn.(driver.Queryer)
+	if !ok {
+		return nil, fmt.Errorf("underlying connection does not implement Query")
+	}
+
+	rows, err := queryer.Query(query, args)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database query failed with critical error: %v", err))
+	}
+	return rows, err
+}
+
+func (c *panicOnErrorConnection) Ping(ctx context.Context) error {
+	pinger, ok := c.conn.(driver.Pinger)
+	if !ok {
+		return fmt.Errorf("underlying connection does not implement Pinger")
+	}
+
+	err := pinger.Ping(ctx)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database ping failed with critical error: %v", err))
+	}
+	return err
+}
+
+func (c *panicOnErrorConnection) Prepare(query string) (driver.Stmt, error) {
+	stmt, err := c.conn.Prepare(query)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database prepare failed with critical error: %v", err))
+	}
+	return stmt, err
+}
+
+func (c *panicOnErrorConnection) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	preparer, ok := c.conn.(driver.ConnPrepareContext)
+	if !ok {
+		return nil, fmt.Errorf("underlying connection does not implement ConnPrepareContext")
+	}
+
+	stmt, err := preparer.PrepareContext(ctx, query)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database prepare context failed with critical error: %v", err))
+	}
+	return stmt, err
+}
+
+func (c *panicOnErrorConnection) Begin() (driver.Tx, error) {
+	tx, err := c.conn.Begin()
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database begin transaction failed with critical error: %v", err))
+	}
+	return tx, err
+}
+
+func (c *panicOnErrorConnection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginner, ok := c.conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, fmt.Errorf("underlying connection does not implement ConnBeginTx")
+	}
+
+	tx, err := beginner.BeginTx(ctx, opts)
+	if err != nil && c.isCritical(err) {
+		c.logger.Crit(fmt.Sprintf("Database begin transaction context failed with critical error: %v", err))
+	}
+	return tx, err
+}
+
+func (c *panicOnErrorConnection) Close() error {
+	return c.conn.Close()
+}
+
+// ensure that panicOnErrorConnection implements all the required interfaces
+var (
+	_ driver.ExecerContext      = (*panicOnErrorConnection)(nil)
+	_ driver.QueryerContext     = (*panicOnErrorConnection)(nil)
+	_ driver.Execer             = (*panicOnErrorConnection)(nil)
+	_ driver.Queryer            = (*panicOnErrorConnection)(nil)
+	_ driver.Pinger             = (*panicOnErrorConnection)(nil)
+	_ driver.ConnPrepareContext = (*panicOnErrorConnection)(nil)
+	_ driver.ConnBeginTx        = (*panicOnErrorConnection)(nil)
+)

--- a/go/enclave/storage/init/sqlite/sqlite.go
+++ b/go/enclave/storage/init/sqlite/sqlite.go
@@ -1,11 +1,15 @@
 package sqlite
 
 import (
+	"database/sql"
 	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/mattn/go-sqlite3"
+	"github.com/ten-protocol/go-ten/go/common/storage"
 	"github.com/ten-protocol/go-ten/go/common/storage/migration"
 
 	"github.com/jmoiron/sqlx"
@@ -17,8 +21,6 @@ import (
 
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/go/common"
-
-	_ "github.com/mattn/go-sqlite3" // this imports the sqlite driver to make the sql.Open() connection work
 )
 
 const (
@@ -28,6 +30,12 @@ const (
 
 //go:embed *.sql
 var sqlFiles embed.FS
+
+var driverName string
+
+func init() {
+	driverName = registerPanicOnConnectionRefusedDriver(nil)
+}
 
 // CreateTemporarySQLiteDB if dbPath is empty will use a random throwaway temp file,
 // otherwise dbPath is a filepath for the sqldb file, allows for tests that care about persistence between restarts
@@ -61,7 +69,7 @@ func CreateTemporarySQLiteDB(dbPath string, dbOptions string, config *enclavecon
 
 	path := fmt.Sprintf("file:%s?mode=rw&%s", dbPath, dbOptions)
 	logger.Info("Connect to sqlite", "path", path)
-	rwdb, err := sqlx.Open("sqlite3", path)
+	rwdb, err := sqlx.Open(driverName, path)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
@@ -85,7 +93,7 @@ func CreateTemporarySQLiteDB(dbPath string, dbOptions string, config *enclavecon
 
 	roPath := fmt.Sprintf("file:%s?mode=ro&%s", dbPath, dbOptions)
 	logger.Info("Connect to sqlite", "ro_path", roPath)
-	rodb, err := sqlx.Open("sqlite3", roPath)
+	rodb, err := sqlx.Open(driverName, roPath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open sqlite db - %w", err)
 	}
@@ -123,4 +131,17 @@ func CreateTempDBFile() (string, error) {
 	}
 	tempFile := filepath.Join(tempDir, "enclave.db")
 	return tempFile, nil
+}
+
+func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
+	driverName := "sqlite3-panic-on-refused"
+	sql.Register(driverName,
+		storage.NewPanicOnDBErrorDriver(
+			&sqlite3.SQLiteDriver{},
+			logger,
+			func(err error) bool {
+				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "invalid connection")
+			}),
+	)
+	return driverName
 }


### PR DESCRIPTION
### Why this change is needed

To make the database wrapper more robust

### What changes were made as part of this PR

- implement `DriverContext`
- implement more interfaces for the connection wrapper
- use the wrapper for the sqlite testing

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


