### PR TITLE
fix: atomically update L2 head sequence number and hash in StateTracker

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -639,7 +639,7 @@ func (g *Guardian) submitL2Batch(batch *common.ExtBatch) error {
 		return errors.Wrap(err, "could not submit L2 batch to enclave")
 	}
 	// successfully processed batch, update the state
-	g.state.OnProcessedBatch(batch.Header.SequencerOrderNo)
+	g.state.OnProcessedBatch(batch.Header.SequencerOrderNo, batch.Hash())
 	return nil
 }
 
@@ -686,7 +686,7 @@ func (g *Guardian) streamEnclaveData() {
 				}
 				// Notify the L2 repo that an enclave has validated a batch, so it can update its validated head and notify subscribers
 				g.sl.L2Repo().NotifyNewValidatedHead(resp.Batch)
-				g.state.OnProcessedBatch(resp.Batch.Header.SequencerOrderNo)
+				g.state.OnProcessedBatch(resp.Batch.Header.SequencerOrderNo, resp.Batch.Hash())
 			}
 
 			if resp.Logs != nil {

--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -109,10 +109,11 @@ func (s *StateTracker) OnReceivedBlock(l1Head gethcommon.Hash) {
 	s.hostL1Head = l1Head
 }
 
-func (s *StateTracker) OnProcessedBatch(enclL2HeadSeqNo *big.Int) {
+func (s *StateTracker) OnProcessedBatch(enclL2HeadSeqNo *big.Int, enclL2HeadHash gethcommon.Hash) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.enclaveL2Head = enclL2HeadSeqNo
+	s.enclaveL2HeadHash = enclL2HeadHash
 	s.setStatus("onProcessedBatch", s.calculateStatus())
 }
 

--- a/go/host/enclave/state_test.go
+++ b/go/host/enclave/state_test.go
@@ -15,6 +15,7 @@ var (
 	_l1Block124        = gethcommon.BytesToHash([]byte{1, 2, 4})
 	_l2Batch456        = big.NewInt(456)
 	_l2Batch457        = big.NewInt(457)
+	_l2Batch456Hash    = gethcommon.BytesToHash([]byte{4, 5, 6})
 	stateTrackerLogger = log.New("stateTracker", int(gethlog.LevelWarn), log.SysOut)
 )
 
@@ -35,7 +36,7 @@ func TestStateTracker_InSyncWithL2(t *testing.T) {
 	s.OnProcessedBlock(_l1Block123)
 	// state tracker is up-to-date with L2
 	s.OnReceivedBatch(_l2Batch456)
-	s.OnProcessedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456, _l2Batch456Hash)
 	assert.Equal(t, Live, s.GetStatus())
 }
 
@@ -47,7 +48,7 @@ func TestStateTracker_InSyncL2ButBehindL1(t *testing.T) {
 	s.OnProcessedBlock(_l1Block123)
 	// batches are up-to-date
 	s.OnReceivedBatch(_l2Batch456)
-	s.OnProcessedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456, _l2Batch456Hash)
 	assert.Equal(t, L1Catchup, s.GetStatus())
 }
 
@@ -58,7 +59,7 @@ func TestStateTracker_InSyncWithL1ButBehindL2(t *testing.T) {
 	// batch 457 is received before batch 456 is processed
 	s.OnReceivedBatch(_l2Batch457)
 	// state tracker becomes aware that it is behind (it works this way to avoid flickering to catch-up every time a batch arrives)
-	s.OnProcessedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456, _l2Batch456Hash)
 	assert.Equal(t, L2Catchup, s.GetStatus())
 }
 
@@ -68,7 +69,7 @@ func TestStateTracker_Disconnected(t *testing.T) {
 	s.OnReceivedBlock(_l1Block123)
 	s.OnProcessedBlock(_l1Block123)
 	s.OnReceivedBatch(_l2Batch456)
-	s.OnProcessedBatch(_l2Batch456)
+	s.OnProcessedBatch(_l2Batch456, _l2Batch456Hash)
 	// but it gets disconnected
 	s.OnDisconnected()
 	assert.Equal(t, Disconnected, s.GetStatus())


### PR DESCRIPTION
### Why this change is needed

 Fixes race condition where enclaveL2HeadHash was updated via polling (OnEnclaveStatus) while enclaveL2Head sequence number was updated via streaming (OnProcessedBatch), causing:  `Active sequencer's L2 head conflicts with the host's L2 head` log messages (~90/hour on Sepolia).

Changed OnProcessedBatch() to accept both sequence number and hash, updating both fields atomically to get rid of window where they're out of sync.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


