### PR TITLE
Properly check for batch conflicts in the host database

### DIFF
--- a/go/common/errutil/errors_util.go
+++ b/go/common/errutil/errors_util.go
@@ -15,6 +15,7 @@ var (
 	// we want to be able to catch both types in a single error-check.
 	ErrNotFound      = ethereum.NotFound
 	ErrAlreadyExists = errors.New("already exists")
+	ErrConflict      = errors.New("conflict")
 	ErrNoImpl        = errors.New("not implemented")
 
 	// Standard errors that can be returned from block submission

--- a/go/host/l2/batchrepository.go
+++ b/go/host/l2/batchrepository.go
@@ -45,7 +45,7 @@ type Repository struct {
 
 	// high watermark for batch sequence numbers seen so far. If we can't find batch for seq no < this, then we should ask peers for missing batches
 	latestBatchSeqNo *big.Int
-	latestSeqNoMutex sync.Mutex
+	batchLock        sync.Mutex
 
 	// high watermark for batch sequence numbers validated by our enclave so far.
 	latestValidatedSeqNo *big.Int
@@ -201,15 +201,31 @@ func (r *Repository) FetchLatestValidatedBatchSeqNo() *big.Int {
 // - when the node is a sequencer to store newly produced batches (the only way the sequencer host receives batches)
 // - when the node is a validator to store batches read from roll-ups
 // If the repository already has the batch it returns an AlreadyExists error which is typically ignored.
+// If the repository already has a batch with the same seq no but a different hash it returns a ErrConflict error, which must be handled!.
 func (r *Repository) AddBatch(batch *common.ExtBatch) error {
 	r.logger.Debug("Saving batch", log.BatchSeqNoKey, batch.Header.SequencerOrderNo, log.BatchHashKey, batch.Hash())
-	err := r.storage.AddBatch(batch)
+
+	// the consistency checks must be done atomically
+	r.batchLock.Lock()
+	defer r.batchLock.Unlock()
+
+	_, err := r.storage.FetchBatch(batch.Hash())
+	// we found the exact same batch
+	if err == nil {
+		return errutil.ErrAlreadyExists
+	}
+
+	_, err = r.storage.FetchBatchBySeqNo(batch.SeqNo().Uint64())
+	// we found a batch with the same seq no, but different hash
+	if err == nil {
+		return errutil.ErrConflict
+	}
+
+	err = r.storage.AddBatch(batch)
 	if err != nil {
 		return fmt.Errorf("could not add batch: %w", err)
 	}
-	// atomically compare and swap latest batch sequence number if successfully added batch is newer
-	r.latestSeqNoMutex.Lock()
-	defer r.latestSeqNoMutex.Unlock()
+	// update latest batch sequence number if successfully added batch is newer
 	if batch.Header.SequencerOrderNo.Cmp(r.latestBatchSeqNo) > 0 {
 		r.latestBatchSeqNo = batch.Header.SequencerOrderNo
 		// notify subscribers, a new batch has been successfully added to the db

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -35,6 +35,7 @@ const (
 )
 
 // AddBatch adds a batch and its header to the DB
+// single threaded
 func AddBatch(dbtx *dbTransaction, db HostDB, batch *common.ExtBatch) error {
 	extBatch, err := rlp.EncodeToBytes(batch)
 	if err != nil {
@@ -50,9 +51,6 @@ func AddBatch(dbtx *dbTransaction, db HostDB, batch *common.ExtBatch) error {
 		len(batch.EncryptedTxBlob),   // txs_size
 	)
 	if err != nil {
-		if IsRowExistsError(err) {
-			return errutil.ErrAlreadyExists
-		}
 		return fmt.Errorf("host failed to insert batch: %w", err)
 	}
 

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -24,13 +24,10 @@ type storageImpl struct {
 	io.Closer
 }
 
+// AddBatch adds a batch to the host storage.
+// Must be single-threaded, because it must atomically check the consistency of the network.
+// It is assumed that this is called after confirming that the batch doesn't exist already.
 func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
-	_, err := hostdb.GetBatchHeader(s.db, batch.Hash())
-	if err == nil {
-		// batch already exists don't error
-		return nil
-	}
-
 	dbtx, err := s.db.NewDBTransaction()
 	if err != nil {
 		return err
@@ -38,16 +35,10 @@ func (s *storageImpl) AddBatch(batch *common.ExtBatch) error {
 	defer dbtx.Rollback()
 
 	if err := hostdb.AddBatch(dbtx, s.db, batch); err != nil {
-		if errors.Is(err, errutil.ErrAlreadyExists) {
-			return nil
-		}
 		return fmt.Errorf("could not add batch to host. Cause: %w", err)
 	}
 
 	if err := dbtx.Write(); err != nil {
-		if hostdb.IsRowExistsError(err) {
-			return nil
-		}
 		return fmt.Errorf("could not commit batch tx. Cause: %w", err)
 	}
 	return nil


### PR DESCRIPTION
### Why this change is needed

The sequencer host database is the ultimate guardian against split-brain in the HA setup.

### What changes were made as part of this PR

- serialise storing of batches
- explicitly check against conflicts and surface proper error
- remove code that ingored constraints failures

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


