### PR TITLE
add unique index on key

### DIFF
--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,0 +1,6 @@
+SET SESSION  rocksdb_max_row_locks = 10000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
+ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
+
+DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
+ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);


### PR DESCRIPTION
### Why this change is needed

To prevent duplicates from the statedb tables

### What changes were made as part of this PR

- delete duplicates
- add unique index

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


