### PR TITLE
Deploy: fix github paths for mainnet config

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -94,7 +94,12 @@ jobs:
             env:
                TESTNET_SHORT_NAME: ${{ steps.prepareTestnetShortName.outputs.TESTNET_SHORT_NAME }}
             run: |
-               CFG=cfg/nonprod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               # Choose the correct config directory based on environment
+               if [[ "$TESTNET_SHORT_NAME" == "mainnet" ]]; then
+                  CFG=cfg/prod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               else
+                  CFG=cfg/nonprod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               fi
                
                echo "network_config=$(yq -r '.l1Config.networkConfig'     "$CFG")"   >> $GITHUB_OUTPUT
                echo "message_bus=$(yq -r '.l1Config.messagebus'           "$CFG")"   >> $GITHUB_OUTPUT

--- a/testnet/launcher/l1contractdeployer/git_config.go
+++ b/testnet/launcher/l1contractdeployer/git_config.go
@@ -15,8 +15,6 @@ import (
 
 const (
 	_githubRepoUrl = "github.com/ten-protocol/ten-apps"
-	// path to the file in the repo (env has to be substituted with the testnet env)
-	_githubFilePath = "nonprod-argocd-config/apps/envs/%s/valuesFile/l1-values.yaml"
 )
 
 // GitL1ConfigWrapper matches a yaml file structure in the ten-apps config repo which looks like this:
@@ -62,7 +60,12 @@ func StoreNetworkCfgInGithub(githubPAT string, networkName string, networkConfig
 		return fmt.Errorf("failed to clone repo: %w", err)
 	}
 
-	relFilePath := fmt.Sprintf(_githubFilePath, networkName)
+	// Choose the correct config directory based on network environment
+	configDir := "nonprod-argocd-config"
+	if networkName == "mainnet" {
+		configDir = "prod-argocd-config"
+	}
+	relFilePath := fmt.Sprintf("%s/apps/envs/%s/valuesFile/l1-values.yaml", configDir, networkName)
 	absFilePath := filepath.Join(tmpDir, relFilePath)
 
 	f, err := os.ReadFile(absFilePath)


### PR DESCRIPTION
### Why this change is needed

Mainnet deploys fail to write and read the L1 contract addresses to the github config repo.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


