### PR TITLE
enclave: clarity on errors causing 'conflict'

### DIFF
--- a/go/host/l2/batchrepository.go
+++ b/go/host/l2/batchrepository.go
@@ -218,23 +218,26 @@ func (r *Repository) AddBatch(batch *common.ExtBatch) error {
 	defer r.batchLock.Unlock()
 
 	_, err := r.storage.FetchBatch(batch.Hash())
-	// we found the exact same batch
+	// no error means we found the exact same batch (same hash)
 	if err == nil {
 		return errutil.ErrAlreadyExists
 	}
+	// there was an error, it's probably 'not found' but if it is unexpected error then we return it
 	if !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("error checking for existing batch by hash: %w", err)
 	}
 
 	_, err = r.storage.FetchBatchBySeqNo(batch.SeqNo().Uint64())
-	// we found a batch with the same seq no, but different hash
+	// no error means we found a batch with the same seq no, but different hash - that is a conflict, do not continue
 	if err == nil {
 		return errutil.ErrConflict
 	}
+	// there was an error, it's probably 'not found' but again we check, if it is an unexpected err then return it
 	if !errors.Is(err, errutil.ErrNotFound) {
 		return fmt.Errorf("error checking for existing batch by seqno: %w", err)
 	}
 
+	// there is no batch with this hash or sequencer number, safe to add it to the database
 	err = r.storage.AddBatch(batch)
 	if err != nil {
 		return fmt.Errorf("could not add batch: %w", err)


### PR DESCRIPTION
### Why this change is needed

We have seen errors like this on the validators when there are ongoing issues in sepolia. It seems to be a weird race condition or something because I can see it's just reprocessing the batch with the same hash so it should just reject it as a duplicate but the lookup by hash  must be failing and we can't see why.

`Batch conflict detected when adding batch to L2 repo - enclave corrupted node_id=0xF7E8fb5b78dA9e37F1Ed210196e5EddbB7f868Fd cmp=host enclave_id=0x4467bE1560be413ce6Fd0d7F6902Dc265cBb88C9 batch=0xebdde2e8fe253123b332eeae33e4cb4053d8f37c6c5fd85434e2b325453f968a err=conflict`

### What changed

Verify the error when lookups fails is a 'not found' error instead of assuming it is. If it's an unexpected error then fail with that.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


