### PR TITLE
Use unique chain IDs for each testnet

### DIFF
--- a/contracts/config/networks.json
+++ b/contracts/config/networks.json
@@ -10,7 +10,7 @@
       ]
     },
     "localObscuro": {
-      "chainId": 443,
+      "chainId": 5443,
       "url": "http://127.0.0.1:11180/v1/",
       "useGateway": true,
       "companionNetworks" : {
@@ -31,7 +31,7 @@
       ]
     },
     "testObscuro": {
-      "chainId": 443,
+      "chainId": 5443,
       "url": "http://127.0.0.1:11180/v1/",
       "useGateway": true,
       "companionNetworks" : {
@@ -75,7 +75,7 @@
       ]
     },
     "testUatObscuro": {
-      "chainId": 8443,
+      "chainId": 7443,
       "url": "https://uat-testnet.ten.xyz/v1/",
       "useGateway": true,
       "companionNetworks" : {
@@ -100,7 +100,7 @@
       ]
     },
     "testDevObscuro": {
-      "chainId": 443,
+      "chainId": 6443,
       "url": "https://dev-testnet.ten.xyz/v1/",
       "useGateway": true,
       "companionNetworks" : {
@@ -126,7 +126,7 @@
       ]
     },
     "localTestnetTen": {
-      "chainId": 443,
+      "chainId": 5443,
       "url": "http://127.0.0.1:3000/v1/",
       "useGateway": true,
       "companionNetworks" : {

--- a/packages/ui/lib/enums/network.ts
+++ b/packages/ui/lib/enums/network.ts
@@ -7,10 +7,11 @@ export enum L1Network {
 }
 
 export enum L2Network {
-  SEPOLIA = 443,
-  UAT = 443,
-  DEV = 443,
-  LOCAL = 443,
+  MAINNET = 443,
+  SEPOLIA = 8443,
+  UAT = 7443,
+  DEV = 6443,
+  LOCAL = 5443,
 }
 
 export enum TransactionStatus {

--- a/tools/bridge-frontend/src/types/index.ts
+++ b/tools/bridge-frontend/src/types/index.ts
@@ -138,10 +138,11 @@ export enum L1Network {
 }
 
 export enum L2Network {
-  SEPOLIA = 443,
-  UAT = 443,
-  DEV = 443,
-  LOCAL = 443,
+  MAINNET = 443,
+  SEPOLIA = 8443,
+  UAT = 7443,
+  DEV = 6443,
+  LOCAL = 5443,
 }
 
 export type Environment = "uat-testnet" | "sepolia-testnet" | "dev-testnet";


### PR DESCRIPTION
### Why this change is needed

We want to use the following values for testnets:

mainnet: 443
sepolia: 8443
uat: 7443
dev: 6443
local: 5443

To actually deploy a testnet with the desired chainID we need to configure the chainID in different places.
- argoCD
- github env variable

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


