### PR TITLE
Secure TLS config: disable 3DES (SWEET32)

### DIFF
--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -117,6 +117,22 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 		tlsConfig := &tls.Config{
 			GetCertificate: certManager.GetCertificate,
 			MinVersion:     tls.VersionTLS12,
+			MaxVersion:     tls.VersionTLS13,
+			// Prefer strong cipher suites and explicitly exclude legacy/3DES suites (SWEET32)
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				// TLS 1.2 modern suites (TLS 1.3 suites are not configurable and always enabled in Go)
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			},
+			CurvePreferences: []tls.CurveID{
+				tls.X25519,
+				tls.CurveP256,
+			},
 		}
 
 		// Update RPC server config to use TLS


### PR DESCRIPTION
### Why this change is needed

During pentesting they suggest us to fix that: https://github.com/ten-protocol/ten-internal/issues/5706


### What changes were made as part of this PR

TLS settings to eliminate 3DES-based suites vulnerable to SWEET32. Enforces TLS 1.2–1.3, prefers server cipher order, restricts to AES-GCM/ChaCha20-Poly1305, and sets curves to X25519/P-256. This aligns with modern security baselines and removes SWEET32 exposure.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


