### PR TITLE
Will/host rollup estimation calc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.25.1"
+		},
 		"ghcr.io/dhoeric/features/act:1": {},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "18"
@@ -16,7 +19,6 @@
 			"extensions": [
 				"766b.go-outliner",
 				"golang.go",
-				"zxh404.vscode-proto3",
 				"NomicFoundation.hardhat-solidity"
 			],
 			"settings": {

--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -94,7 +94,12 @@ jobs:
             env:
                TESTNET_SHORT_NAME: ${{ steps.prepareTestnetShortName.outputs.TESTNET_SHORT_NAME }}
             run: |
-               CFG=cfg/nonprod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               # Choose the correct config directory based on environment
+               if [[ "$TESTNET_SHORT_NAME" == "mainnet" ]]; then
+                  CFG=cfg/prod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               else
+                  CFG=cfg/nonprod-argocd-config/apps/envs/$TESTNET_SHORT_NAME/valuesFile/l1-values.yaml
+               fi
                
                echo "network_config=$(yq -r '.l1Config.networkConfig'     "$CFG")"   >> $GITHUB_OUTPUT
                echo "message_bus=$(yq -r '.l1Config.messagebus'           "$CFG")"   >> $GITHUB_OUTPUT

--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -29,6 +29,11 @@ on:
           description: 'Type "confirm" if deploying sepolia or mainnet'
           required: false
           type: string
+      max_gas_gwei:
+          description: 'Max gas price in gwei (default 1.5)'
+          required: false
+          default: '1.5'
+          type: string
 
 jobs:
   build:
@@ -117,6 +122,8 @@ jobs:
           DEPLOY_L1_DEPLOYERPK: ${{ secrets.ACCOUNT_PK_WORKER }}
           DEPLOY_L1_INITIALSEQADDRESS: ${{ vars.ACCOUNT_ADDR_NODE_0 }}
           DEPLOY_L1_ETHERSCANAPIKEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          DEPLOY_L1_MAXGASGWEI: ${{ github.event.inputs.max_gas_gwei }}
+          DEPLOY_L1_CHECKGASPRICE: ${{ github.event.inputs.testnet_type == 'mainnet' && 'true' || 'false' }}
         run: |
           # Run deployer and capture output
           go run ./testnet/launcher/l1contractdeployer/cmd

--- a/contracts/deployment_scripts/core/001_deploy_contracts.ts
+++ b/contracts/deployment_scripts/core/001_deploy_contracts.ts
@@ -1,7 +1,6 @@
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
-import {ethers} from "hardhat";
-import { hexlify, toUtf8Bytes } from 'ethers';
+import { hexlify, toUtf8Bytes, parseUnits, formatUnits } from 'ethers';
 
 /*
     This deployment script instantiates the network contracts and stores them in the deployed NetworkConfig contract.
@@ -11,6 +10,30 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     if (!sequencerHostAddress) {
         console.error("SEQUENCER_HOST_ADDRESS environment variable is not set.");
         process.exit(1);
+    }
+
+    // Gas price safety check if enabled
+    if (process.env.CHECK_GAS_PRICE === 'true') {
+        const provider = hre.ethers.provider;
+        const feeData = await provider.getFeeData();
+        const currentGasPrice = feeData.gasPrice;
+        const maxGasGwei = parseFloat(process.env.MAX_GAS_GWEI || '1.5');
+        const maxGasWei = parseUnits(maxGasGwei.toString(), 'gwei');
+
+        if (!currentGasPrice) {
+            console.error("Current gas price unavailable, unable to check price conditions.")
+            console.error("Deployment aborted. Please check network connectivity.")
+            process.exit(1);
+        }
+        
+        if (currentGasPrice > maxGasWei) {
+            const currentGwei = formatUnits(currentGasPrice, 'gwei');
+            console.error(`\n⚠️  Gas price too high: ${currentGwei} gwei (limit: ${maxGasGwei} gwei)`);
+            console.error(`Deployment aborted. Please wait for gas prices to drop or increase the max_gas_gwei limit.\n`);
+            process.exit(1);
+        }
+
+        console.log(`✅ Gas price check passed: ${formatUnits(currentGasPrice, 'gwei')} gwei (limit: ${maxGasGwei} gwei)\n`);
     }
 
     const {

--- a/contracts/deployment_scripts/funding/layer1/001_fund_accounts.ts
+++ b/contracts/deployment_scripts/funding/layer1/001_fund_accounts.ts
@@ -15,7 +15,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log(`TenBridge address = ${bridgeAddress}`);
 
     const tenBridge = (await hre.ethers.getContractFactory('TenBridge')).attach(bridgeAddress)
-    const prefundAmount = hre.ethers.parseEther("0.5");
+    // the last L2 deployment run against sepolia used 0.0003 eth (sept 2025)
+    // 0.005 eth aims to allow cushion without requiring unnecessary eth for deployment testing
+    const prefundAmount = hre.ethers.parseEther("0.005");
     console.log(`Prefund amount ${prefundAmount}; MB = ${tenBridge}`);
 
     const tx = await tenBridge.getFunction("sendNative").populateTransaction(deployer);

--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -109,6 +109,8 @@ deploy:
     challengePeriod: 1 # challenge period for rollups in seconds
     initialSeqAddress: 0x0 # initial sequencer address for the L1 network, only address allowed to initialize the L2 network
     etherscanAPIKey: "" # optional Etherscan API key for verifying contracts on Etherscan
+    maxGasGwei: 1.5 # max network gas price to proceed with L1 deployment (avoid deploying in spikes)
+    checkGasPrice: false # flag to turn on maxGasGwei checks (for mainnet mostly)
   l2:
     rpcAddress: "localhost" # L2 RPC address for deploying contracts
     httpPort: 80 # L2 RPC port for deploying contracts

--- a/go/config/defaults/0-base-config.yaml
+++ b/go/config/defaults/0-base-config.yaml
@@ -49,6 +49,7 @@ host:
     useInMemory: true
     postgresHost: "" # host address for postgres db when used
     sqlitePath: "" # path to sqlite db, will use a throwaway temp file when empty
+    historicalTxCount: 0
   debug:
     enableMetrics: true
     metricsPort: 14000

--- a/go/config/deployment.go
+++ b/go/config/deployment.go
@@ -23,6 +23,8 @@ type L1DeployConfig struct {
 	InitialSeqAddress string `mapstructure:"initialSeqAddress"` // the initial sequencer EOA to expect for network initialization
 	ChallengePeriod   int    `mapstructure:"challengePeriod"`   // the rollup challenge period in seconds
 	EtherscanAPIKey   string `mapstructure:"etherscanAPIKey"`   // optional Etherscan API key for contract verification
+	MaxGasGwei        string `mapstructure:"maxGasGwei"`        // maximum network gas price (gwei) - above this we abort
+	CheckGasPrice     string `mapstructure:"checkGasPrice"`     // whether to check maxGasGwei gas price before deployment
 }
 
 // L2DeployConfig contains the configuration for the deployment of the L2 contracts

--- a/go/config/host.go
+++ b/go/config/host.go
@@ -26,6 +26,8 @@ type HostDB struct {
 	// SqlitePath is the filepath for the sqlite DB persistence file (can be empty if a throwaway file in /tmp/ is acceptable or
 	// if using InMemory DB)
 	SqlitePath string `mapstructure:"sqlitePath"`
+	// HistoricalTxCount is the running total of tesnet transactions
+	HistoricalTxCount int `mapstructure:"historicalTxCount"`
 }
 
 // HostLog contains the configuration for the host logger.

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -177,6 +177,7 @@ func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, up
 			return nil, nil, err
 		}
 		if !didAcceptBatch {
+			br.logger.Debug("Did not accept batch at height ", currentBatchSeq)
 			break
 		}
 

--- a/go/enclave/components/batch_registry.go
+++ b/go/enclave/components/batch_registry.go
@@ -177,7 +177,7 @@ func (br *batchRegistry) BatchesAfter(ctx context.Context, batchSeqNo uint64, up
 			return nil, nil, err
 		}
 		if !didAcceptBatch {
-			br.logger.Debug("Did not accept batch at height ", currentBatchSeq)
+			br.logger.Debug(fmt.Sprintf("Did not accept batch at height %d", currentBatchSeq))
 			break
 		}
 

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -111,14 +111,14 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 	}
 
 	headerRaw, _ := rlp.EncodeToBytes(header)
-	rc.logger.Debug(fmt.Sprintf("CalldataRollupHeader raw size %d", len(headerRaw)))
+	rc.logger.Debug("CalldataRollupHeader", "raw_size", len(headerRaw))
 
 	encryptedHeader, err := rc.serialiseCompressAndEncrypt(header)
 	if err != nil {
 		return nil, err
 	}
 
-	rc.logger.Debug(fmt.Sprintf("CalldataRollupHeader encrypted size %d", len(encryptedHeader)))
+	rc.logger.Debug("CalldataRollupHeader", "encrypted_size", len(encryptedHeader))
 
 	transactions := make([]*common.TxsWithTimeStamp, len(r.Batches))
 	totalTxs := 0
@@ -128,18 +128,18 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 	}
 
 	transactionsRaw, _ := rlp.EncodeToBytes(transactions)
-	rc.logger.Debug(fmt.Sprintf("BatchPayloads raw size: %d bytes, total_batches: %d, total_txs: %d",
-		len(transactionsRaw), len(r.Batches), totalTxs))
+	rc.logger.Debug("BatchPayloads", "raw_bytes", len(transactionsRaw), "total_batches", len(r.Batches),
+		"num_txs", totalTxs)
 
 	encryptedTransactions, err := rc.serialiseCompressAndEncrypt(transactions)
 	if err != nil {
 		return nil, err
 	}
 
-	rc.logger.Debug(fmt.Sprintf("BatchPayloads encrypted size: %d bytes", len(encryptedTransactions)))
+	rc.logger.Debug("BatchPayloads", "encrypted_size", len(encryptedTransactions))
 
 	rollupHeaderRaw, _ := rlp.EncodeToBytes(r.Header)
-	rc.logger.Debug(fmt.Sprintf("RollupHeader size: %d bytes", len(rollupHeaderRaw)))
+	rc.logger.Debug("RollupHeader", "raw_bytes", len(rollupHeaderRaw))
 
 	extRollup := &common.ExtRollup{
 		Header:               r.Header,
@@ -148,7 +148,7 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 	}
 
 	extRollupRaw, _ := rlp.EncodeToBytes(extRollup)
-	rc.logger.Debug(fmt.Sprintf("Total ExtRollup size %d", len(extRollupRaw)))
+	rc.logger.Debug("ExtRollup", "total_size", len(extRollupRaw))
 
 	return extRollup, nil
 }

--- a/go/enclave/components/rollup_compression.go
+++ b/go/enclave/components/rollup_compression.go
@@ -118,7 +118,7 @@ func (rc *RollupCompression) CreateExtRollup(ctx context.Context, r *core.Rollup
 		return nil, err
 	}
 
-	rc.logger.Debug(fmt.Sprintf("CalldataRollupHeader encrypted size", "size_bytes", len(encryptedHeader)))
+	rc.logger.Debug(fmt.Sprintf("CalldataRollupHeader encrypted size %d", len(encryptedHeader)))
 
 	transactions := make([]*common.TxsWithTimeStamp, len(r.Batches))
 	totalTxs := 0

--- a/go/enclave/crosschain/message_bus_manager.go
+++ b/go/enclave/crosschain/message_bus_manager.go
@@ -217,52 +217,95 @@ func (m *MessageBusManager) CreateSyntheticTransactions(_ context.Context, messa
 func ConvertCrossChainMessagesToValueTransfers(msgs common.CrossChainMessages, eventName string, bridgeAddress *common.L1Address) (common.ValueTransferEvents, error) {
 	transfers := msgs.FilterValueTransfers(*bridgeAddress)
 
-	// Create the ABI components for the ValueTransfer struct
-	uint256Type, _ := abi.NewType("uint256", "", nil)
-	addressType, _ := abi.NewType("address", "", nil)
-
-	// Define the struct components matching the Solidity struct
-	valueTransferComponents := abi.Arguments{
-		{
-			Name: "amount",
-			Type: uint256Type,
-		},
-		{
-			Name: "recipient",
-			Type: addressType,
-		},
-	}
-
 	valueTransfers := make(common.ValueTransferEvents, 0)
-	for _, transfer := range transfers {
-		// Unpack the log data
-		unpacked, err := valueTransferComponents.Unpack(transfer.Payload)
+	for _, m := range transfers {
+		// 1) Decode CrossChainCall wrapper (tuple)
+		out, err := decodeCrossChainCall(m.Payload)
 		if err != nil {
-			return nil, fmt.Errorf("unable to unpack the value transfer struct: %w", err)
+			return nil, fmt.Errorf("unpack CrossChainCall failed: topic=%d sender=%s seq=%d: %w", m.Topic, m.Sender.Hex(), m.Sequence, err)
 		}
 
-		// Make sure we get the expected number of values
-		if len(unpacked) != 2 {
-			return nil, fmt.Errorf("unexpected number of values unpacked: expected 2, got %d", len(unpacked))
+		// 2) Decode inner receiveAssets call
+		asset, amount, recipient, err := decodeReceiveAssetsCall(out.Data)
+		if err != nil {
+			selector := ""
+			if len(out.Data) >= 4 {
+				selector = gethcommon.Bytes2Hex(out.Data[:4])
+			}
+			return nil, fmt.Errorf("unable to unpack receiveAssets call data: topic=%d sender=%s seq=%d selector=%s: %w", m.Topic, m.Sender.Hex(), m.Sequence, selector, err)
 		}
 
-		// Convert the unpacked values to the right types
-		amount, ok1 := unpacked[0].(*big.Int)
-		recipient, ok2 := unpacked[1].(gethcommon.Address)
-
-		if !ok1 || !ok2 {
-			return nil, fmt.Errorf("failed to convert unpacked values to expected types")
+		// Only native asset transfers (asset == address(0)) affect L2 native balance
+		if asset == (gethcommon.Address{}) {
+			valueTransfers = append(valueTransfers, common.ValueTransferEvent{
+				Amount:   amount,
+				Receiver: recipient,
+				Sender:   m.Sender,
+			})
 		}
-
-		// Create the ValueTransferEvent with the unpacked data
-		valueTransfer := common.ValueTransferEvent{
-			Amount:   amount,
-			Receiver: recipient,
-			Sender:   gethcommon.BytesToAddress(transfer.Sender.Bytes()), // Sender is in the first topic
-		}
-
-		valueTransfers = append(valueTransfers, valueTransfer)
 	}
 
 	return valueTransfers, nil
+}
+
+// crossChainCall mirrors the Solidity ICrossChainMessenger.CrossChainCall struct
+type crossChainCall struct {
+	Target gethcommon.Address
+	Data   []byte
+	Gas    *big.Int
+}
+
+func decodeCrossChainCall(payload []byte) (*crossChainCall, error) {
+	tupleType, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "target", Type: "address"},
+		{Name: "data", Type: "bytes"},
+		{Name: "gas", Type: "uint256"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build tuple type: %w", err)
+	}
+	args := abi.Arguments{{Type: tupleType}}
+	unpacked, err := args.Unpack(payload)
+	if err != nil {
+		head := 32
+		if len(payload) < head {
+			head = len(payload)
+		}
+		return nil, fmt.Errorf("len=%d head=%s: %w", len(payload), gethcommon.Bytes2Hex(payload[:head]), err)
+	}
+	if len(unpacked) != 1 {
+		return nil, fmt.Errorf("unexpected tuple arity: got=%d", len(unpacked))
+	}
+	conv := abi.ConvertType(unpacked[0], new(crossChainCall))
+	out, ok := conv.(*crossChainCall)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert tuple to crossChainCall")
+	}
+	if out.Target == (gethcommon.Address{}) {
+		return nil, fmt.Errorf("cross chain call has zero target")
+	}
+	return out, nil
+}
+
+func decodeReceiveAssetsCall(data []byte) (gethcommon.Address, *big.Int, gethcommon.Address, error) {
+	if len(data) < 4 {
+		return gethcommon.Address{}, nil, gethcommon.Address{}, fmt.Errorf("calldata too short for selector")
+	}
+	addressType, _ := abi.NewType("address", "", nil)
+	uint256Type, _ := abi.NewType("uint256", "", nil)
+	args := abi.Arguments{{Type: addressType}, {Type: uint256Type}, {Type: addressType}}
+	params, err := args.Unpack(data[4:])
+	if err != nil {
+		return gethcommon.Address{}, nil, gethcommon.Address{}, err
+	}
+	if len(params) != 3 {
+		return gethcommon.Address{}, nil, gethcommon.Address{}, fmt.Errorf("unexpected arg count: %d", len(params))
+	}
+	asset, ok1 := params[0].(gethcommon.Address)
+	amount, ok2 := params[1].(*big.Int)
+	receiver, ok3 := params[2].(gethcommon.Address)
+	if !ok1 || !ok2 || !ok3 {
+		return gethcommon.Address{}, nil, gethcommon.Address{}, fmt.Errorf("type assertion failed")
+	}
+	return asset, amount, receiver, nil
 }

--- a/go/enclave/limiters/rolluplimiter.go
+++ b/go/enclave/limiters/rolluplimiter.go
@@ -12,11 +12,11 @@ const (
 	// 85% is a very conservative number. It will most likely be 66% in practice.
 	// We can lower it, once we have a mechanism in place to handle batches that don't actually compress to that.
 	txCompressionFactor  = 0.85
-	// Based on mainnet logs: 86,695 batches → 176,958 bytes (way over 90KB limit)
-	// Need much more aggressive limiting: target ~15,000 batches for safety
-	// Target: 90,000 ÷ 15,000 = 6 bytes/batch estimated
-	// With 0.85 factor: 2.55 + 3.5 = 6.05 bytes/batch
-	compressedHeaderSize = 4
+	// Based on testing: compressedHeaderSize=4 gives ~17K batches (too conservative)
+	// Target: ~25K batches for better utilization of 90KB limit
+	// Current: 2.06 bytes/batch actual, target estimation: 3.6 bytes/batch
+	// With 0.85 factor: 2.55 + 1.5 = 4.05 bytes/batch ≈ 22,222 batches
+	compressedHeaderSize = 2
 )
 
 type rollupLimiter struct {

--- a/go/enclave/limiters/rolluplimiter.go
+++ b/go/enclave/limiters/rolluplimiter.go
@@ -12,7 +12,11 @@ const (
 	// 85% is a very conservative number. It will most likely be 66% in practice.
 	// We can lower it, once we have a mechanism in place to handle batches that don't actually compress to that.
 	txCompressionFactor  = 0.85
-	compressedHeaderSize = 1
+	// Based on mainnet logs: 86,695 batches → 176,958 bytes (way over 90KB limit)
+	// Need much more aggressive limiting: target ~15,000 batches for safety
+	// Target: 90,000 ÷ 15,000 = 6 bytes/batch estimated
+	// With 0.85 factor: 2.55 + 3.5 = 6.05 bytes/batch
+	compressedHeaderSize = 4
 )
 
 type rollupLimiter struct {

--- a/go/enclave/limiters/rolluplimiter.go
+++ b/go/enclave/limiters/rolluplimiter.go
@@ -11,7 +11,7 @@ import (
 const (
 	// 85% is a very conservative number. It will most likely be 66% in practice.
 	// We can lower it, once we have a mechanism in place to handle batches that don't actually compress to that.
-	txCompressionFactor  = 0.85
+	txCompressionFactor = 0.85
 	// Based on testing: compressedHeaderSize=4 gives ~17K batches (too conservative)
 	// Target: ~25K batches for better utilization of 90KB limit
 	// Current: 2.06 bytes/batch actual, target estimation: 3.6 bytes/batch

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -327,10 +327,11 @@ func (s *sequencer) CreateRollup(ctx context.Context, lastBatchNo uint64) (*comm
 		return nil, fmt.Errorf("failed to encode rollup: %w", err)
 	}
 
-	// Create temp blobs to get blob hash
+	// Create blobs to get blob hash
+	s.logger.Debug(fmt.Sprintf("Creating blobs for rollup with from batch %d to %d", rollup.Header.FirstBatchSeqNo, rollup.Header.LastBatchSeqNo))
 	blobs, err := ethadapter.EncodeBlobs(rollupData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode rollup to tmpBlobs: %w", err)
+		return nil, fmt.Errorf("failed to encode rollup to blobs: %w", err)
 	}
 
 	commitment, err := kzg4844.BlobToCommitment(blobs[0])

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -327,9 +327,11 @@ func (s *sequencer) CreateRollup(ctx context.Context, lastBatchNo uint64) (*comm
 		return nil, fmt.Errorf("failed to encode rollup: %w", err)
 	}
 
+	s.logger.Debug("EncodeRollup size", "size_bytes", len(rollupData))
+
 	// Create blobs to get blob hash
 	s.logger.Debug(fmt.Sprintf("Creating blobs for rollup with from batch %d to %d", rollup.Header.FirstBatchSeqNo, rollup.Header.LastBatchSeqNo))
-	blobs, err := ethadapter.EncodeBlobs(rollupData)
+	blobs, err := ethadapter.EncodeBlobs(rollupData, s.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode rollup to blobs: %w", err)
 	}

--- a/go/enclave/storage/enclavedb/block.go
+++ b/go/enclave/storage/enclavedb/block.go
@@ -96,7 +96,7 @@ func FetchBlockHeader(ctx context.Context, db *sqlx.DB, hash common.L1BlockHash)
 }
 
 func FetchHeadBlock(ctx context.Context, db *sqlx.DB) (*types.Header, error) {
-	return fetchBlock(ctx, db, "order by id desc limit 1")
+	return fetchBlock(ctx, db, "where is_canonical and processed order by id desc limit 1")
 }
 
 func FetchBlockHeaderByHeight(ctx context.Context, db *sqlx.DB, height *big.Int) (*types.Header, error) {

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -2,7 +2,14 @@ SET SESSION rocksdb_max_row_locks = 10000000;
 SET SESSION net_read_timeout = 600;
 SET SESSION net_write_timeout = 600;
 
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 1000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 2000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 3000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 4000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 5000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 6000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 7000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 8000000;
 ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
 
 DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,9 +1,1 @@
--- SET SESSION rocksdb_max_row_locks = 10000000;
--- SET SESSION net_read_timeout = 600;
--- SET SESSION net_write_timeout = 600;
---
--- DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
--- ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
---
--- DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
--- ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);
+select 1 from dual

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -2,14 +2,14 @@ SET SESSION rocksdb_max_row_locks = 10000000;
 SET SESSION net_read_timeout = 600;
 SET SESSION net_write_timeout = 600;
 
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 1000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 2000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 3000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 4000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 5000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 6000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 7000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE s1.id < 8000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 0       AND s1.id < 1000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 1000000 AND s1.id < 2000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 2000000 AND s1.id < 3000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 3000000 AND s1.id < 4000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 4000000 AND s1.id < 5000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 5000000 AND s1.id < 6000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 6000000 AND s1.id < 7000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 7000000 AND s1.id < 8000000;
 ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
 
 DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,0 +1,6 @@
+SET SESSION  rocksdb_max_row_locks = 10000000;
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
+ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
+
+DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
+ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,1 +1,9 @@
-select 1 from dual
+SET SESSION rocksdb_max_row_locks = 10000000;
+SET SESSION net_read_timeout = 600;
+SET SESSION net_write_timeout = 600;
+
+DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
+ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
+
+DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
+ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,16 +1,9 @@
-SET SESSION rocksdb_max_row_locks = 10000000;
-SET SESSION net_read_timeout = 600;
-SET SESSION net_write_timeout = 600;
-
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 0       AND s1.id < 1000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 1000000 AND s1.id < 2000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 2000000 AND s1.id < 3000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 3000000 AND s1.id < 4000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 4000000 AND s1.id < 5000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 5000000 AND s1.id < 6000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 6000000 AND s1.id < 7000000;
-DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id WHERE  s1.id >= 7000000 AND s1.id < 8000000;
-ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
-
-DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
-ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);
+-- SET SESSION rocksdb_max_row_locks = 10000000;
+-- SET SESSION net_read_timeout = 600;
+-- SET SESSION net_write_timeout = 600;
+--
+-- DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
+-- ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
+--
+-- DELETE FROM statedb64  WHERE id NOT IN (SELECT MIN(id) FROM statedb64 GROUP BY ky);
+-- ALTER TABLE statedb64 ADD CONSTRAINT unique_ky_statedb64 UNIQUE (ky);

--- a/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
+++ b/go/enclave/storage/init/edgelessdb/002_unique_ky.sql
@@ -1,4 +1,7 @@
-SET SESSION  rocksdb_max_row_locks = 10000000;
+SET SESSION rocksdb_max_row_locks = 10000000;
+SET SESSION net_read_timeout = 600;
+SET SESSION net_write_timeout = 600;
+
 DELETE s1 FROM statedb32 s1 INNER JOIN statedb32 s2 ON s1.ky = s2.ky AND s1.id > s2.id;
 ALTER TABLE statedb32 ADD CONSTRAINT unique_ky_statedb32 UNIQUE (ky);
 

--- a/go/enclave/storage/init/sqlite/sqlite.go
+++ b/go/enclave/storage/init/sqlite/sqlite.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"embed"
 	"fmt"
 	"os"
@@ -141,6 +142,8 @@ func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 			logger,
 			func(err error) bool {
 				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "invalid connection")
+			},
+			func(conn driver.Conn) {
 			}),
 	)
 	return driverName

--- a/go/ethadapter/blob.go
+++ b/go/ethadapter/blob.go
@@ -68,7 +68,7 @@ func EncodeBlobs(data []byte) ([]*kzg4844.Blob, error) {
 	}
 
 	if len(data) >= MaxBlobBytes {
-		return nil, fmt.Errorf("data too large to encode in blobs")
+		return nil, fmt.Errorf("data too large to encode in blobs. data length: %d", len(data))
 	}
 
 	var blobs []*kzg4844.Blob

--- a/go/ethadapter/blob.go
+++ b/go/ethadapter/blob.go
@@ -64,7 +64,7 @@ func (KZGToVersionedHasher) BlobHash(blob *kzg4844.Blob) (gethcommon.Hash, kzg48
 // transactions on Ethereum.
 func EncodeBlobs(data []byte, logger gethlog.Logger) ([]*kzg4844.Blob, error) {
 	originalSize := len(data)
-	logger.Debug(fmt.Sprintf("EncodeBlobs input size: %d bytes\n", originalSize))
+	logger.Debug("EncodeBlobs input size", "raw_bytes", originalSize)
 
 	data, err := rlp.EncodeToBytes(data)
 	if err != nil {
@@ -73,8 +73,7 @@ func EncodeBlobs(data []byte, logger gethlog.Logger) ([]*kzg4844.Blob, error) {
 
 	rlpEncodedSize := len(data)
 	rlpOverhead := rlpEncodedSize - originalSize
-	logger.Debug(fmt.Sprintf("EncodeBlobs after RLP encoding: %d bytes (overhead: %d, limit: %d)",
-		rlpEncodedSize, rlpOverhead, MaxBlobBytes))
+	logger.Debug("EncodeBlobs after RLP encoding", "encoded_size", rlpEncodedSize, "rlp_overhead", rlpOverhead, "max_blob_bytes", MaxBlobBytes)
 
 	if len(data) >= MaxBlobBytes {
 		return nil, fmt.Errorf("data too large to encode in blobs. data length: %d", len(data))

--- a/go/ethadapter/blob_beacon_client_test.go
+++ b/go/ethadapter/blob_beacon_client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	gethlog "github.com/ethereum/go-ethereum/log"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 
@@ -98,7 +100,7 @@ func TestBlobEncoding(t *testing.T) {
 	}
 
 	// Encode data into blobs
-	blobs, err := EncodeBlobs(encRollup)
+	blobs, err := EncodeBlobs(encRollup, gethlog.New())
 	if err != nil {
 		t.Errorf("error encoding blobs: %s", err)
 	}
@@ -119,7 +121,7 @@ func TestBlobEncodingLarge(t *testing.T) {
 	// make this rollup larger than 128kb
 	extRlp := createLargeRollup(4445)
 	encRollup, _ := common.EncodeRollup(&extRlp)
-	_, err := EncodeBlobs(encRollup)
+	_, err := EncodeBlobs(encRollup, gethlog.New())
 	require.Error(t, err)
 }
 

--- a/go/host/config/config.go
+++ b/go/host/config/config.go
@@ -66,6 +66,8 @@ type HostConfig struct {
 	// filepath for the sqlite DB persistence file (can be empty if a throwaway file in /tmp/ is acceptable or
 	// if using InMemory DB)
 	SqliteDBPath string
+	// Historical transaction count for testnet
+	HistoricalTxCount int
 
 	//////
 	// NODE NETWORKING
@@ -138,9 +140,10 @@ func HostConfigFromTenConfig(tenCfg *config.TenConfig) *HostConfig {
 		LogLevel: tenCfg.Host.Log.Level,
 		LogPath:  tenCfg.Host.Log.Path,
 
-		UseInMemoryDB:  tenCfg.Host.DB.UseInMemory,
-		PostgresDBHost: tenCfg.Host.DB.PostgresHost,
-		SqliteDBPath:   tenCfg.Host.DB.SqlitePath,
+		UseInMemoryDB:     tenCfg.Host.DB.UseInMemory,
+		PostgresDBHost:    tenCfg.Host.DB.PostgresHost,
+		SqliteDBPath:      tenCfg.Host.DB.SqlitePath,
+		HistoricalTxCount: tenCfg.Host.DB.HistoricalTxCount,
 
 		HasClientRPCHTTP:       tenCfg.Host.RPC.EnableHTTP,
 		ClientRPCPortHTTP:      tenCfg.Host.RPC.HTTPPort,

--- a/go/host/enclave/service.go
+++ b/go/host/enclave/service.go
@@ -320,9 +320,10 @@ func (e *Service) tryPromoteNewSequencer() {
 	e.activeSequencerID.Store(_noActiveSequencer)
 }
 
-// This compression factor is based on data we've seen in production where the rollups is typically
-// 10-15% the size of the raw batch txs. This still allows some buffer so the rollup should rarely be completely full
-const batchCompressionFactor = 0.25
+// This compression factor is based on actual mainnet data showing much better compression
+// for mostly empty batches: 12,770 batches → 23,677 bytes ≈ 2.5% compression ratio
+// Using conservative 10% to allow buffer for variation in batch content
+const batchCompressionFactor = 0.1
 
 // managePeriodicRollups is a background goroutine that periodically produces a rollup
 // where possible it will prefer to use a non-active sequencer enclave to avoid disrupting the production of batches

--- a/go/host/rpc/clientapi/client_api_scan.go
+++ b/go/host/rpc/clientapi/client_api_scan.go
@@ -43,6 +43,11 @@ func (s *ScanAPI) GetTotalTransactionsQuery() (*big.Int, error) {
 	return s.host.Storage().FetchTotalTxsQuery()
 }
 
+// GetHistoricalTransactionCount returns the historical transaction count plus current count
+func (s *ScanAPI) GetHistoricalTransactionCount() (*big.Int, error) {
+	return s.host.Storage().FetchHistoricalTransactionCount()
+}
+
 // GetBatchListing returns a paginated list of batches
 func (s *ScanAPI) GetBatchListing(pagination *common.QueryPagination) (*common.BatchListingResponse, error) {
 	return s.host.Storage().FetchBatchListing(pagination)

--- a/go/host/storage/db_init.go
+++ b/go/host/storage/db_init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ten-protocol/go-ten/go/host/storage/init/sqlite"
 
 	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/jmoiron/sqlx"
 	"github.com/ten-protocol/go-ten/go/host/storage/init/postgres"
 )
 
@@ -16,23 +17,38 @@ const HOST = "HOST_"
 // CreateDBFromConfig creates an appropriate ethdb.Database instance based on your config
 func CreateDBFromConfig(cfg *hostconfig.HostConfig, logger gethlog.Logger) (hostdb.HostDB, error) {
 	dbName := HOST + cfg.ID
-	if err := validateDBConf(cfg); err != nil {
+	var db *sqlx.DB
+	var err error
+	if err = validateDBConf(cfg); err != nil {
 		return nil, err
 	}
 	if cfg.UseInMemoryDB {
+		// create sqlite db
 		logger.Info("UseInMemoryDB flag is true, data will not be persisted. Creating in-memory database...")
-		sqliteDB, err := sqlite.CreateTemporarySQLiteHostDB(dbName, "mode=memory&cache=shared&_foreign_keys=on", logger)
+		db, err = sqlite.CreateTemporarySQLiteHostDB(dbName, "mode=memory&cache=shared&_foreign_keys=on", logger)
 		if err != nil {
 			return nil, fmt.Errorf("could not create in memory sqlite DB: %w", err)
 		}
-		return hostdb.NewHostDB(sqliteDB, logger)
+	} else {
+		// create postgres db
+		logger.Info(fmt.Sprintf("Preparing Postgres DB connection to %s...", cfg.PostgresDBHost))
+		db, err = postgres.CreatePostgresDBConnection(cfg.PostgresDBHost, dbName, logger)
+		if err != nil {
+			return nil, fmt.Errorf("could not create postresql connection: %w", err)
+		}
 	}
-	logger.Info(fmt.Sprintf("Preparing Postgres DB connection to %s...", cfg.PostgresDBHost))
-	postgresDB, err := postgres.CreatePostgresDBConnection(cfg.PostgresDBHost, dbName, logger)
-	if err != nil {
-		return nil, fmt.Errorf("could not create postresql connection: %w", err)
+
+	// Update historical transaction count from config if it's greater than 0
+	if cfg.HistoricalTxCount > 0 {
+		err = updateHistoricalTransactionCount(db, cfg.HistoricalTxCount)
+		if err != nil {
+			logger.Warn("Failed to update historical transaction count", "error", err)
+		} else {
+			logger.Info("Updated historical transaction count from config", "count", cfg.HistoricalTxCount)
+		}
 	}
-	return hostdb.NewHostDB(postgresDB, logger)
+
+	return hostdb.NewHostDB(db, logger)
 }
 
 // validateDBConf high-level checks that you have a valid configuration for DB creation
@@ -43,5 +59,18 @@ func validateDBConf(cfg *hostconfig.HostConfig) error {
 	if cfg.SqliteDBPath != "" && cfg.UseInMemoryDB {
 		return fmt.Errorf("useInMemoryDB=true so sqlite database will not be used and no path is needed, but sqliteDBPath=%s", cfg.SqliteDBPath)
 	}
+	return nil
+}
+
+// updateHistoricalTransactionCount updates the historical transaction count from config
+func updateHistoricalTransactionCount(db *sqlx.DB, historicalTxCount int) error {
+	updateQuery := "UPDATE historical_transaction_count SET total = ? where id = 1"
+
+	reboundQuery := db.Rebind(updateQuery)
+	_, err := db.Exec(reboundQuery, historicalTxCount)
+	if err != nil {
+		return fmt.Errorf("failed to update historical transaction count: %w", err)
+	}
+
 	return nil
 }

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -41,13 +41,28 @@ func AddBatch(dbtx *dbTransaction, db HostDB, batch *common.ExtBatch) error {
 		return fmt.Errorf("could not encode L2 transactions: %w", err)
 	}
 
+	// this value is used on host side rollup size estimation
+	txDataSize := 0
+	if len(batch.TxHashes) > 0 {
+		// this will be compressed in the rollup, so apply estimated compression factor
+		txDataSize = len(batch.EncryptedTxBlob)
+	} else {
+		// empty batches still contribute to rollup size through:
+		// - RLP encoded empty transaction array (~3 bytes)
+		// - Time delta (~1-2 bytes when compressed)
+		// - L1 height delta (~1-2 bytes when compressed)
+		// actual data from mainnet: 12,769 empty batches = 26KB rollup = ~2 bytes/batch final
+		// batchCompressionFactor=0.1: 26KB ÷ 0.1 ÷ 12,769 = ~20 bytes raw estimate
+		txDataSize = 20
+	}
+
 	reboundInsertBatch := db.GetSQLDB().Rebind(insertBatch)
 	_, err = dbtx.Tx.Exec(reboundInsertBatch,
 		batch.SeqNo().Uint64(),       // sequence
 		batch.Hash(),                 // full hash
 		batch.Header.Number.Uint64(), // height
 		extBatch,                     // ext_batch
-		len(batch.EncryptedTxBlob),   // txs_size
+		txDataSize,                   // txs_size
 	)
 	if err != nil {
 		if IsRowExistsError(err) {

--- a/go/host/storage/hostdb/transaction.go
+++ b/go/host/storage/hostdb/transaction.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	selectTxCount = "SELECT total FROM transaction_count WHERE id = 1"
-	selectTx      = "SELECT hash, b_sequence FROM transaction_host WHERE hash = ?"
-	selectTxs     = "SELECT t.hash, b.ext_batch FROM transaction_host t JOIN batch_host b ON t.b_sequence = b.sequence ORDER BY b.height DESC"
-	countTxs      = "SELECT COUNT(b_sequence) AS row_count FROM transaction_host"
+	selectTxCount           = "SELECT total FROM transaction_count WHERE id = 1"
+	selectTx                = "SELECT hash, b_sequence FROM transaction_host WHERE hash = ?"
+	selectTxs               = "SELECT t.hash, b.ext_batch FROM transaction_host t JOIN batch_host b ON t.b_sequence = b.sequence ORDER BY b.height DESC"
+	countTxs                = "SELECT COUNT(b_sequence) AS row_count FROM transaction_host"
+	selectHistoricalTxCount = "SELECT total FROM historical_transaction_count WHERE id = 1"
 )
 
 // GetTransactionListing returns a paginated list of transactions in descending order
@@ -115,4 +116,15 @@ func GetTotalTxsQuery(db HostDB) (*big.Int, error) {
 		return nil, fmt.Errorf("failed to count number of transactions: %w", err)
 	}
 	return big.NewInt(int64(totalCount)), nil
+}
+
+// GetHistoricalTransactionCount returns the historical transaction count plus current count
+func GetHistoricalTransactionCount(db HostDB) (*big.Int, error) {
+	var historicalCount int
+	err := db.GetSQLDB().QueryRow(selectHistoricalTxCount).Scan(&historicalCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve historical transaction count: %w", err)
+	}
+
+	return big.NewInt(int64(historicalCount)), nil
 }

--- a/go/host/storage/init/postgres/003_init.sql
+++ b/go/host/storage/init/postgres/003_init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS historical_transaction_count
+(
+    id          SERIAL PRIMARY KEY,
+    total       INT  NOT NULL
+);
+
+INSERT INTO historical_transaction_count (id, total)
+VALUES (1, 0)
+    ON CONFLICT (id)
+DO NOTHING;

--- a/go/host/storage/init/postgres/postgres.go
+++ b/go/host/storage/init/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"embed"
 	"fmt"
 	"strings"
@@ -91,6 +92,8 @@ func registerPanicOnConnectionRefusedDriver(logger gethlog.Logger) string {
 			logger,
 			func(err error) bool {
 				return strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "shutting down")
+			},
+			func(conn driver.Conn) {
 			}),
 	)
 

--- a/go/host/storage/init/sqlite/003_init.sql
+++ b/go/host/storage/init/sqlite/003_init.sql
@@ -1,0 +1,8 @@
+create table if not exists historical_transaction_count
+(
+    id          int  NOT NULL PRIMARY KEY,
+    total       int  NOT NULL
+);
+
+insert into historical_transaction_count (id, total)
+values (1, 0) on CONFLICT (id) DO NOTHING;

--- a/go/host/storage/interfaces.go
+++ b/go/host/storage/interfaces.go
@@ -47,6 +47,8 @@ type BatchResolver interface {
 	FetchTotalTxCount() (*big.Int, error)
 	// FetchTotalTxsQuery returns the number of transactions in the DB. Required for e2e tests
 	FetchTotalTxsQuery() (*big.Int, error)
+	// FetchHistoricalTransactionCount returns the historical number of transactions on the testnet
+	FetchHistoricalTransactionCount() (*big.Int, error)
 	// FetchTransaction returns the transaction given its hash
 	FetchTransaction(hash gethcommon.Hash) (*common.PublicTransaction, error)
 	// FetchBatchTransactions returns a list of public transaction data within a given batch hash

--- a/go/host/storage/storage.go
+++ b/go/host/storage/storage.go
@@ -208,6 +208,10 @@ func (s *storageImpl) FetchTotalTxsQuery() (*big.Int, error) {
 	return hostdb.GetTotalTxsQuery(s.db)
 }
 
+func (s *storageImpl) FetchHistoricalTransactionCount() (*big.Int, error) {
+	return hostdb.GetHistoricalTransactionCount(s.db)
+}
+
 func (s *storageImpl) FetchTransaction(hash gethcommon.Hash) (*common.PublicTransaction, error) {
 	return hostdb.GetTransaction(s.db, hash)
 }

--- a/go/obsclient/obsclient.go
+++ b/go/obsclient/obsclient.go
@@ -170,6 +170,16 @@ func (oc *ObsClient) GetTotalTransactionCount() (int, error) {
 	return count, nil
 }
 
+// GetHistoricalTransactionCount returns the historical transaction count plus current count
+func (oc *ObsClient) GetHistoricalTransactionCount() (int, error) {
+	var count int
+	err := oc.rpcClient.Call(&count, rpc.GetHistoricalTxCount)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 // GetLatestRollupHeader returns the header of the latest rollup
 func (oc *ObsClient) GetLatestRollupHeader() (*common.RollupHeader, error) {
 	var header *common.RollupHeader

--- a/go/rpc/client.go
+++ b/go/rpc/client.go
@@ -29,6 +29,7 @@ const (
 	GetLatestRollupHeader    = "scan_getLatestRollupHeader"
 	GetTotalTxCount          = "scan_getTotalTransactionCount"
 	GetTotalTxsQuery         = "scan_getTotalTransactionsQuery"
+	GetHistoricalTxCount     = "scan_getHistoricalTransactionCount"
 	GetTotalContractCount    = "scan_getTotalContractCount"
 	GetPublicTransactionData = "scan_getPublicTransactionData"
 	GetBatchListing          = "scan_getBatchListing"

--- a/integration/simulation/network/socket.go
+++ b/integration/simulation/network/socket.go
@@ -130,6 +130,7 @@ func (n *networkOfSocketNodes) Create(simParams *params.SimParams, _ *stats.Stat
 		tenCfg.Host.RPC.WSPort = uint64(simParams.StartPort + integration.DefaultHostRPCWSOffset + i)
 		tenCfg.Host.Enclave.RPCAddresses = []string{fmt.Sprintf("127.0.0.1:%d", simParams.StartPort+integration.DefaultEnclaveOffset+i)}
 		tenCfg.Host.L1.WebsocketURL = fmt.Sprintf("ws://127.0.0.1:%d", simParams.StartPort+100)
+		tenCfg.Host.DB.HistoricalTxCount = 10 // needed to test historicalTxCount endpoint
 		tenCfg.Host.L1.L1BeaconUrl = beaconURL
 		tenCfg.Host.Log.Level = 1
 		tenCfg.Enclave.Log.Level = 1

--- a/integration/tenscan/tenscan_test.go
+++ b/integration/tenscan/tenscan_test.go
@@ -93,6 +93,21 @@ func TestTenscan(t *testing.T) {
 	assert.Equal(t, 200, statusCode)
 	assert.Equal(t, "{\"count\":5}", string(body))
 
+	statusCode, body, err = fasthttp.Get(nil, fmt.Sprintf("%s/count/transactions/historical/", serverAddress))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, statusCode)
+
+	type historicalCountRes struct {
+		Count int `json:"historicalCount"`
+	}
+	historicalCountObj := historicalCountRes{}
+	err = json.Unmarshal(body, &historicalCountObj)
+	assert.NoError(t, err)
+
+	// historical count should be config value (10) plus the additional 5 transactions added in the test
+	assert.GreaterOrEqual(t, historicalCountObj.Count, 15,
+		"Historical count should be >= current count")
+
 	statusCode, body, err = fasthttp.Get(nil, fmt.Sprintf("%s/items/batch/latest/", serverAddress))
 	assert.NoError(t, err)
 	assert.Equal(t, 200, statusCode)

--- a/testnet/launcher/docker.go
+++ b/testnet/launcher/docker.go
@@ -153,6 +153,7 @@ func (t *Testnet) Start() error {
 			faucet.WithTenNodeHost("validator-host"),
 			faucet.WithFaucetPrivKey("0x8dfb8083da6275ae3e4f41e3e8a8c19d028d32c9247e24530933782f2a05035b"),
 			faucet.WithDockerImage("testnetobscuronet.azurecr.io/obscuronet/faucet:latest"),
+			faucet.WithChainID(sequencerCfg.Network.ChainID),
 		),
 	)
 	if err != nil {

--- a/testnet/launcher/faucet/config.go
+++ b/testnet/launcher/faucet/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	faucetPort    int
 	faucetPrivKey string
 	dockerImage   string
+	chainID       int64
 }
 
 func NewFaucetConfig(opts ...Option) *Config {
@@ -49,5 +50,11 @@ func WithTenNodePort(i int) Option {
 func WithFaucetPort(i int) Option {
 	return func(c *Config) {
 		c.faucetPort = i
+	}
+}
+
+func WithChainID(chainID int64) Option {
+	return func(c *Config) {
+		c.chainID = chainID
 	}
 }

--- a/testnet/launcher/faucet/docker.go
+++ b/testnet/launcher/faucet/docker.go
@@ -30,6 +30,7 @@ func (n *DockerFaucet) Start() error {
 		"--pk", n.cfg.faucetPrivKey,
 		"--jwtSecret", "someKey",
 		"--serverPort", fmt.Sprintf("%d", n.cfg.faucetPort),
+		"--chainID", fmt.Sprintf("%d", n.cfg.chainID),
 	}
 
 	_, err := docker.StartNewContainer("faucet", n.cfg.dockerImage, cmds, []int{n.cfg.faucetPort}, nil, nil, nil, false)

--- a/testnet/launcher/l1contractdeployer/config.go
+++ b/testnet/launcher/l1contractdeployer/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	SequencerHostAddress string
 	DebugEnabled         bool
 	EtherscanAPIKey      string
+	MaxGasGwei           string
+	CheckGasPrice        string
 }
 
 func NewContractDeployerConfig(tenCfg *config.TenConfig) *Config {
@@ -20,5 +22,7 @@ func NewContractDeployerConfig(tenCfg *config.TenConfig) *Config {
 		SequencerHostAddress: tenCfg.Deployment.L1Deploy.InitialSeqAddress,
 		DebugEnabled:         tenCfg.Deployment.DebugEnabled,
 		EtherscanAPIKey:      tenCfg.Deployment.L1Deploy.EtherscanAPIKey,
+		MaxGasGwei:           tenCfg.Deployment.L1Deploy.MaxGasGwei,
+		CheckGasPrice:        tenCfg.Deployment.L1Deploy.CheckGasPrice,
 	}
 }

--- a/testnet/launcher/l1contractdeployer/docker.go
+++ b/testnet/launcher/l1contractdeployer/docker.go
@@ -45,6 +45,8 @@ func (n *ContractDeployer) Start() error {
 	envs := map[string]string{
 		"SEQUENCER_HOST_ADDRESS": n.cfg.SequencerHostAddress,
 		"ETHERSCAN_API_KEY":      n.cfg.EtherscanAPIKey,
+		"MAX_GAS_GWEI":           n.cfg.MaxGasGwei,
+		"CHECK_GAS_PRICE":        n.cfg.CheckGasPrice,
 		"NETWORK_JSON": fmt.Sprintf(`
 {
         "layer1" : {

--- a/testnet/launcher/l1contractdeployer/git_config.go
+++ b/testnet/launcher/l1contractdeployer/git_config.go
@@ -15,8 +15,6 @@ import (
 
 const (
 	_githubRepoUrl = "github.com/ten-protocol/ten-apps"
-	// path to the file in the repo (env has to be substituted with the testnet env)
-	_githubFilePath = "nonprod-argocd-config/apps/envs/%s/valuesFile/l1-values.yaml"
 )
 
 // GitL1ConfigWrapper matches a yaml file structure in the ten-apps config repo which looks like this:
@@ -62,7 +60,12 @@ func StoreNetworkCfgInGithub(githubPAT string, networkName string, networkConfig
 		return fmt.Errorf("failed to clone repo: %w", err)
 	}
 
-	relFilePath := fmt.Sprintf(_githubFilePath, networkName)
+	// Choose the correct config directory based on network environment
+	configDir := "nonprod-argocd-config"
+	if networkName == "mainnet" {
+		configDir = "prod-argocd-config"
+	}
+	relFilePath := fmt.Sprintf("%s/apps/envs/%s/valuesFile/l1-values.yaml", configDir, networkName)
 	absFilePath := filepath.Join(tmpDir, relFilePath)
 
 	f, err := os.ReadFile(absFilePath)

--- a/tools/tenscan/backend/tenscan_backend.go
+++ b/tools/tenscan/backend/tenscan_backend.go
@@ -48,6 +48,10 @@ func (b *Backend) GetTotalTransactionCount() (int, error) {
 	return b.obsClient.GetTotalTransactionCount()
 }
 
+func (b *Backend) GetHistoricalTransactionCount() (int, error) {
+	return b.obsClient.GetHistoricalTransactionCount()
+}
+
 func (b *Backend) GetLatestRollupHeader() (*common.RollupHeader, error) {
 	return b.obsClient.GetLatestRollupHeader()
 }

--- a/tools/tenscan/backend/webserver/webserver_routes_counts.go
+++ b/tools/tenscan/backend/webserver/webserver_routes_counts.go
@@ -10,6 +10,7 @@ import (
 func routeCounts(r *gin.Engine, server *WebServer) {
 	r.GET("/count/contracts/", server.getTotalContractCount)
 	r.GET("/count/transactions/", server.getTotalTransactionCount)
+	r.GET("/count/transactions/historical/", server.getHistoricalTransactionCount)
 }
 
 func (w *WebServer) getTotalContractCount(c *gin.Context) {
@@ -30,4 +31,14 @@ func (w *WebServer) getTotalTransactionCount(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"count": count})
+}
+
+func (w *WebServer) getHistoricalTransactionCount(c *gin.Context) {
+	count, err := w.backend.GetHistoricalTransactionCount()
+	if err != nil {
+		errorHandler(c, fmt.Errorf("unable to execute request %w", err), w.logger)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"historicalCount": count})
 }

--- a/tools/tenscan/frontend/api/transactions.ts
+++ b/tools/tenscan/frontend/api/transactions.ts
@@ -29,6 +29,13 @@ export const fetchTransactionCount = async (): Promise<TransactionCount> => {
   });
 };
 
+export const fetchHistoricalTransactionCount = async (): Promise<TransactionCount> => {
+  return await httpRequest<TransactionCount>({
+    method: "get",
+    url: pathToUrl(apiRoutes.getHistoricalTransactionCount),
+  });
+};
+
 export const fetchEtherPrice = async (): Promise<Price> => {
   return await httpRequest<Price>({
     method: "get",

--- a/tools/tenscan/frontend/src/routes/index.ts
+++ b/tools/tenscan/frontend/src/routes/index.ts
@@ -23,6 +23,7 @@ export const apiRoutes = {
   // **** TRANSACTIONS ****
   getTransactions: "/items/transactions/",
   getTransactionCount: "/count/transactions/",
+  getHistoricalTransactionCount: "/count/transactions/historical/",
   getTransactionByHash: "/items/transaction/:hash",
 
   getEtherPrice:


### PR DESCRIPTION
### Why this change is needed

The host side rollup estimation is still a little off because its not linear for empty batches vs batches with txs. When the host adds batches we store the `tx_size` as `len(batch.EncryptedTxBlob` which is ~41b for an empty batch, we then apply a compression factor of 0.1 on the host side calculation. The logs show the metadata per empty batch compresses more in reality. 

* Empty batch metadata compresses raw size 5.9b to 0.28b ~4.8% 
* The current calculation compresses 41b to 4b at ~9% 

This leaves lots of space in the rollup, producing them more frequently and wastes gas. 

There are two options: 
1. Apply a larger compression estimation on the host which assumes linear compression between empty vs non-empty batches
2. Reduce the tx_size on the host for empty batches to account for the slightly different compression ratio 

This PR shows option 2 but option 1 would just be to change `batchCompressionFactor` in `service.go` to `0.07`.

### What changes were made as part of this PR

* Reduce host tx_size for empty batches. 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


