### PR TITLE
Include base ref in the repository dispatch

### DIFF
--- a/.github/workflows/on-merged-pr.yml
+++ b/.github/workflows/on-merged-pr.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - name: 'Trigger obscuro-test local testnet tun'
         run: |
-          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/ten-protocol/ten-test/dispatches --data '{ "event_type": "merged_pull_request", "client_payload": { "number": ${{ github.event.number }}, "owner": "${{ github.event.pull_request.user.login }}" } }'
+          curl -XPOST -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" -H "Accept:application/vnd.github" -H "Content-Type:application/json" https://api.github.com/repos/ten-protocol/ten-test/dispatches --data '{ "event_type": "merged_pull_request", "client_payload": { "number": ${{ github.event.number }}, "owner": "${{ github.event.pull_request.user.login }}", "base_branch": "${{ github.event.pull_request.base.ref }}" } }'
          


### PR DESCRIPTION
### Why this change is needed

When a PR is merged the repository dispatch is used to trigger running the e2e tests. At the moment the trigger always runs the tests against main ... it would be good to have the option to extract the target branch, and if a release branch, run the tests against that release branch. 


