### PR TITLE
Enclave: only look for canonical, processed L1 blocks as current head

### DIFF
--- a/go/enclave/storage/enclavedb/block.go
+++ b/go/enclave/storage/enclavedb/block.go
@@ -96,7 +96,7 @@ func FetchBlockHeader(ctx context.Context, db *sqlx.DB, hash common.L1BlockHash)
 }
 
 func FetchHeadBlock(ctx context.Context, db *sqlx.DB) (*types.Header, error) {
-	return fetchBlock(ctx, db, "order by id desc limit 1")
+	return fetchBlock(ctx, db, "where is_canonical and processed order by id desc limit 1")
 }
 
 func FetchBlockHeaderByHeight(ctx context.Context, db *sqlx.DB, height *big.Int) (*types.Header, error) {


### PR DESCRIPTION
### Why this change is needed

Race with the dirty blocks cleanup at startup meant the block processor could get into a bad state. It should ignore unprocessed for head block.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


