### PR TITLE
add ordering to services

### DIFF
--- a/go/host/container/host_container.go
+++ b/go/host/container/host_container.go
@@ -196,7 +196,7 @@ func NewHostContainer(cfg *hostconfig.HostConfig, services *host.ServicesRegistr
 				},
 			})
 		}
-		services.RegisterService(hostcommon.FilterAPIServiceName, filterAPI.NewHeadsService)
+		services.RegisterService(hostcommon.FilterAPIServiceName, filterAPI.NewHeadsService, 60)
 	}
 	return hostContainer
 }

--- a/go/host/host.go
+++ b/go/host/host.go
@@ -100,8 +100,8 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 	l2Repo := l2.NewBatchRepository(config, hostServices, hostStorage, logger)
 	subsService := events.NewLogEventManager(hostServices, logger)
 	l2Repo.SubscribeValidatedBatches(batchListener{newHeads: host.newHeads})
-	hostServices.RegisterService(hostcommon.P2PName, p2p)
-	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo)
+	hostServices.RegisterService(hostcommon.P2PName, p2p, 70)
+	hostServices.RegisterService(hostcommon.L1DataServiceName, l1Repo, 20)
 	maxWaitForL1Receipt := 6 * config.L1BlockTime   // wait ~10 blocks to see if tx gets published before retrying
 	retryIntervalForL1Receipt := config.L1BlockTime // retry ~every block
 	retryIntervalForBlobReceipt := config.L1RollupRetryDelay
@@ -122,10 +122,10 @@ func NewHost(config *hostconfig.HostConfig, hostServices *ServicesRegistry, p2p 
 		l1ChainCfg,
 	)
 
