### PR TITLE
Statedb.val is nullable, remove  unused `executor.lastExecutedBatch`

### DIFF
--- a/go/enclave/storage/init/edgelessdb/003_statedb_val_nullable.sql
+++ b/go/enclave/storage/init/edgelessdb/003_statedb_val_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tendb.statedb32 MODIFY COLUMN val mediumblob NULL;
+ALTER TABLE tendb.statedb64 MODIFY COLUMN val mediumblob NULL;

--- a/go/enclave/storage/init/sqlite/001_init.sql
+++ b/go/enclave/storage/init/sqlite/001_init.sql
@@ -2,7 +2,7 @@ create table if not exists statedb32
 (
     id  INTEGER PRIMARY KEY AUTOINCREMENT,
     ky  binary(32) UNIQUE NOT NULL,
-    val mediumblob      NOT NULL
+    val mediumblob
 );
 create index IDX_KY32 on statedb32 (ky);
 
@@ -10,7 +10,7 @@ create table if not exists statedb64
 (
     id  INTEGER PRIMARY KEY AUTOINCREMENT,
     ky  varbinary(64) UNIQUE NOT NULL,
-    val mediumblob           NOT NULL
+    val mediumblob
 );
 create index IDX_KY64 on statedb64 (ky);
 


### PR DESCRIPTION
### Why this change is needed

to fix bugs

### What changes were made as part of this PR

- Statedb.val is nullable
- remove  unused `executor.lastExecutedBatch`

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


