### PR TITLE
feat: Add granular step skipping for k8s consolidated workflow testing

### DIFF
--- a/.github/workflows/manual-deploy-k8s-consolidated.yml
+++ b/.github/workflows/manual-deploy-k8s-consolidated.yml
@@ -46,12 +46,6 @@ on:
         type: string
         default: 'log_level=3,max_gas_gwei=1.5,sync_timeout=10m,use_azure_hsm=no'
 
-      skip_steps:
-        description: 'Skip specific steps for testing (comma-separated: l1-deployment, l2-trigger, image-build, config-update, argocd-delete)'
-        required: false
-        type: string
-        default: ''
-
       destructive_options:
         description: 'Destructive deployment options (format: node_selectors=sequencer=node1,validator-01=node2,validator-02=node3,gateway=node4|additional_apps=gateway,tools,postgres-client)'
         required: false
@@ -364,7 +358,7 @@ jobs:
   # ============================================================================
   update-ten-apps-config:
     needs: [validate-inputs, build-images]
-    if: ${{ always() && !contains(github.event.inputs.skip_steps, 'config-update') }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.testnet_type }}
@@ -639,8 +633,7 @@ jobs:
     needs: [validate-inputs, deploy-l1-contracts]
     if: |
       needs.validate-inputs.outputs.IS_DESTRUCTIVE == 'true' &&
-      (needs.deploy-l1-contracts.result == 'success' || needs.deploy-l1-contracts.result == 'skipped') &&
-      !contains(github.event.inputs.skip_steps, 'argocd-delete')
+      (needs.deploy-l1-contracts.result == 'success' || needs.deploy-l1-contracts.result == 'skipped')
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.testnet_type }}
@@ -1081,8 +1074,7 @@ jobs:
       - name: 'Trigger L2 contract deployment workflow'
         if: |
           needs.validate-inputs.outputs.IS_DESTRUCTIVE == 'true' &&
-          needs.wait-argocd-healthy.result == 'success' &&
-          !contains(github.event.inputs.skip_steps, 'l2-trigger')
+          needs.wait-argocd-healthy.result == 'success'
         run: |
           echo "🚀 Triggering L2 contract deployment workflow..."
           echo "Branch/Ref: ${{ github.ref_name }}"
@@ -1096,11 +1088,3 @@ jobs:
           echo "✅ L2 deployment workflow triggered on branch: ${{ github.ref_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Display skipped steps'
-        if: github.event.inputs.skip_steps != ''
-        run: |
-          echo "⚠️  TESTING MODE: The following steps were SKIPPED:"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "${{ github.event.inputs.skip_steps }}" | tr ',' '\n' | sed 's/^/  ✋ /'
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary
Add flexible `skip_steps` parameter and consolidate advanced configuration options to reduce workflow inputs from 11 to 8 (within GitHub's 10 input limit).

## Changes
- Consolidated optional parameters into single `advanced_config` parameter:
  - `log_level` (default: 3)
  - `max_gas_gwei` (default: 1.5)
  - `sync_timeout` (default: 10m)
  - `use_azure_hsm` (default: no)
  
- Added `skip_steps` parameter for granular step testing:
  - `l1-deployment`: Skip L1 contract deployment
  - `l2-trigger`: Skip L2 deployment workflow trigger
  - `image-build`: Skip Docker image building
  - `config-update`: Skip ten-apps config update
  - `argocd-delete`: Skip ArgoCD resource deletion

- Added parsing steps to extract config values from `advanced_config` string

## Use Cases

**Test only sync + health check (skip L1/L2):**
```
skip_steps: l1-deployment,l2-trigger
advanced_config: log_level=3,max_gas_gwei=1.5,sync_timeout=10m,use_azure_hsm=no
```

**Build and config update without deployment:**
```
skip_steps: l1-deployment,l2-trigger,argocd-delete
```

**Full production deployment (use defaults):**
```
skip_steps: 
advanced_config: log_level=3,max_gas_gwei=1.5,sync_timeout=10m,use_azure_hsm=no
```

## Input Reduction
- Before: 11 inputs (exceeded GitHub's 10 input limit)
- After: 8 inputs (compliant with limits)

Inputs after consolidation:
1. testnet_type (required)
2. deployment_strategy (required)
3. image_build (required)
4. image_tag (optional)
5. confirmation (optional)
6. skip_steps (optional)
7. advanced_config (optional)
8. destructive_options (optional)

## Test Plan
- [ ] Verify workflow runs with default advanced_config
- [ ] Test skip_steps with individual steps
- [ ] Test with multiple comma-separated skip steps
- [ ] Verify L1/L2 skipping works correctly
- [ ] Test advanced_config parsing with custom values
- [ ] Verify Azure HSM option works via advanced_config