-	hostServices.RegisterService(hostcommon.L1PublisherName, l1Publisher)
-	hostServices.RegisterService(hostcommon.L2BatchRepositoryName, l2Repo)
-	hostServices.RegisterService(hostcommon.EnclaveServiceName, enclService)
-	hostServices.RegisterService(hostcommon.LogSubscriptionServiceName, subsService)
+	hostServices.RegisterService(hostcommon.L1PublisherName, l1Publisher, 50)
+	hostServices.RegisterService(hostcommon.L2BatchRepositoryName, l2Repo, 10)
+	hostServices.RegisterService(hostcommon.EnclaveServiceName, enclService, 30)
+	hostServices.RegisterService(hostcommon.LogSubscriptionServiceName, subsService, 40)
 
 	var prof *profiler.Profiler
 	if config.ProfilerEnabled {
@@ -151,11 +151,9 @@ func (h *host) Start() error {
 	h.validateConfig()
 
 	// start all registered services
-	for name, service := range h.services.All() {
-		err := service.Start()
-		if err != nil {
-			return fmt.Errorf("could not start service=%s: %w", name, err)
-		}
+	err := h.services.Start()
+	if err != nil {
+		return fmt.Errorf("could not start services. Cause: %w", err)
 	}
 
 	tomlConfig, err := toml.Marshal(h.config)
@@ -203,10 +201,9 @@ func (h *host) Stop() error {
 	h.logger.Info("Host received a stop command. Attempting shutdown...")
 
 	// stop all registered services
-	for name, service := range h.services.All() {
-		if err := service.Stop(); err != nil {
-			h.logger.Error("Failed to stop service", "service", name, log.ErrKey, err)
-		}
+	err := h.services.Stop()
+	if err != nil {
+		h.logger.Error("Failed to stop services", log.ErrKey, err)
 	}
 
 	if err := h.storage.Close(); err != nil {

--- a/go/host/servicelocator.go
+++ b/go/host/servicelocator.go
@@ -5,31 +5,55 @@ import (
 	hostcommon "github.com/ten-protocol/go-ten/go/common/host"
 )
 
+type serviceEntry struct {
+	name    string
+	service hostcommon.Service
+	order   int
+}
+
 type ServicesRegistry struct {
-	services map[string]hostcommon.Service
-	logger   log.Logger
+	orderedServices []serviceEntry
+	serviceIndex    map[string]hostcommon.Service
+	logger          log.Logger
 }
 
 func NewServicesRegistry(logger log.Logger) *ServicesRegistry {
 	return &ServicesRegistry{
-		services: make(map[string]hostcommon.Service),
-		logger:   logger,
+		orderedServices: make([]serviceEntry, 0),
+		serviceIndex:    make(map[string]hostcommon.Service),
+		logger:          logger,
 	}
 }
 
 func (s *ServicesRegistry) All() map[string]hostcommon.Service {
-	return s.services
+	return s.serviceIndex
 }
 
-func (s *ServicesRegistry) RegisterService(name string, service hostcommon.Service) {
-	if _, ok := s.services[name]; ok {
+func (s *ServicesRegistry) RegisterService(name string, service hostcommon.Service, order int) {
+	if _, ok := s.serviceIndex[name]; ok {
 		s.logger.Crit("service already registered", "name", name)
 	}
-	s.services[name] = service
+
+	entry := serviceEntry{name: name, service: service, order: order}
+
+	// Insert in order
+	inserted := false
+	for i, existing := range s.orderedServices {
+		if order < existing.order {
+			s.orderedServices = append(s.orderedServices[:i], append([]serviceEntry{entry}, s.orderedServices[i:]...)...)
+			inserted = true
+			break
+		}
+	}
+	if !inserted {
+		s.orderedServices = append(s.orderedServices, entry)
+	}
+
+	s.serviceIndex[name] = service
 }
 
 func (s *ServicesRegistry) getService(name string) hostcommon.Service {
-	service, ok := s.services[name]
+	service, ok := s.serviceIndex[name]
 	if !ok {
 		s.logger.Crit("requested service not registered", "name", name)
 	}
@@ -58,4 +82,27 @@ func (s *ServicesRegistry) Enclaves() hostcommon.EnclaveService {
 
 func (s *ServicesRegistry) LogSubs() hostcommon.LogSubscriptionManager {
 	return s.getService(hostcommon.LogSubscriptionServiceName).(hostcommon.LogSubscriptionManager)
+}
+
+func (s *ServicesRegistry) Start() error {
+	for _, entry := range s.orderedServices {
+		s.logger.Info("Starting service", "name", entry.name)
+		if err := entry.service.Start(); err != nil {
+			s.logger.Error("Failed to start service", "name", entry.name, "error", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *ServicesRegistry) Stop() error {
+	for i := len(s.orderedServices) - 1; i >= 0; i-- {
+		entry := s.orderedServices[i]
+		s.logger.Info("Stopping service", "name", entry.name)
+		if err := entry.service.Stop(); err != nil {
+			s.logger.Error("Failed to stop service", "name", entry.name, "error", err)
+			return err
+		}
+	}
+	return nil
 }

--- a/go/host/storage/hostdb/batch.go
+++ b/go/host/storage/hostdb/batch.go
@@ -370,35 +370,15 @@ func fetchBatchNumber(db HostDB, args ...any) (*big.Int, error) {
 }
 
 func fetchPublicBatch(db HostDB, whereQuery string, args ...any) (*common.PublicBatch, error) {
-	var sequenceInt64 uint64
-	var fullHash common.TxHash
-	var heightInt64 int
-	var extBatch []byte
-
-	query := selectBatch + whereQuery
-	reboundQuery := db.GetSQLDB().Rebind(query)
-	var err error
-	if len(args) > 0 {
-		err = db.GetSQLDB().QueryRow(reboundQuery, args...).Scan(&sequenceInt64, &fullHash, &heightInt64, &extBatch)
-	} else {
-		err = db.GetSQLDB().QueryRow(reboundQuery).Scan(&sequenceInt64, &fullHash, &heightInt64, &extBatch)
-	}
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errutil.ErrNotFound
-		}
-		return nil, fmt.Errorf("failed to scan with query %s - %w", query, err)
-	}
-	var b common.ExtBatch
-	err = rlp.DecodeBytes(extBatch, &b)
+	b, err := fetchFullBatch(db, whereQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode ext batch. Cause: %w", err)
 	}
 
 	batch := &common.PublicBatch{
-		SequencerOrderNo: new(big.Int).SetInt64(int64(sequenceInt64)),
-		FullHash:         fullHash,
-		Height:           new(big.Int).SetInt64(int64(heightInt64)),
+		SequencerOrderNo: b.SeqNo(),
+		FullHash:         b.Hash(),
+		Height:           b.Header.Number,
 		Header:           b.Header,
 		EncryptedTxBlob:  b.EncryptedTxBlob,
 		TxHashes:         b.TxHashes,


### PR DESCRIPTION
### Why this change is needed

The host services were started in a random order, which causes some initialisation issues

### What changes were made as part of this PR

- add an "order" parameter to the registration
- start and stop services in the right order

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


