### PR TITLE
Enclave: log error instead of crit when enclave waiting for initial batches

### DIFF
--- a/go/enclave/components/txpool.go
+++ b/go/enclave/components/txpool.go
@@ -145,6 +145,7 @@ func (t *TxPool) start() {
 	)
 	defer close(newHeadCh)
 	defer newHeadSub.Unsubscribe()
+	startWait := time.Now()
 	for {
 		select {
 		case event := <-newHeadCh:
@@ -157,8 +158,7 @@ func (t *TxPool) start() {
 				return
 			}
 		case <-time.After(startMempoolTimeout):
-			t.logger.Crit("Timeout waiting to start mempool.")
-			return
+			t.logger.Error("Still waiting for batches to init mempool", "timeWaiting", time.Since(startWait))
 		}
 	}
 }


### PR DESCRIPTION
### Why this change is needed

When enclave doesn't receive its first batches within 2mins of starting up it kills itself with a CRIT message. This can happen for a variety of reasons, especially when node is not starting immediately after L1 contract deployments and has some catching up to do.

I think we originally put this in because when we had some major bugs then the sim tests would hang instead of failing but we don't see them any more (and if we did then better to have timeouts in the test structure rather than in the production code).

The CRITs add noise and timing issues to the node startup and catch-up process.

### What changes were made as part of this PR

Instead of CRIT after 2mins, we log how long the enclave has been waiting every 2 mins at ERROR level.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


