### PR TITLE
pass chainID to the faucet in testnet launcher

### DIFF
--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -153,6 +153,7 @@ func (t *Testnet) Start() error {
 			faucet.WithTenNodeHost("validator-host"),
 			faucet.WithFaucetPrivKey("0x8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"),
 			faucet.WithDockerImage("testnetobscuronet.azurecr.io/obscuronet/faucet:latest"),
+			faucet.WithChainID(sequencerCfg.Network.ChainID),
 		),
 	)
 	if err != nil {

--- a/testnet/launcher/faucet/config.go
+++ b/testnet/launcher/faucet/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	faucetPort    int
 	faucetPrivKey string
 	dockerImage   string
+	chainID       int64
 }
 
 func NewFaucetConfig(opts ...Option) *Config {
@@ -49,5 +50,11 @@ func WithTenNodePort(i int) Option {
 func WithFaucetPort(i int) Option {
 	return func(c *Config) {
 		c.faucetPort = i
+	}
+}
+
+func WithChainID(chainID int64) Option {
+	return func(c *Config) {
+		c.chainID = chainID
 	}
 }

--- a/testnet/launcher/faucet/docker.go
+++ b/testnet/launcher/faucet/docker.go
@@ -30,6 +30,7 @@ func (n *DockerFaucet) Start() error {
 		"--pk", n.cfg.faucetPrivKey,
 		"--jwtSecret", "someKey",
 		"--serverPort", fmt.Sprintf("%d", n.cfg.faucetPort),
+		"--chainID", fmt.Sprintf("%d", n.cfg.chainID),
 	}
 
 	_, err := docker.StartNewContainer("faucet", n.cfg.dockerImage, cmds, []int{n.cfg.faucetPort}, nil, nil, nil, false)


### PR DESCRIPTION
### Why this change is needed

This change is needed if we want to run local testnet with a different chainID.

https://github.com/ten-protocol/ten-test/actions/runs/17676424741

### What changes were made as part of this PR

Please provide a high level list of the changes made

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


