### PR TITLE
host: always assert that active seq enclave is not behind

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -194,6 +194,10 @@ func (g *Guardian) IsEnclaveL2AheadOfHost() bool {
 	return g.state.IsEnclaveAheadOfHost()
 }
 
+func (g *Guardian) IsEnclaveL2BehindHost() bool {
+	return g.state.IsEnclaveBehindHost()
+}
+
 func (g *Guardian) GetEnclaveState() *StateTracker {
 	return g.state
 }

--- a/go/host/enclave/state.go
+++ b/go/host/enclave/state.go
@@ -208,6 +208,15 @@ func (s *StateTracker) IsEnclaveAheadOfHost() bool {
 	return s.enclaveL2Head.Cmp(s.hostL2Head) > 0
 }
 
+func (s *StateTracker) IsEnclaveBehindHost() bool {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	if s.enclaveL2Head == nil || s.hostL2Head == nil {
+		return false
+	}
+	return s.enclaveL2Head.Cmp(s.hostL2Head) < 0
+}
+
 func (s *StateTracker) GetHostL1Head() gethcommon.Hash {
 	s.m.RLock()
 	defer s.m.RUnlock()


### PR DESCRIPTION
### Why this change is needed

We saw this situation in a mainnet dry run after some issues required component restarts:

```
INFO [09-29|15:50:00.000] Batch produced. Sending to peers..       node_id=0x6165F6a8db5b898b2D98826F7a86cFc12Bdd2999 cmp=host enclave_id=0xCC19Af8B3be962124962e967eeb76AFE6d678126 batch_height=371,908 batch=0x285d0163a590b3340a206775a6b2553e6c65ba83f8d4cf8a181798d75ab1c89a
INFO [09-29|15:50:01.004] Batch produced. Sending to peers..       node_id=0x6165F6a8db5b898b2D98826F7a86cFc12Bdd2999 cmp=host enclave_id=0xCC19Af8B3be962124962e967eeb76AFE6d678126 batch_height=371,909 batch=0xa81200c8ca672bd1b7d16a7311b5adb2cea5c89a67a008a450eec906eb0f6ff9

INFO [09-29|15:51:38.414] Successfully promoted enclave to active sequencer node_id=0x6165F6a8db5b898b2D98826F7a86cFc12Bdd2999 cmp=host enclave_id=0x6c7871AA8Be61cFB05B4144dD1dCA510974AbA87

INFO [09-29|15:51:39.446] Batch produced. Sending to peers..       node_id=0x6165F6a8db5b898b2D98826F7a86cFc12Bdd2999 cmp=host enclave_id=0x6c7871AA8Be61cFB05B4144dD1dCA510974AbA87 batch_height=371,907 batch=0x68fb3708e83acb7c6eab2b70cf7d9a01ea1eb4532dd6231a9af0e8ecfddc94b1
INFO [09-29|15:51:40.447] Batch produced. Sending to peers..       node_id=0x6165F6a8db5b898b2D98826F7a86cFc12Bdd2999 cmp=host enclave_id=0x6c7871AA8Be61cFB05B4144dD1dCA510974AbA87 batch_height=371,908 batch=0xa1de37d6b749586973fa8f36693d1032f13651fd3b85df35f8142f87aa542d54
```

It was able to promote an enclave to active sequencer despite that enclave not having seen some batches that the host knew about. I suspect this was some edge case soon after a restart.

We need to guard forcefully against this scenario as it is painful to recover from (batches broadcast must be respected so one of the enclaves needs db clean up).

This PR asserts that host is not ahead of the enclave before it produces a batch. I also check explicitly for this case in the promotion code too.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


