### PR TITLE
fix: respect PCCS_URL environment variable in entry.sh

### DIFF
--- a/go/enclave/main/entry.sh
+++ b/go/enclave/main/entry.sh
@@ -11,7 +11,7 @@ if [ ! -L /dev/sgx/enclave ]; then
 	ln -s /dev/sgx_enclave /dev/sgx/enclave
 fi
 
-PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
+PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
 echo "PCCS_URL: ${PCCS_URL}"
 
 apt-get install -qq libsgx-dcap-default-qpl


### PR DESCRIPTION
## Summary
Cherry-pick of PR #2745 from `releases/v1.6` to `main`.

The `entry.sh` script was hardcoding the PCCS_URL to Azure's global cache, ignoring any environment variable set in the container. This prevented deployments from using custom PCCS services for bare-metal SGX environments.

## Changes
- Line 14: Changed from hardcoded assignment to shell parameter expansion
- Before: `PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/`
- After: `PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}`

## Benefits
- **Backward Compatible**: Existing deployments retain the Azure URL as default
- **Flexible Configuration**: Allows environment variable override via Kubernetes or docker-compose
- **SGX Support**: Enables on-premises and bare-metal SGX deployments (OVH, etc.) to use local/custom PCCS services for attestation

## Test Plan
- [ ] Verify existing Azure deployments still work (default behavior unchanged)
- [ ] Verify custom PCCS_URL can be set via environment variable