### PR TITLE
Enclave: batch exec can be failing for val block processing

### DIFF
--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -206,6 +206,7 @@ func (e *enclaveAdminService) SubmitL1Block(ctx context.Context, blockData *comm
 				e.logger.Crit("failed to revert L1 head after critical rollup error", log.BlockHashKey, blockData.BlockHeader.Hash(), log.ErrKey, err)
 				return nil, err
 			}
+			e.logger.Info("Reverted L1 block after critical processing error", log.BlockHashKey, blockData.BlockHeader.Hash())
 		}
 		return nil, e.rejectBlockErr(ctx, fmt.Errorf("could not submit L1 block. Cause: %w", err))
 	}
@@ -291,20 +292,18 @@ func (e *enclaveAdminService) SubmitBatch(ctx context.Context, extBatch *common.
 
 	// todo - review whether we need to lock here.
 	e.dataInMutex.Lock()
+	defer e.dataInMutex.Unlock()
+
 	// if the signature is valid, then store the batch together with the converted hash
 	err = e.storage.StoreBatch(ctx, batch, convertedHeader.Hash())
 	if err != nil {
-		e.dataInMutex.Unlock()
 		return responses.ToInternalError(fmt.Errorf("could not store batch. Cause: %w", err))
 	}
 
 	err = e.validator().ExecuteStoredBatches(ctx)
 	if err != nil {
-		e.dataInMutex.Unlock()
 		return responses.ToInternalError(fmt.Errorf("could not execute batches. Cause: %w", err))
 	}
-
-	e.dataInMutex.Unlock()
 
 	return nil
 }

--- a/go/enclave/nodetype/validator.go
+++ b/go/enclave/nodetype/validator.go
@@ -126,7 +126,12 @@ func (val *validator) handleGenesis(ctx context.Context, batch *common.BatchHead
 }
 
 func (val *validator) OnL1Block(ctx context.Context, block *types.Header, result *components.BlockIngestionType) error {
-	return val.ExecuteStoredBatches(ctx)
+	err := val.ExecuteStoredBatches(ctx)
+	if err != nil {
+		val.logger.Error("failed to execute stored batches after L1 block ingestion", log.BlockHeightKey, block.Number, log.BlockHashKey, block.Hash(), log.ErrKey, err)
+		return err
+	}
+	return nil
 }
 
 func (val *validator) Close() error {


### PR DESCRIPTION
### Why this change is needed

Validator doesn't need all batches to be executing to continue processing L1 blocks. It is a concern but they are independent processes and this could speed recovery in some situations.

### What changes were made as part of this PR

- Avoid failing on batch execution error during L1 block submission.
- Add a log msg for rollback for visibility

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


