### PR TITLE
never panic when printing audit message

### DIFF
--- a/tools/walletextension/services/utils.go
+++ b/tools/walletextension/services/utils.go
@@ -51,7 +51,16 @@ func Audit(services *Services, level LogLevel, msg string, params ...any) {
 		}
 	}
 
-	formattedMsg := fmt.Sprintf(msg, safeParams...)
+	var formattedMsg string
+	// Recover from panics caused by nested nil pointers (e.g., **hexutil.Big) - not nested nil pointers are handled by the safeParams loop above
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				formattedMsg = fmt.Sprintf("[audit format error: %v] %s", r, msg)
+			}
+		}()
+		formattedMsg = fmt.Sprintf(msg, safeParams...)
+	}()
 
 	switch level {
 	case CriticalLevel:


### PR DESCRIPTION
### Why this change is needed

When fmt.Sprintf() formats a struct containing a nil *hexutil.Big, it calls the String() method, which in turn calls EncodeBig() on a nil pointer, causing a segfault.

### What changes were made as part of this PR

I wrapped fmt.Sprintf() in an anon function with recover() to catch panics during formatting. If formatting fails, a safe fallback message is logged instead of crashing the application.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


