### PR TITLE
Increase GH runner cleanup frequency

### DIFF
--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -6,8 +6,13 @@ on:
     - cron: '*/30 * * * *'  #30 mins
   workflow_dispatch:
 
+concurrency:
+  group: clean-runner-01
+  cancel-in-progress: true
+
 jobs:
   clean-ten-persistence:
+    timeout-minutes: 10
     runs-on: [self-hosted, Linux, X64, ten-gh-runner-01]
     steps:
       - name: 'Clean /tmp/ten-persistence (keep newest only)'
@@ -32,4 +37,4 @@ jobs:
           echo "Deleting ${#TO_DELETE[@]} older dir(s):"
           printf ' - %s\n' "${TO_DELETE[@]}"
 
-          sudo rm -rf -- "${TO_DELETE[@]}"
+          sudo -n rm -rf -- "${TO_DELETE[@]}"

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -3,7 +3,7 @@ run-name: Cleaning runner 01 (${{ github.event_name }})
 
 on:
   schedule:
-    - cron: '0 */2 * * *'  #2 hours
+    - cron: '*/30 * * * *'  #30 mins
   workflow_dispatch:
 
 jobs:

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,7 +1,4 @@
-SET SESSION rocksdb_max_row_locks = 10000000;
-SET SESSION net_read_timeout = 600;
-SET SESSION net_write_timeout = 600;
-
+SET SESSION  rocksdb_max_row_locks = 10000000;
 DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
 ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
 

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,4 +1,7 @@
-SET SESSION  rocksdb_max_row_locks = 10000000;
+SET SESSION rocksdb_max_row_locks = 10000000;
+SET SESSION net_read_timeout = 600;
+SET SESSION net_write_timeout = 600;
+
 DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
 ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
 


### PR DESCRIPTION
### Why this change is needed

Lots of queued jobs

### What changes were made as part of this PR

* Switch cleanup from 2 hours to 30 mins

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


