### PR TITLE
increase db lock timeout

### DIFF
--- a/go/enclave/storage/init/sqlite/sqlite.go
+++ b/go/enclave/storage/init/sqlite/sqlite.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"embed"
 	"fmt"
 	"os"
@@ -141,6 +142,8 @@ func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 			logger,
 			func(err error) bool {
 				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "invalid connection")
+			},
+			func(conn driver.Conn) {
 			}),
 	)
 	return driverName

--- a/go/host/storage/init/postgres/postgres.go
+++ b/go/host/storage/init/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"embed"
 	"fmt"
 	"strings"
@@ -91,6 +92,8 @@ func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 			logger,
 			func(err error) bool {
 				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "shutting down")
+			},
+			func(conn driver.Conn) {
 			}),
 	)
 


### PR DESCRIPTION
### Why this change is needed

- The default lock timeout is 1 second, which is very short

### What changes were made as part of this PR

- Increase to 5 seconds. 
- Set as a session variable when the connection pool creates a new connection

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


