### PR TITLE
Deploy: update naming for sepolia network

### DIFF
--- a/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-after-nodes.yml
@@ -66,6 +66,8 @@ jobs:
                 # extract the environment prefix (dev, uat, sepolia, mainnet)
                 if [[ "$TESTNET_TYPE" == "mainnet" ]]; then
                   short_name="mainnet"
+                elif [[ "$TESTNET_TYPE" == "sepolia-testnet" ]]; then
+                  short_name="testnet"
                 else
                   # strip the -testnet suffix from testnet environments
                   short_name=${TESTNET_TYPE%-testnet}

--- a/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
+++ b/.github/workflows/manual-deploy-k8s-testnet-before-nodes.yml
@@ -71,6 +71,8 @@ jobs:
           # extract the environment prefix (dev, uat, sepolia, mainnet)
           if [[ "$TESTNET_TYPE" == "mainnet" ]]; then
             short_name="mainnet"
+          elif [[ "$TESTNET_TYPE" == "sepolia-testnet" ]]; then
+            short_name="testnet"
           else
             # strip the -testnet suffix from testnet environments
             short_name=${TESTNET_TYPE%-testnet}


### PR DESCRIPTION
### Why this change is needed

Dir changed in ten-apps and node names changed. It's now env `testnet` and the hosts are `testnet-sequencer` etc.

### What changes were made as part of this PR

Patch the short name method to use `testnet` for health checks and L1 contract addresses.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


