### PR TITLE
Guard against zero chain ID 

### DIFF
--- a/go/enclave/core/utils.go
+++ b/go/enclave/core/utils.go
@@ -98,7 +98,11 @@ func LogMethodDuration(logger gethlog.Logger, stopWatch *measure.Stopwatch, msg 
 
 // GetExternalTxSigner returns the address that signed a transaction
 func GetExternalTxSigner(tx *types.Transaction) (gethcommon.Address, error) {
-	from, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
+	chainID := tx.ChainId()
+	if chainID == nil || chainID.Int64() == 0 {
+		return gethcommon.Address{}, fmt.Errorf("cannot get external tx signer for nil or 0 chain ID")
+	}
+	from, err := types.Sender(types.LatestSignerForChainID(chainID), tx)
 	if err != nil {
 		return gethcommon.Address{}, fmt.Errorf("could not recover sender for transaction. Cause: %w", err)
 	}


### PR DESCRIPTION
### Why this change is needed

Val01 was falling over when someone submitted a transaction with zero chain ID

```
INFO [10-16|17:58:41.892] Received new p2p batch                   node_id=0 cmp=enclave batch_height=693,710 batch=0xd3d58173f83ffcd9b40c943c612815c66bebbc1c5b1dea31ada8fde215d31b1b l1=0xf299db881359050994d7b6184a547b02a14c90ca61622b9ad5e83d0d6129f65b
panic: invalid chainID 0
goroutine 6236 [running]:
github.com/ethereum/go-ethereum/core/types.newModernSigner(0x7f0601913417?, 0x18?)
```

### What changes were made as part of this PR

* Check for zero or nil chain ID before fetching signer from geth

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


