### PR TITLE
get the token from path in JSON-RPC

### DIFF
--- a/lib/gethfork/node/extract_params_handler.go
+++ b/lib/gethfork/node/extract_params_handler.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/ten-protocol/go-ten/lib/gethfork/rpc"
 )
@@ -24,7 +25,41 @@ func newHTTPParamsHandler(exposedParam string, next http.Handler) http.Handler {
 func (handler *httpParamsHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	val := q.Get(handler.exposedParam)
+	if val == "" {
+		// Attempt to extract token from path as /v1/<TOKEN>
+		// Do not alter routing; only read the segment.
+		// Expected segments: ["", "v1", "<TOKEN>", ...]
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) >= 3 && parts[1] == "v1" {
+			candidate := parts[2]
+			if isLikelyHexToken(candidate) {
+				val = candidate
+			}
+		}
+	}
 	ctx := context.WithValue(r.Context(), rpc.GWTokenKey{}, val)
 	handler.next.ServeHTTP(out, r.WithContext(ctx))
 	handler.next.ServeHTTP(out, r)
+}
+
+// isLikelyHexToken performs a lightweight validation for a user token
+// Accepts both 0x-prefixed (42 chars) and non-prefixed (40 chars) lowercase/uppercase hex
+func isLikelyHexToken(s string) bool {
+	n := len(s)
+	if n != 40 && n != 42 {
+		return false
+	}
+	if n == 42 {
+		if !(strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X")) {
+			return false
+		}
+		s = s[2:]
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
### Why this change is needed

Some wallets (for example Trust wallet) don't support query parameters in the RPC url. We need to make a change in the gateway to also support tokens as part of the path `v1/<TOKEN>` and not only as query params: `v1/?token=<TOKEN>`.


### What changes were made as part of this PR

Added path-token support in the shared HTTP params middleware so JSON-RPC accepts both query and path tokens.


The solution is not ideal as we are modifying code inside the gethfork, but there are no good alternatives:

- inside wallet extension we (without touching gethfork) cannot enable path tokens for JSON-RPC. The JSON-RPC stack reads the token from the request context set by the shared middleware; wallet extension cannot intercept and pass control onward to JSON-RPC after rewriting because theres no “next” handler exposed.

- a catch‑all /v1/ route inside wallet extension would shadow both the JSON-RPC handler and your REST endpoints unless we also implemented full delegation logic, which is effectively a major refactor or a reverse proxy.

- usually a nginx/traefik can do that, but due to the requirement that we run everything inside an enclave this is not an option.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


