### PR TITLE
Host: remove data submission locking as handled on enclave

### DIFF
--- a/go/enclave/enclave_admin_service.go
+++ b/go/enclave/enclave_admin_service.go
@@ -315,8 +315,8 @@ func (e *enclaveAdminService) CreateBatch(ctx context.Context, skipBatchIfEmpty 
 
 	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateBatch call ended", &core.RelaxedThresholds)
 
-	e.dataInMutex.RLock()
-	defer e.dataInMutex.RUnlock()
+	e.dataInMutex.Lock()
+	defer e.dataInMutex.Unlock()
 
 	err := e.sequencer().CreateBatch(ctx, skipBatchIfEmpty)
 	if err != nil {
@@ -333,8 +333,8 @@ func (e *enclaveAdminService) CreateRollup(ctx context.Context, fromSeqNo uint64
 	defer core.LogMethodDuration(e.logger, measure.NewStopwatch(), "CreateRollup call ended", &core.RelaxedThresholds)
 
 	// allow the simultaneous production of rollups and batches
-	e.dataInMutex.RLock()
-	defer e.dataInMutex.RUnlock()
+	e.dataInMutex.Lock()
+	defer e.dataInMutex.Unlock()
 
 	if e.registry.HeadBatchSeq() == nil {
 		return nil, responses.ToInternalError(fmt.Errorf("not initialised yet"))


### PR DESCRIPTION
### Why this change is needed

To reduce complexity and risk of deadlocks that have been creeping in we have decided we don't need locking on both sides of the host-enclave data comms.

Removing the mutex on the guardian side and upgrading the enclave locks to use write-lock for data creation.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


