### PR TITLE
Deploy: change bridged deployment eth from 0.5 to 0.005

### DIFF
--- a/contracts/deployment_scripts/funding/layer1/001_fund_accounts.ts
+++ b/contracts/deployment_scripts/funding/layer1/001_fund_accounts.ts
@@ -15,7 +15,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log(`TenBridge address = ${bridgeAddress}`);
 
     const tenBridge = (await hre.ethers.getContractFactory('TenBridge')).attach(bridgeAddress)
-    const prefundAmount = hre.ethers.parseEther("0.5");
+    // the last L2 deployment run against sepolia used 0.0003 eth (sept 2025)
+    // 0.005 eth aims to allow cushion without requiring unnecessary eth for deployment testing
+    const prefundAmount = hre.ethers.parseEther("0.005");
     console.log(`Prefund amount ${prefundAmount}; MB = ${tenBridge}`);
 
     const tx = await tenBridge.getFunction("sendNative").populateTransaction(deployer);


### PR DESCRIPTION
### Why this change is needed

Auto-bridging $2k dollars in a mainnet launch dry run is an unnecessary risk.

The last run against sepolia used 0.0003 eth and the gas price in mainnet is normally around 2x sepolia's price so 0.005 allows plenty of cushion in all environments. We can adjust if any problems but less risk to start low.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


