### PR TITLE
releases/1.5 rollup limiter tweaks

### DIFF
--- a/go/enclave/limiters/rolluplimiter.go
+++ b/go/enclave/limiters/rolluplimiter.go
@@ -12,7 +12,11 @@ const (
 	// 85% is a very conservative number. It will most likely be 66% in practice.
 	// We can lower it, once we have a mechanism in place to handle batches that don't actually compress to that.
 	txCompressionFactor  = 0.85
-	compressedHeaderSize = 1
+	// Based on testing: compressedHeaderSize=4 gives ~17K batches (too conservative)
+	// Target: ~25K batches for better utilization of 90KB limit
+	// Current: 2.06 bytes/batch actual, target estimation: 3.6 bytes/batch
+	// With 0.85 factor: 2.55 + 1.5 = 4.05 bytes/batch ≈ 22,222 batches
+	compressedHeaderSize = 2
 )
 
 type rollupLimiter struct {


### PR DESCRIPTION
### Why this change is needed

Please provide a description and a link to the underlying ticket

### What changes were made as part of this PR

* Reduce from 4 to 2 as 4 was leaving too much space

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


