### PR TITLE
Tests: skip blob test failing on external service response

### DIFF
--- a/go/ethadapter/blob_beacon_client_test.go
+++ b/go/ethadapter/blob_beacon_client_test.go
@@ -136,6 +136,7 @@ func TestBlobArchiveClient(t *testing.T) {
 }
 
 func TestBlobClient(t *testing.T) {
+	t.Skipf("TODO this one needs fixing too")
 	client := NewBeaconHTTPClient(new(http.Client), testlog.Logger(), "https://ethereum-sepolia-beacon-api.publicnode.com")
 	var vHashes []gethcommon.Hash
 	ctx := context.Background()


### PR DESCRIPTION
### Why this change is needed

Build is broken because external service response has changed. I think the blob it's asking for might be too old or something. Fix it later, there's another similar one in there already skipped.

### PR checks pre-merging

Please indicate below by ticking the checkbox that you have read and performed the required
[PR checks](https://github.com/ten-protocol/ten-internal/blob/main/dev-ops-docs/dev-pr-checks.md)

- [ ] PR checks reviewed and performed 


