### PR TITLE
Geth fork script tweaks

### DIFF
--- a/.github/workflows/geth-release-notification.yml
+++ b/.github/workflows/geth-release-notification.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Match any standalone "fork" (case-insensitive)
           if printf '%s\n%s\n' "$title" "$body" | grep -iq '\bfork\b'; then
-            payload=$(jq -n --arg content "Fork mentioned in ${title} release. Please take a look or pay the iron price ${url}" '{content: $content}')
+            payload=$(jq -n --arg content "Fork mentioned in ${title} release. Please take a look or pay the iron price <#945360340613484684> ${url}" '{content: $content}')
             curl -sS -H "Content-Type: application/json" -X POST \
               -d "$payload" "$DISCORD_WEBHOOK_URL" \
               -o /dev/stderr -w "\nHTTP %{http_code}\n"


### PR DESCRIPTION
### Why this change is needed

Geth don't always refer to "hard fork"

### What changes were made as part of this PR

* Change filter to `fork` instead of `hard fork` so we don't miss anything

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


