### PR TITLE
Host: get rid of noisy forking error

### DIFF
--- a/go/host/enclave/guardian.go
+++ b/go/host/enclave/guardian.go
@@ -585,7 +585,7 @@ func (g *Guardian) submitL1Block(block *types.Header, isLatest bool) error {
 				// check if the block doesn't exist yet (NotFound) vs a real error
 				if errors.Is(err, ethereum.NotFound) {
 					// This is very common, when the next block hasn't been produced yet on L1
-					// return false (not processed) with no error, so the caller will retry without logging a warning
+					// return with no error, so the caller will retry without logging a warning
 					g.logger.Debug("Next block not yet available after skipping already-processed block, will retry",
 						"skippedBlock", block.Hash(), "nextHeight", nextHeight)
 					return nil


### PR DESCRIPTION
### Why this change is needed

This error happens a lot but it is just noise. It happens when we slip into catch-up mode because of the timing of block arrivals and then when it catches up and the next block is not found we hit this.

`could not catch up with L1               node_id=0xEEd55Ff2853b004A82D2b4CE97B038D712216dCa cmp=host enclave_id=0xFFC6fEf37a460Ae32e9Ee19373CBdfb29dF099F7 err="failed to fetch next block after forking block 0x81da1eca579018fa73574d3902d912f7078807e37b4ef892685deeee7e2f85d3: not found"`

### What changes were made as part of this PR

Make sure we log when it's not a not found error, but otherwise handle it quietly.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


