### PR TITLE
Fix postgres connection issue

### DIFF
--- a/go/host/storage/init/postgres/postgres.go
+++ b/go/host/storage/init/postgres/postgres.go
@@ -60,7 +60,7 @@ func CreatePostgresDBConnection(baseURL string, dbName string, logger gethlog.Lo
 
 	dbURL = fmt.Sprintf("%s%s", baseURL, dbName)
 
-	// open conneciton to target DB
+	// open connection to target DB
 	db, err := sqlx.Open("postgres", dbURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to PostgreSQL database %s: %v", dbName, err)


### PR DESCRIPTION
### Why this change is needed

`pq: remaining connection slots are reserved for azure replication users"`

### What changes were made as part of this PR

* Close the connection to the default `postgres` DB - it was being left open
* Change max connections to 75
* Reduce max idle connections
* Reduce lifetime of max idle connections

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


