### PR TITLE
Debug logging to check signature is being verified

### DIFF
--- a/go/enclave/components/sigverifier.go
+++ b/go/enclave/components/sigverifier.go
@@ -72,6 +72,7 @@ func (sigChecker *SignatureValidator) verifyForSequencer(seqID common.EnclaveID,
 		sigChecker.logger.Debug("Could not verify signature", "sequencerID", seqID, log.ErrKey, err)
 		return fmt.Errorf("could not verify the signature of batch or rollup %s against the stored sequencer enclave key: %s", hash.Hex(), seqID.Hex())
 	}
+	sigChecker.logger.Debug("Sequencer signature verified", "sequencerID", seqID, log.ErrKey, err)
 
 	return nil
 }


### PR DESCRIPTION
### Why this change is needed

We have a log message to indicate if it fails which it will if we have a HA sequencer, so we need to check we do actually verify the signature at some point. 

### What changes were made as part of this PR

* Log a debug message if verification is successful

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


