### PR TITLE
Network tests: configurable chain IDs per env

### DIFF
--- a/integration/networktest/actions/setup_actions.go
+++ b/integration/networktest/actions/setup_actions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ten-protocol/go-ten/integration"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/datagenerator"
 	"github.com/ten-protocol/go-ten/integration/networktest"
@@ -24,7 +23,7 @@ func (c *CreateTestUser) String() string {
 func (c *CreateTestUser) Run(ctx context.Context, network networktest.NetworkConnector) (context.Context, error) {
 	logger := testlog.Logger()
 
-	wal := datagenerator.RandomWallet(integration.TenChainID)
+	wal := datagenerator.RandomWallet(network.ChainID())
 	var user userwallet.User
 	if c.UseGateway {
 		gwURL, err := network.GetGatewayURL()

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ten-protocol/go-ten/integration/common"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
-	"github.com/ten-protocol/go-ten/integration"
 	"github.com/ten-protocol/go-ten/integration/common/testlog"
 	"github.com/ten-protocol/go-ten/integration/networktest"
 	"github.com/ten-protocol/go-ten/tools/walletextension"
@@ -27,6 +26,7 @@ func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		"wss://ethereum-sepolia-rpc.publicnode.com",
 		"https://testnet.ten.xyz",  //"https://rpc.dexynth-gateway.ten.xyz",
 		"wss://testnet.ten.xyz:81", // "wss://rpc.dexynth-gateway.ten.xyz:81",
+		8443,
 	)
 	return newTestnetEnv(connector, opts...)
 }
@@ -39,6 +39,7 @@ func UATTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		"wss://ethereum-sepolia-rpc.publicnode.com",
 		"https://rpc.uat-gw-testnet.ten.xyz",
 		"wss://rpc.uat-gw-testnet.ten.xyz:81",
+		7443,
 	)
 	return newTestnetEnv(connector, opts...)
 }
@@ -51,6 +52,7 @@ func DevTestnet(opts ...TestnetEnvOption) networktest.Environment {
 		"ws://dev-testnet-eth2network-522.uksouth.cloudapp.azure.com:9000",
 		"https://rpc.dev-gw-testnet.ten.xyz",
 		"wss://rpc.dev-gw-testnet.ten.xyz:81",
+		6443,
 	)
 	return newTestnetEnv(connector, opts...)
 }
@@ -112,7 +114,7 @@ func (t *testnetEnv) startTenGateway() {
 		LogPath:                 "sys_out",
 		LogLevel:                3, // info level
 		DBType:                  "sqlite",
-		TenChainID:              integration.TenChainID,
+		TenChainID:              t.testnetConnector.chainID,
 	}
 	tenGWContainer := walletextension.NewContainerFromConfig(cfg, t.logger)
 

--- a/integration/networktest/env/testnet.go
+++ b/integration/networktest/env/testnet.go
@@ -35,9 +35,10 @@ type testnetConnector struct {
 	tenGatewayURL         string
 	tenGatewayWSURL       string
 	faucetWallet          userwallet.User
+	chainID               int
 }
 
-func newTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string, l1WSURL string, tenGatewayURL string, tenGatewayWSURL string) *testnetConnector {
+func newTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, faucetHTTPAddress string, l1WSURL string, tenGatewayURL string, tenGatewayWSURL string, chainID int) *testnetConnector {
 	return &testnetConnector{
 		seqRPCAddress:         seqRPCAddr,
 		validatorRPCAddresses: validatorRPCAddressses,
@@ -45,6 +46,7 @@ func newTestnetConnector(seqRPCAddr string, validatorRPCAddressses []string, fau
 		l1RPCURL:              l1WSURL,
 		tenGatewayURL:         tenGatewayURL,
 		tenGatewayWSURL:       tenGatewayWSURL,
+		chainID:               chainID,
 	}
 }
 
@@ -60,11 +62,12 @@ func newTestnetConnectorWithFaucetAccount(seqRPCAddr string, validatorRPCAddress
 		faucetWallet:          userwallet.NewUserWallet(wal, validatorRPCAddressses[0], testlog.Logger()),
 		l1RPCURL:              l1RPCAddress,
 		tenGatewayURL:         tenGatewayURL,
+		chainID:               integration.TenChainID,
 	}
 }
 
 func (t *testnetConnector) ChainID() int64 {
-	return integration.TenChainID
+	return int64(t.chainID)
 }
 
 func (t *testnetConnector) AllocateFaucetFunds(ctx context.Context, account gethcommon.Address) error {


### PR DESCRIPTION
### Why this change is needed

Now we're using a different chain ID per env we need to make sure they are configurable in network tests.



### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


