### PR TITLE
Fix GetRollupListing

### DIFF
--- a/go/host/storage/hostdb/rollup.go
+++ b/go/host/storage/hostdb/rollup.go
@@ -333,7 +333,7 @@ func fetchTotalRollups(db *sqlx.DB) (*big.Int, error) {
 	err := db.QueryRow(selectLatestRollupCount).Scan(&total)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errutil.ErrNotFound
+			return big.NewInt(0), nil
 		}
 		return big.NewInt(0), fmt.Errorf("failed to fetch rollup latest rollup ID: %w", err)
 	}

--- a/go/host/storage/hostdb/rollup_test.go
+++ b/go/host/storage/hostdb/rollup_test.go
@@ -332,6 +332,29 @@ func TestGetRollupByHash(t *testing.T) {
 	}
 }
 
+func TestGetRollupListingEmpty(t *testing.T) {
+	db, err := CreateSQLiteDB(t)
+	if err != nil {
+		t.Fatalf("unable to initialise test db: %s", err)
+	}
+
+	// Test with empty database - should return 0 total and empty rollups data
+	rollupListing, err := GetRollupListing(db, &common.QueryPagination{Offset: 0, Size: 10})
+	if err != nil {
+		t.Errorf("could not get rollup listing from empty database. Cause: %s", err)
+	}
+
+	// Should have 0 total rollups
+	if rollupListing.Total != 0 {
+		t.Errorf("expected total to be 0, got %d", rollupListing.Total)
+	}
+
+	// Should have empty rollups data slice
+	if len(rollupListing.RollupsData) != 0 {
+		t.Errorf("expected empty rollups data, got %d items", len(rollupListing.RollupsData))
+	}
+}
+
 func TestGetRollupBatches(t *testing.T) {
 	db, _ := CreateSQLiteDB(t)
 	txHashesOne := []common.L2TxHash{gethcommon.BytesToHash([]byte("magicStringOne")), gethcommon.BytesToHash([]byte("magicStringTwo"))}


### PR DESCRIPTION
### Why this change is needed

https://github.com/ten-protocol/ten-internal/issues/5790

### What changes were made as part of this PR

* Return 0 if no rows are found in the DB instead of error so FE can return N/A

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


