### PR TITLE
Fix geth notifications

### DIFF
--- a/.github/workflows/geth-release-notification.yml
+++ b/.github/workflows/geth-release-notification.yml
@@ -19,7 +19,7 @@ jobs:
           echo "name=$(jq -r .name latest.json)" >> "$GITHUB_OUTPUT"
           echo "url=$(jq -r .html_url latest.json)" >> "$GITHUB_OUTPUT"
 
-      # Check release ID using the cache. If cache-hit=true, we've already posted.
+      # Check release ID using the cache
       - name: Check if this release was already notified
         id: cache
         uses: actions/cache@v4
@@ -27,8 +27,7 @@ jobs:
           path: .release-notify
           key: geth-release-${{ steps.latest.outputs.id }}
 
-      # Prepare something to store in the cache for this ID (saved automatically if cache was a miss)
-      - name: Prepare cache payload
+      - name: Prepare cache dir
         run: |
           set -euo pipefail
           mkdir -p .release-notify


### PR DESCRIPTION
### Why this change is needed

Duplicate notifications for releases

### What changes were made as part of this PR

* Last successful run check was brittle so we cache the last posted release ID and check for this instead

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


