### PR TITLE
minor: fix sepolia faucet url and add comment for debug noise confusion

### DIFF
--- a/go/enclave/components/sigverifier.go
+++ b/go/enclave/components/sigverifier.go
@@ -68,6 +68,7 @@ func (sigChecker *SignatureValidator) verifyForSequencer(seqID common.EnclaveID,
 
 	err = signature.VerifySignature(attestedEnclave.PubKey, hash.Bytes(), sig)
 	if err != nil {
+		// this is only debug level as we loop through all sequencers and expect to see this error often in HA setup
 		sigChecker.logger.Debug("Could not verify signature", "sequencerID", seqID, log.ErrKey, err)
 		return fmt.Errorf("could not verify the signature of batch or rollup %s against the stored sequencer enclave key: %s", hash.Hex(), seqID.Hex())
 	}

--- a/integration/networktest/env/network_setup.go
+++ b/integration/networktest/env/network_setup.go
@@ -22,7 +22,7 @@ func SepoliaTestnet(opts ...TestnetEnvOption) networktest.Environment {
 	connector := newTestnetConnector(
 		"http://erpc.sepolia-testnet.ten.xyz:80", // this is actually a validator...
 		[]string{"http://erpc.sepolia-testnet.ten.xyz:80"},
-		"http://sepolia-testnet-faucet.uksouth.azurecontainer.io/fund/eth",
+		"https://sepolia-faucet.ten.xyz/fund/eth",
 		"wss://ethereum-sepolia-rpc.publicnode.com",
 		"https://testnet.ten.xyz",  //"https://rpc.dexynth-gateway.ten.xyz",
 		"wss://testnet.ten.xyz:81", // "wss://rpc.dexynth-gateway.ten.xyz:81",


### PR DESCRIPTION
### Why this change is needed

faucet URL was wrong for network tests, and when we're at debug level the 'Could not verify signature' log msg can be unnerving (I spent time investigating unnecessarily).

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


