### PR TITLE
fix: respect PCCS_URL environment variable in entry.sh (v1.6.1)

### DIFF
--- a/go/enclave/main/entry.sh
+++ b/go/enclave/main/entry.sh
@@ -11,7 +11,7 @@ if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 
-PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
+PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
 echo "PCCS_URL: ${PCCS_URL}"
 
 apt-get install -qq libsgx-dcap-default-qpl


### PR DESCRIPTION
## Summary
The enclave entry.sh script was hardcoding the PCCS_URL to Azure's global cache, ignoring any environment variable set in the container. This prevented deployments from using custom PCCS services (e.g., local sgx-pccs for bare-metal SGX environments).

## Changes
Changed line 14 in `go/enclave/main/entry.sh` from:
```bash
PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
```

To use bash parameter expansion:
```bash
PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
```

## Impact
- **Backward Compatible**: Existing deployments continue to use Azure's PCCS URL as the default
- **New Capability**: Allows PCCS_URL to be overridden via Kubernetes environment variables or docker-compose
- **Use Case**: Enables bare-metal SGX deployments (e.g., OVH, on-prem) to use local PCCS services for attestation

## Testing
- Helm chart configuration: Set `enclave.edb.pccsUrl` and `config.enclave.pccsUrl` in values.yaml
- Environment variable is now properly respected and written to `/etc/sgx_default_qcnl.conf`

## Related
- Based on v1.6.1 release tag
- Can be cherry-picked to main and releases/v1.7 after merge