### PR TITLE
Attestation: use intel PCS for verification collateral

### DIFF
--- a/go/enclave/main/entry.sh
+++ b/go/enclave/main/entry.sh
@@ -15,6 +15,7 @@ PCCS_URL=${PCCS_URL:-https://global.acccache.azure.net/sgx/certification/v4/}
 COLLATERAL_SERVICE=${COLLATERAL_SERVICE:-https://api.trustedservices.intel.com/sgx/certification/v4/}
 
 echo "PCCS_URL: ${PCCS_URL}"
+echo "COLLATERAL_SERVICE: ${COLLATERAL_SERVICE}"
 
 apt-get install -qq libsgx-dcap-default-qpl
 


### PR DESCRIPTION
### Why this change is needed

Piecing together the issue with OVH-Azure attestation compatibility it seems (from info [like this](https://learn.microsoft.com/en-us/azure/attestation/faq?utm_source=chatgpt.com#is-software-guard-extensions--sgx--attestation-supported-by-azure-attestation-in-non-azure-environments-)) that Azure servers need to use the Azure THIM service as their PCCS_URL because non-azure endpoints don't have all the data to produce the attestation but that Azure service is unable to verify non-azure attestations.

The COLLATERAL_SERVICE config allows you to supply a separate collateral service endpoint that gets used for verification for this case. We need to test it a bit because I've seen mention in a couple of places that it's less reliable (I think that might be because it's **stricter** than the azure endpoint).

### What changes were made as part of this PR

Allow COLLATERAL_SERVICE to be configured for enclaves, default it to the Intel PCS endpoint.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


