### PR TITLE
GH action for geth hard fork notification

### DIFF
--- a/.github/workflows/geth-release-notification.yml
+++ b/.github/workflows/geth-release-notification.yml
@@ -1,0 +1,73 @@
+name: Geth Hard Fork Alert
+
+on:
+  schedule:
+    # Every day at 09:00 UTC
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch latest go-ethereum release
+        id: latest
+        run: |
+          set -euo pipefail
+          curl -sSL https://api.github.com/repos/ethereum/go-ethereum/releases/latest > latest.json
+          echo "id=$(jq -r .id latest.json)" >> "$GITHUB_OUTPUT"
+          echo "name=$(jq -r .name latest.json)" >> "$GITHUB_OUTPUT"
+          echo "url=$(jq -r .html_url latest.json)" >> "$GITHUB_OUTPUT"
+          echo "body<<__EOF__" >> "$GITHUB_OUTPUT"
+          jq -r '.body // ""' latest.json >> "$GITHUB_OUTPUT"
+          echo "__EOF__" >> "$GITHUB_OUTPUT"
+
+      - name: Get last successful run timestamp
+        id: lastrun
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          last_success="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?per_page=50" \
+            | jq -r --arg name "${GITHUB_WORKFLOW}" --argjson current ${GITHUB_RUN_ID} '
+                .workflow_runs
+                | map(select(.name == $name and .conclusion == "success" and .id < $current))
+                | sort_by(.run_started_at) | last // empty
+                | .updated_at // empty
+            ')"
+          echo "last_success=$last_success" >> "$GITHUB_OUTPUT"
+
+      - name:  Check if newer than last release
+        id: decide
+        run: |
+          set -euo pipefail
+          pub=$(jq -r .published_at latest.json)
+          last="${{ steps.lastrun.outputs.last_success }}"
+          should_post=false
+          if [ -z "$last" ] || [ "$pub" \> "$last" ]; then
+            should_post=true
+          fi
+          echo "should_post=$should_post" >> "$GITHUB_OUTPUT"
+          echo "Publish date: $pub | Last run: ${last:-<none>} | Post? $should_post"
+
+      - name: Post hard-fork notification to Discord
+        if: steps.decide.outputs.should_post == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          title="${{ steps.latest.outputs.name }}"
+          body="${{ steps.latest.outputs.body }}"
+          url="${{ steps.latest.outputs.url }}"
+
+          if printf '%s\n%s\n' "$title" "$body" | grep -iq '\bhard[[:space:]]*fork\b'; then
+            message="Hard fork mentioned in release ${title}! ${url}"
+            payload=$(jq -n --arg content "$message" '{content: $content}')
+            curl -sS -H "Content-Type: application/json" -X POST \
+              -d "$payload" "$DISCORD_WEBHOOK_URL" \
+              -o /dev/stderr -w "\nHTTP %{http_code}\n"
+          else
+            echo "No 'hard fork' mention — skipping post."
+          fi


### PR DESCRIPTION
### Why this change is needed

Don't want to get blindsided again

### What changes were made as part of this PR

* New workflow that will check the releases once daily and filter out if theres a new mention of "hard fork". If there is, we post a notification to Discord 

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


