### PR TITLE
add rate limiting for /join request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/TwiN/gocache/v2 v2.4.0
 	github.com/andybalholm/brotli v1.2.0
-	github.com/bytedance/gopkg v0.1.3
 	github.com/codeclysm/extract/v3 v3.1.1
 	github.com/containerd/errdefs v1.0.0
 	github.com/deckarep/golang-set/v2 v2.8.0
@@ -49,6 +48,7 @@ require (
 	golang.org/x/crypto v0.45.0
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
 	golang.org/x/sync v0.18.0
+	golang.org/x/time v0.9.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -67,6 +67,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.13.0 // indirect
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.3 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.2 // indirect
 	github.com/bytedance/sonic/loader v0.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/tools/walletextension/common/config.go
+++ b/tools/walletextension/common/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	RateLimitWindow                time.Duration
 	RateLimitMaxConcurrentRequests int
 
+	// HTTP endpoint rate limiting (for /join - can be used by other endpoints in the future too)
+	// Burst is automatically set to 1.5x the rate for both limiters
+	HTTPRateLimitGlobalRate float64 // Global requests per second (0 = disabled)
+	HTTPRateLimitPerIPRate  float64 // Per-IP requests per second (0 = disabled)
+
 	InsideEnclave                 bool // Indicates if the program is running inside an enclave
 	EncryptionKeySource           string
 	EnableTLS                     bool

--- a/tools/walletextension/httpapi/routes.go
+++ b/tools/walletextension/httpapi/routes.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	tencommon "github.com/ten-protocol/go-ten/go/common"
 	"github.com/ten-protocol/go-ten/tools/walletextension/cache"
 	"github.com/ten-protocol/go-ten/tools/walletextension/keymanager"
+	"github.com/ten-protocol/go-ten/tools/walletextension/ratelimiter"
 	"github.com/ten-protocol/go-ten/tools/walletextension/services"
 
 	"github.com/status-im/keycard-go/hexutils"
@@ -45,7 +47,7 @@ func NewHTTPRoutes(walletExt *services.Services) []node.Route {
 		},
 		{
 			Name: common.APIVersion1 + common.PathJoin,
-			Func: httpHandler(walletExt, joinRequestHandler),
+			Func: rateLimitedHttpHandler(walletExt, joinRequestHandler),
 		},
 		{
 			Name: common.APIVersion1 + common.PathGetToken,
@@ -112,6 +114,17 @@ func restrictiveHttpHandler(
 	}
 }
 
+// rateLimitedHttpHandler wraps an HTTP handler with rate limiting.
+// It applies both global and per-IP rate limits before processing the request.
+func rateLimitedHttpHandler(
+	walletExt *services.Services,
+	fun func(walletExt *services.Services, conn UserConn),
+) func(resp http.ResponseWriter, req *http.Request) {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		rateLimitedHttpRequestHandler(walletExt, resp, req, fun)
+	}
+}
+
 // Overall request handler for http requests
 func httpRequestHandler(walletExt *services.Services, resp http.ResponseWriter, req *http.Request, fun func(walletExt *services.Services, conn UserConn)) {
 	if walletExt.IsStopping() {
@@ -136,12 +149,46 @@ func restrictiveHttpRequestHandler(walletExt *services.Services, resp http.Respo
 	fun(walletExt, userConn)
 }
 
+// rateLimitedHttpRequestHandler handles HTTP requests with rate limiting applied.
+// It checks both global and per-IP rate limits before processing the request.
+func rateLimitedHttpRequestHandler(walletExt *services.Services, resp http.ResponseWriter, req *http.Request, fun func(walletExt *services.Services, conn UserConn)) {
+	if walletExt.IsStopping() {
+		return
+	}
+	if httputil.EnableCORS(resp, req) {
+		return
+	}
+
+	// Apply rate limiting if enabled
+	if walletExt.HTTPRateLimiter != nil && walletExt.HTTPRateLimiter.IsEnabled() {
+		clientIP := ratelimiter.GetClientIP(req)
+		allowed, retryAfter := walletExt.HTTPRateLimiter.Allow(clientIP)
+		if !allowed {
+			writeRateLimitResponse(resp, retryAfter)
+			return
+		}
+	}
+
+	userConn := NewUserConnHTTP(resp, req, walletExt.Logger())
+	fun(walletExt, userConn)
+}
+
+// writeRateLimitResponse writes an HTTP 429 response with appropriate headers and body.
+func writeRateLimitResponse(resp http.ResponseWriter, retryAfter time.Duration) {
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter.Seconds()))
+	resp.WriteHeader(http.StatusTooManyRequests)
+	_ = json.NewEncoder(resp).Encode(map[string]interface{}{
+		"error":       "rate limit exceeded",
+		"retry_after": int(retryAfter.Seconds()),
+	})
+}
+
 // readyRequestHandler is used to check whether the server is ready
 func readyRequestHandler(_ *services.Services, _ UserConn) {}
 
 // This function handles request to /join endpoint. It is responsible to create new user (new key-pair) and store it to the db
 func joinRequestHandler(walletExt *services.Services, conn UserConn) {
-	// todo (@ziga) add protection against DDOS attacks
 	_, err := conn.ReadRequest()
 	if err != nil {
 		handleError(conn, walletExt.Logger(), fmt.Errorf("error reading request: %w", err))

--- a/tools/walletextension/main/cli.go
+++ b/tools/walletextension/main/cli.go
@@ -73,6 +73,14 @@ const (
 	rateLimitMaxConcurrentRequestsDefault = 3
 	rateLimitMaxConcurrentRequestsUsage   = "Number of concurrent requests allowed per user. Default: 3"
 
+	httpRateLimitGlobalRateName    = "httpRateLimitGlobalRate"
+	httpRateLimitGlobalRateDefault = 0.0
+	httpRateLimitGlobalRateUsage   = "Global HTTP rate limit in requests per second for endpoints like /join. Set to 0 to disable. Default: 0 (disabled)"
+
+	httpRateLimitPerIPRateName    = "httpRateLimitPerIPRate"
+	httpRateLimitPerIPRateDefault = 0.0
+	httpRateLimitPerIPRateUsage   = "Per-IP HTTP rate limit in requests per second for endpoints like /join. Burst is automatically 1.5x this value. Set to 0 to disable. Default: 0 (disabled)"
+
 	insideEnclaveFlagName    = "insideEnclave"
 	insideEnclaveFlagDefault = false
 	insideEnclaveFlagUsage   = "Flag to indicate if the program is running inside an enclave. Default: false"
@@ -147,6 +155,8 @@ func parseCLIArgs() wecommon.Config {
 	rateLimitUserComputeTime := flag.Duration(rateLimitUserComputeTimeName, rateLimitUserComputeTimeDefault, rateLimitUserComputeTimeUsage)
 	rateLimitWindow := flag.Duration(rateLimitWindowName, rateLimitWindowDefault, rateLimitWindowUsage)
 	rateLimitMaxConcurrentRequests := flag.Int(rateLimitMaxConcurrentRequestsName, rateLimitMaxConcurrentRequestsDefault, rateLimitMaxConcurrentRequestsUsage)
+	httpRateLimitGlobalRate := flag.Float64(httpRateLimitGlobalRateName, httpRateLimitGlobalRateDefault, httpRateLimitGlobalRateUsage)
+	httpRateLimitPerIPRate := flag.Float64(httpRateLimitPerIPRateName, httpRateLimitPerIPRateDefault, httpRateLimitPerIPRateUsage)
 	insideEnclaveFlag := flag.Bool(insideEnclaveFlagName, insideEnclaveFlagDefault, insideEnclaveFlagUsage)
 	encryptionKeySource := flag.String(encryptionKeySourceFlagName, encryptionKeySourceFlagDefault, encryptionKeySourceFlagUsage)
 	enableTLSFlag := flag.Bool(enableTLSFlagName, enableTLSFlagDefault, enableTLSFlagUsage)
@@ -174,6 +184,8 @@ func parseCLIArgs() wecommon.Config {
 		RateLimitUserComputeTime:       *rateLimitUserComputeTime,
 		RateLimitWindow:                *rateLimitWindow,
 		RateLimitMaxConcurrentRequests: *rateLimitMaxConcurrentRequests,
+		HTTPRateLimitGlobalRate:        *httpRateLimitGlobalRate,
+		HTTPRateLimitPerIPRate:         *httpRateLimitPerIPRate,
 		InsideEnclave:                  *insideEnclaveFlag,
 		EncryptionKeySource:            *encryptionKeySource,
 		EnableTLS:                      *enableTLSFlag,

--- a/tools/walletextension/ratelimiter/http_rate_limiter.go
+++ b/tools/walletextension/ratelimiter/http_rate_limiter.go
@@ -1,0 +1,235 @@
+package ratelimiter
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"golang.org/x/time/rate"
+)
+
+// HTTPRateLimiter provides two-layer rate limiting for HTTP endpoints:
+// 1. Global rate limit - limits total requests per second across all clients
+// 2. Per-IP rate limit - limits requests per second from a single IP address
+type HTTPRateLimiter struct {
+	globalLimiter *rate.Limiter
+	perIPLimiters map[string]*ipLimiter // map of IP -> limiter
+	perIPRate     rate.Limit
+	perIPBurst    int
+	mu            sync.RWMutex
+	logger        gethlog.Logger
+	logLimiter    *rate.Limiter
+	cleanupTicker *time.Ticker
+	stopCleanup   chan struct{}
+}
+
+// ipLimiter holds a rate limiter and last seen time for a specific IP
+type ipLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+const (
+	// cleanupInterval is how often we check for stale IP entries
+	// TODO: determine good values for interval and threshold
+	cleanupInterval = 5 * time.Minute
+	// staleThreshold is how long an IP entry can be idle before removal
+	staleThreshold = 10 * time.Minute
+	// logRateLimit limits rate limit warning logs to 1 per second
+	logRateLimit = 1.0
+)
+
+// NewHTTPRateLimiter creates a new HTTP rate limiter.
+// Set globalRate to 0 to disable global rate limiting.
+// Set perIPRate to 0 to disable per-IP rate limiting.
+// If both are 0, all requests are allowed (same functionality as before).
+// Burst is automatically set to 1.5x the rate for both limiters.
+func NewHTTPRateLimiter(globalRate float64, perIPRate float64, logger gethlog.Logger) *HTTPRateLimiter {
+	// Calculate per-IP burst as 1.5x the rate
+	perIPBurst := int(perIPRate * 1.5)
+	if perIPBurst < 1 && perIPRate > 0 {
+		perIPBurst = 1
+	}
+
+	rl := &HTTPRateLimiter{
+		perIPLimiters: make(map[string]*ipLimiter),
+		perIPRate:     rate.Limit(perIPRate),
+		perIPBurst:    perIPBurst,
+		logger:        logger,
+		logLimiter:    rate.NewLimiter(logRateLimit, 1),
+		stopCleanup:   make(chan struct{}),
+	}
+
+	// Create global limiter if enabled (burst = 1.5x rate)
+	var globalBurst int
+	if globalRate > 0 {
+		globalBurst = int(globalRate * 1.5)
+		if globalBurst < 1 {
+			globalBurst = 1
+		}
+		rl.globalLimiter = rate.NewLimiter(rate.Limit(globalRate), globalBurst)
+	}
+
+	// Start cleanup goroutine if per-IP limiting is enabled
+	if perIPRate > 0 {
+		rl.startCleanup()
+	}
+
+	logger.Info("HTTP rate limiter initialized",
+		"globalRate", globalRate,
+		"globalBurst", globalBurst,
+		"perIPRate", perIPRate,
+		"perIPBurst", perIPBurst,
+		"globalEnabled", globalRate > 0,
+		"perIPEnabled", perIPRate > 0)
+
+	return rl
+}
+
+// Allow checks if a request from the given IP should be allowed.
+// Returns (allowed, retryAfter) where retryAfter is the suggested wait time if not allowed.
+func (rl *HTTPRateLimiter) Allow(ip string) (bool, time.Duration) {
+	// If both limiters are disabled, always allow
+	if rl.globalLimiter == nil && rl.perIPRate <= 0 {
+		return true, 0
+	}
+
+	// Check global limit first (if enabled)
+	if rl.globalLimiter != nil {
+		if !rl.globalLimiter.Allow() {
+			rl.logRateLimited("Global rate limit exceeded")
+			return false, rl.calculateRetryAfter(rl.globalLimiter)
+		}
+	}
+
+	// Check per-IP limit (if enabled)
+	if rl.perIPRate > 0 {
+		limiter := rl.getOrCreateIPLimiter(ip)
+		if !limiter.Allow() {
+			rl.logRateLimited("Per-IP rate limit exceeded", "ip", ip)
+			return false, rl.calculateRetryAfter(limiter)
+		}
+	}
+
+	return true, 0
+}
+
+// getOrCreateIPLimiter returns the rate limiter for the given IP, creating one if needed.
+func (rl *HTTPRateLimiter) getOrCreateIPLimiter(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	if ipLim, exists := rl.perIPLimiters[ip]; exists {
+		ipLim.lastSeen = time.Now()
+		return ipLim.limiter
+	}
+
+	// Create new limiter for this IP
+	limiter := rate.NewLimiter(rl.perIPRate, rl.perIPBurst)
+	rl.perIPLimiters[ip] = &ipLimiter{
+		limiter:  limiter,
+		lastSeen: time.Now(),
+	}
+	return limiter
+}
+
+// calculateRetryAfter estimates when the next request would be allowed.
+func (rl *HTTPRateLimiter) calculateRetryAfter(limiter *rate.Limiter) time.Duration {
+	// Reserve a token and immediately cancel to get the delay
+	reservation := limiter.Reserve()
+	delay := reservation.Delay()
+	reservation.Cancel()
+
+	// Minimum 1 second retry-after
+	if delay < time.Second {
+		delay = time.Second
+	}
+	return delay
+}
+
+// logRateLimited logs a rate limit event, but rate-limits the logging itself.
+func (rl *HTTPRateLimiter) logRateLimited(msg string, ctx ...interface{}) {
+	if rl.logLimiter.Allow() {
+		rl.logger.Warn(msg, ctx...)
+	}
+}
+
+// startCleanup starts the background goroutine that removes stale IP entries.
+func (rl *HTTPRateLimiter) startCleanup() {
+	rl.cleanupTicker = time.NewTicker(cleanupInterval)
+	go func() {
+		for {
+			select {
+			case <-rl.cleanupTicker.C:
+				rl.cleanupStaleEntries()
+			case <-rl.stopCleanup:
+				rl.cleanupTicker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// cleanupStaleEntries removes IP entries that haven't been seen recently.
+func (rl *HTTPRateLimiter) cleanupStaleEntries() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-staleThreshold)
+	removedCount := 0
+	for ip, ipLim := range rl.perIPLimiters {
+		if ipLim.lastSeen.Before(cutoff) {
+			delete(rl.perIPLimiters, ip)
+			removedCount++
+		}
+	}
+
+	if removedCount > 0 {
+		rl.logger.Debug("Cleaned up stale IP rate limiters", "removed", removedCount, "remaining", len(rl.perIPLimiters))
+	}
+}
+
+// Stop stops the cleanup goroutine. Call this when shutting down.
+func (rl *HTTPRateLimiter) Stop() {
+	if rl.stopCleanup != nil {
+		close(rl.stopCleanup)
+	}
+}
+
+// GetClientIP extracts the client IP from an HTTP request.
+// It respects X-Forwarded-For header for requests behind a proxy.
+func GetClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header (set by proxies/load balancers)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// X-Forwarded-For can contain multiple IPs: "client, proxy1, proxy2"
+		// The first one is the original client IP
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 {
+			ip := strings.TrimSpace(parts[0])
+			if ip != "" {
+				return ip
+			}
+		}
+	}
+
+	// Check X-Real-IP header (alternative header used by some proxies)
+	if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+		return strings.TrimSpace(xrip)
+	}
+
+	// Fall back to RemoteAddr
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr might not have a port
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// IsEnabled returns true if any rate limiting is enabled.
+func (rl *HTTPRateLimiter) IsEnabled() bool {
+	return rl.globalLimiter != nil || rl.perIPRate > 0
+}


### PR DESCRIPTION
### Why this change is needed

`/join` endpoint is at the moment not protected from bots making tons of requests on it. 
Because it results in a write to the database this can have an effect on gateways performance and can grow our cosmosDB database.

Why we need to do in in the gateway:

- Rate limiting with Azure can be expensive and can be still turned on if we are under attack (I can prepare readme how to activate it if needed).
- Traefik (which we use in Kubernetes) allows rate limiting, but not for our specific use case. We terminate TLS connections inside the enclave and Traefik is not able to see which requests are going to specific endpoints (like `/join`) that we want to rate limit.

### What changes were made as part of this PR

HTTP Rate Limiting for `/join` Endpoint
Added two-layer rate limiting (global + per-IP) to protect the `/join` endpoint from abuse.
Rate limiting is configurable via CLI flags (disabled by default).

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


