### PR TITLE
 use LRU eviction to prevent session key data loss in the gateway

### DIFF
--- a/tools/walletextension/services/session_key_activity.go
+++ b/tools/walletextension/services/session_key_activity.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"container/list"
 	"sync"
 	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/ten-protocol/go-ten/tools/walletextension/common"
+	"github.com/ten-protocol/go-ten/tools/walletextension/storage"
 )
 
 // SessionKeyActivityTracker exposes a minimal API for tracking activity
@@ -16,62 +18,224 @@ type SessionKeyActivityTracker interface {
 	ListAll() []common.SessionKeyActivity
 	Load(items []common.SessionKeyActivity)
 	Delete(addr gethcommon.Address) bool
+	// Stop gracefully shuts down the tracker, flushing pending writes
+	Stop()
+}
+
+// lruEntry represents an entry in the LRU cache
+type lruEntry struct {
+	addr       gethcommon.Address
+	userID     []byte
+	lastActive time.Time
 }
 
 type sessionKeyActivityTracker struct {
-	mu    sync.RWMutex
-	byKey map[gethcommon.Address]sessionKeyActivityState
-	// maxEntries bounds memory usage; when full, oldest entry is evicted upon new insert
+	mu sync.RWMutex
+
+	// LRU cache: doubly-linked list for O(1) eviction of oldest entry
+	// Front = most recently used, Back = least recently used (oldest)
+	lruList *list.List
+	// Map for O(1) lookup by address
+	byKey map[gethcommon.Address]*list.Element
+
+	// maxEntries bounds memory usage; when full, oldest entry is evicted
 	maxEntries int
 	logger     gethlog.Logger
+
+	// Async write queue for persisting evicted entries to DB
+	persistQueue   chan common.SessionKeyActivity
+	persistStorage storage.SessionKeyActivityStorage
+	stopChan       chan struct{}
+	stopOnce       sync.Once
+	wg             sync.WaitGroup
 }
 
-// sessionKeyActivityState is the internal storage value; address is the map key
-type sessionKeyActivityState struct {
-	UserID     []byte
-	LastActive time.Time
-}
-
-// defaultMaxActivityEntries defines an upper bound to avoid unbounded memory growth
-const defaultMaxActivityEntries = 100000
+// Configuration constants
+const (
+	defaultMaxActivityEntries = 100000
+	persistQueueSize          = 10000
+	persistBatchSize          = 100
+	persistFlushInterval      = 5 * time.Second
+)
 
 func NewSessionKeyActivityTracker(logger gethlog.Logger) SessionKeyActivityTracker {
-	return &sessionKeyActivityTracker{
-		byKey:      make(map[gethcommon.Address]sessionKeyActivityState),
-		maxEntries: defaultMaxActivityEntries,
-		logger:     logger,
+	return NewSessionKeyActivityTrackerWithStorage(logger, nil)
+}
+
+// NewSessionKeyActivityTrackerWithStorage creates a tracker with async DB persistence
+func NewSessionKeyActivityTrackerWithStorage(logger gethlog.Logger, persistStorage storage.SessionKeyActivityStorage) SessionKeyActivityTracker {
+	t := &sessionKeyActivityTracker{
+		lruList:        list.New(),
+		byKey:          make(map[gethcommon.Address]*list.Element),
+		maxEntries:     defaultMaxActivityEntries,
+		logger:         logger,
+		persistStorage: persistStorage,
+		stopChan:       make(chan struct{}),
 	}
+
+	// Start async persistence worker if storage is provided
+	if persistStorage != nil {
+		t.persistQueue = make(chan common.SessionKeyActivity, persistQueueSize)
+		t.wg.Add(1)
+		go t.persistWorker()
+	}
+
+	return t
+}
+
+// persistWorker runs in the background and batches writes to CosmosDB
+func (t *sessionKeyActivityTracker) persistWorker() {
+	defer t.wg.Done()
+
+	batch := make([]common.SessionKeyActivity, 0, persistBatchSize)
+	ticker := time.NewTicker(persistFlushInterval)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := t.persistStorage.SaveBatch(batch); err != nil {
+			if t.logger != nil {
+				t.logger.Warn("Failed to persist evicted session key activities", "count", len(batch), "error", err)
+			}
+		} else {
+			if t.logger != nil {
+				t.logger.Debug("Persisted evicted session key activities", "count", len(batch))
+			}
+		}
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case item, ok := <-t.persistQueue:
+			if !ok {
+				// Channel closed, flush remaining and exit
+				flush()
+				return
+			}
+			batch = append(batch, item)
+			if len(batch) >= persistBatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-t.stopChan:
+			// Drain remaining items from queue, checking for closed channel
+			for {
+				select {
+				case item, ok := <-t.persistQueue:
+					if !ok {
+						// Channel closed, flush and exit
+						flush()
+						return
+					}
+					batch = append(batch, item)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+// Stop gracefully shuts down the tracker, flushing pending writes
+func (t *sessionKeyActivityTracker) Stop() {
+	t.stopOnce.Do(func() {
+		close(t.stopChan)
+		if t.persistQueue != nil {
+			close(t.persistQueue)
+		}
+	})
+	t.wg.Wait()
 }
 
 func (t *sessionKeyActivityTracker) MarkActive(userID []byte, addr gethcommon.Address) {
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	// if the address is already in the map, update the last active time
-	if state, ok := t.byKey[addr]; ok {
-		state.LastActive = now
-		t.byKey[addr] = state
-	} else {
-		// check if the map is at capacity
-		if len(t.byKey) >= t.maxEntries {
-			if t.logger != nil {
-				t.logger.Warn("SessionKeyActivityTracker capacity reached; dropping new activity", "capacity", t.maxEntries, "addr", addr.Hex())
-			}
-		} else {
-			// if the map is not at capacity, add the address to the map
-			t.byKey[addr] = sessionKeyActivityState{UserID: userID, LastActive: now}
+
+	// If the address already exists, update and move to front (most recently used)
+	if elem, ok := t.byKey[addr]; ok {
+		entry := elem.Value.(*lruEntry)
+		entry.lastActive = now
+		t.lruList.MoveToFront(elem)
+		return
+	}
+
+	// New entry: check capacity
+	if len(t.byKey) >= t.maxEntries {
+		// Evict the oldest entry (back of the list)
+		t.evictOldest()
+	}
+
+	// Add new entry at front (most recently used)
+	entry := &lruEntry{
+		addr:       addr,
+		userID:     userID,
+		lastActive: now,
+	}
+	elem := t.lruList.PushFront(entry)
+	t.byKey[addr] = elem
+}
+
+// evictOldest removes the least recently used entry and queues it for DB persistence
+// Must be called with lock held
+func (t *sessionKeyActivityTracker) evictOldest() {
+	back := t.lruList.Back()
+	if back == nil {
+		return
+	}
+
+	entry := back.Value.(*lruEntry)
+
+	// Queue for async DB persistence before removing from memory
+	if t.persistQueue != nil {
+		activity := common.SessionKeyActivity{
+			Addr:       entry.addr,
+			UserID:     entry.userID,
+			LastActive: entry.lastActive,
 		}
+		select {
+		case t.persistQueue <- activity:
+			// Successfully queued
+		default:
+			// Queue full, log warning but continue with eviction
+			if t.logger != nil {
+				t.logger.Warn("Persist queue full, evicted entry may be lost", "addr", entry.addr.Hex())
+			}
+		}
+	}
+
+	// Remove from cache
+	t.lruList.Remove(back)
+	delete(t.byKey, entry.addr)
+
+	if t.logger != nil {
+		t.logger.Debug("Evicted oldest session key activity", "addr", entry.addr.Hex(), "lastActive", entry.lastActive)
 	}
 }
 
 func (t *sessionKeyActivityTracker) ListOlderThan(cutoff time.Time) []common.SessionKeyActivity {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	// preallocate with current size upper bound; filter below
-	result := make([]common.SessionKeyActivity, 0, len(t.byKey))
-	for addr, state := range t.byKey {
-		if state.LastActive.Before(cutoff) {
-			result = append(result, common.SessionKeyActivity{Addr: addr, UserID: state.UserID, LastActive: state.LastActive})
+
+	result := make([]common.SessionKeyActivity, 0)
+	for elem := t.lruList.Back(); elem != nil; elem = elem.Prev() {
+		entry := elem.Value.(*lruEntry)
+		if entry.lastActive.Before(cutoff) {
+			result = append(result, common.SessionKeyActivity{
+				Addr:       entry.addr,
+				UserID:     entry.userID,
+				LastActive: entry.lastActive,
+			})
+		} else {
+			// Since list is ordered by last access time (oldest at back),
+			// once we hit an entry newer than cutoff, all remaining entries
+			// will also be newer, so we can stop early
+			break
 		}
 	}
 	return result
@@ -80,37 +244,73 @@ func (t *sessionKeyActivityTracker) ListOlderThan(cutoff time.Time) []common.Ses
 func (t *sessionKeyActivityTracker) ListAll() []common.SessionKeyActivity {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+
 	result := make([]common.SessionKeyActivity, 0, len(t.byKey))
-	for addr, state := range t.byKey {
-		result = append(result, common.SessionKeyActivity{Addr: addr, UserID: state.UserID, LastActive: state.LastActive})
+	for elem := t.lruList.Front(); elem != nil; elem = elem.Next() {
+		entry := elem.Value.(*lruEntry)
+		result = append(result, common.SessionKeyActivity{
+			Addr:       entry.addr,
+			UserID:     entry.userID,
+			LastActive: entry.lastActive,
+		})
 	}
 	return result
 }
 
 func (t *sessionKeyActivityTracker) Load(items []common.SessionKeyActivity) {
 	t.mu.Lock()
-	// Enforce capacity limit by truncating the input slice if necessary
-	if len(items) > t.maxEntries {
-		if t.logger != nil {
-			t.logger.Warn("ReplaceAll truncated due to capacity", "requested", len(items), "capacity", t.maxEntries)
+	defer t.mu.Unlock()
+
+	// Clear existing data
+	t.lruList = list.New()
+	t.byKey = make(map[gethcommon.Address]*list.Element)
+
+	// Sort items by LastActive (oldest first) so we can build the LRU list correctly
+	// Items at the front will be most recent, items at back will be oldest
+	// We'll add them in reverse order (oldest first) so oldest ends up at back
+	sorted := make([]common.SessionKeyActivity, len(items))
+	copy(sorted, items)
+
+	// Simple insertion sort by LastActive (ascending = oldest first)
+	for i := 1; i < len(sorted); i++ {
+		j := i
+		for j > 0 && sorted[j].LastActive.Before(sorted[j-1].LastActive) {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+			j--
 		}
-		items = items[:t.maxEntries]
 	}
 
-	newMap := make(map[gethcommon.Address]sessionKeyActivityState, len(items))
-	for _, it := range items {
-		newMap[it.Addr] = sessionKeyActivityState{UserID: it.UserID, LastActive: it.LastActive}
+	// Enforce capacity limit
+	startIdx := 0
+	if len(sorted) > t.maxEntries {
+		startIdx = len(sorted) - t.maxEntries
+		if t.logger != nil {
+			t.logger.Warn("Load truncated due to capacity, oldest entries dropped",
+				"total", len(sorted), "dropped", startIdx, "loaded", t.maxEntries)
+		}
 	}
-	t.byKey = newMap
-	t.mu.Unlock()
+
+	// Add entries: oldest first (will be at back of list), newest last (will be at front)
+	for i := startIdx; i < len(sorted); i++ {
+		item := sorted[i]
+		entry := &lruEntry{
+			addr:       item.Addr,
+			userID:     item.UserID,
+			lastActive: item.LastActive,
+		}
+		elem := t.lruList.PushFront(entry)
+		t.byKey[item.Addr] = elem
+	}
 }
 
 func (t *sessionKeyActivityTracker) Delete(addr gethcommon.Address) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	_, existed := t.byKey[addr]
-	if existed {
+
+	if elem, ok := t.byKey[addr]; ok {
+		t.lruList.Remove(elem)
 		delete(t.byKey, addr)
+		return true
 	}
-	return existed
+	return false
 }

--- a/tools/walletextension/services/session_key_activity_test.go
+++ b/tools/walletextension/services/session_key_activity_test.go
@@ -1,0 +1,349 @@
+package services
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ten-protocol/go-ten/tools/walletextension/common"
+)
+
+// mockActivityStorage is a mock implementation of SessionKeyActivityStorage for testing
+type mockActivityStorage struct {
+	mu     sync.Mutex
+	items  map[gethcommon.Address]common.SessionKeyActivity
+	saved  []common.SessionKeyActivity
+	errors map[string]error
+}
+
+func newMockActivityStorage() *mockActivityStorage {
+	return &mockActivityStorage{
+		items:  make(map[gethcommon.Address]common.SessionKeyActivity),
+		saved:  make([]common.SessionKeyActivity, 0),
+		errors: make(map[string]error),
+	}
+}
+
+func (m *mockActivityStorage) Load() ([]common.SessionKeyActivity, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]common.SessionKeyActivity, 0, len(m.items))
+	for _, item := range m.items {
+		result = append(result, item)
+	}
+	return result, m.errors["Load"]
+}
+
+func (m *mockActivityStorage) Save(items []common.SessionKeyActivity) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = make(map[gethcommon.Address]common.SessionKeyActivity)
+	for _, item := range items {
+		m.items[item.Addr] = item
+	}
+	return m.errors["Save"]
+}
+
+func (m *mockActivityStorage) SaveBatch(items []common.SessionKeyActivity) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saved = append(m.saved, items...)
+	for _, item := range items {
+		m.items[item.Addr] = item
+	}
+	return m.errors["SaveBatch"]
+}
+
+func (m *mockActivityStorage) ListOlderThan(cutoff time.Time) ([]common.SessionKeyActivity, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]common.SessionKeyActivity, 0)
+	for _, item := range m.items {
+		if item.LastActive.Before(cutoff) {
+			result = append(result, item)
+		}
+	}
+	return result, m.errors["ListOlderThan"]
+}
+
+func (m *mockActivityStorage) Delete(addr gethcommon.Address) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, addr)
+	return m.errors["Delete"]
+}
+
+func (m *mockActivityStorage) getSaved() []common.SessionKeyActivity {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]common.SessionKeyActivity{}, m.saved...)
+}
+
+func TestSessionKeyActivityTracker_MarkActive_Basic(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	addr := gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")
+	userID := []byte("test-user-1")
+
+	tracker.MarkActive(userID, addr)
+
+	all := tracker.ListAll()
+	require.Len(t, all, 1)
+	assert.Equal(t, addr, all[0].Addr)
+	assert.Equal(t, userID, all[0].UserID)
+}
+
+func TestSessionKeyActivityTracker_MarkActive_UpdateExisting(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	addr := gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")
+	userID := []byte("test-user-1")
+
+	// First activation
+	tracker.MarkActive(userID, addr)
+	firstAll := tracker.ListAll()
+	firstTime := firstAll[0].LastActive
+
+	// Wait a bit and activate again
+	time.Sleep(10 * time.Millisecond)
+	tracker.MarkActive(userID, addr)
+
+	all := tracker.ListAll()
+	require.Len(t, all, 1)
+	assert.True(t, all[0].LastActive.After(firstTime), "LastActive should be updated")
+}
+
+func TestSessionKeyActivityTracker_ListOlderThan(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	addr1 := gethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	addr2 := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	// Add first entry
+	tracker.MarkActive([]byte("user1"), addr1)
+
+	// Wait and add second entry
+	time.Sleep(20 * time.Millisecond)
+	cutoff := time.Now()
+	time.Sleep(20 * time.Millisecond)
+
+	tracker.MarkActive([]byte("user2"), addr2)
+
+	// Only addr1 should be older than cutoff
+	older := tracker.ListOlderThan(cutoff)
+	require.Len(t, older, 1)
+	assert.Equal(t, addr1, older[0].Addr)
+}
+
+func TestSessionKeyActivityTracker_Delete(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	addr := gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	tracker.MarkActive([]byte("user"), addr)
+	require.Len(t, tracker.ListAll(), 1)
+
+	deleted := tracker.Delete(addr)
+	assert.True(t, deleted)
+	assert.Empty(t, tracker.ListAll())
+
+	// Delete non-existent
+	deleted = tracker.Delete(addr)
+	assert.False(t, deleted)
+}
+
+func TestSessionKeyActivityTracker_Load(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	items := []common.SessionKeyActivity{
+		{
+			Addr:       gethcommon.HexToAddress("0x1111111111111111111111111111111111111111"),
+			UserID:     []byte("user1"),
+			LastActive: time.Now().Add(-2 * time.Hour),
+		},
+		{
+			Addr:       gethcommon.HexToAddress("0x2222222222222222222222222222222222222222"),
+			UserID:     []byte("user2"),
+			LastActive: time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	tracker.Load(items)
+
+	all := tracker.ListAll()
+	require.Len(t, all, 2)
+}
+
+func TestSessionKeyActivityTracker_LRU_EvictsOldest(t *testing.T) {
+	storage := newMockActivityStorage()
+	tracker := NewSessionKeyActivityTrackerWithStorage(nil, storage).(*sessionKeyActivityTracker)
+	// Override max entries for testing
+	tracker.maxEntries = 3
+
+	addr1 := gethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	addr2 := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	addr3 := gethcommon.HexToAddress("0x3333333333333333333333333333333333333333")
+	addr4 := gethcommon.HexToAddress("0x4444444444444444444444444444444444444444")
+
+	// Add 3 entries (at capacity)
+	tracker.MarkActive([]byte("user1"), addr1)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user2"), addr2)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user3"), addr3)
+
+	require.Len(t, tracker.ListAll(), 3)
+
+	// Add 4th entry - should evict addr1 (oldest)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user4"), addr4)
+
+	// Should still have 3 entries
+	all := tracker.ListAll()
+	require.Len(t, all, 3)
+
+	// addr1 should be gone, addr2, addr3, addr4 should remain
+	addrs := make(map[gethcommon.Address]bool)
+	for _, a := range all {
+		addrs[a.Addr] = true
+	}
+
+	assert.False(t, addrs[addr1], "addr1 should have been evicted")
+	assert.True(t, addrs[addr2], "addr2 should remain")
+	assert.True(t, addrs[addr3], "addr3 should remain")
+	assert.True(t, addrs[addr4], "addr4 should remain")
+
+	// Stop the tracker to flush pending writes
+	tracker.Stop()
+
+	// Check that evicted entry was queued for persistence
+	saved := storage.getSaved()
+	require.Len(t, saved, 1)
+	assert.Equal(t, addr1, saved[0].Addr)
+}
+
+func TestSessionKeyActivityTracker_LRU_UpdateMovesToFront(t *testing.T) {
+	storage := newMockActivityStorage()
+	tracker := NewSessionKeyActivityTrackerWithStorage(nil, storage).(*sessionKeyActivityTracker)
+	tracker.maxEntries = 3
+
+	addr1 := gethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	addr2 := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	addr3 := gethcommon.HexToAddress("0x3333333333333333333333333333333333333333")
+	addr4 := gethcommon.HexToAddress("0x4444444444444444444444444444444444444444")
+
+	// Add 3 entries
+	tracker.MarkActive([]byte("user1"), addr1) // oldest
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user2"), addr2)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user3"), addr3)
+
+	// Re-activate addr1 - this should move it to front (most recently used)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user1"), addr1)
+
+	// Now add addr4 - addr2 should be evicted (it's now the oldest)
+	time.Sleep(5 * time.Millisecond)
+	tracker.MarkActive([]byte("user4"), addr4)
+
+	all := tracker.ListAll()
+	require.Len(t, all, 3)
+
+	addrs := make(map[gethcommon.Address]bool)
+	for _, a := range all {
+		addrs[a.Addr] = true
+	}
+
+	assert.True(t, addrs[addr1], "addr1 should remain (was re-activated)")
+	assert.False(t, addrs[addr2], "addr2 should have been evicted (was oldest after addr1 re-activation)")
+	assert.True(t, addrs[addr3], "addr3 should remain")
+	assert.True(t, addrs[addr4], "addr4 should remain")
+
+	tracker.Stop()
+}
+
+func TestSessionKeyActivityTracker_ConcurrentAccess(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil)
+	defer tracker.Stop()
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	numOpsPerGoroutine := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < numOpsPerGoroutine; j++ {
+				addr := gethcommon.HexToAddress("0x" + string(rune('0'+idx)) + "234567890123456789012345678901234567890")
+				tracker.MarkActive([]byte("user"), addr)
+				tracker.ListAll()
+				tracker.ListOlderThan(time.Now())
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Should not panic or deadlock
+}
+
+func TestSessionKeyActivityTracker_LoadWithCapacityLimit(t *testing.T) {
+	tracker := NewSessionKeyActivityTracker(nil).(*sessionKeyActivityTracker)
+	tracker.maxEntries = 3
+	defer tracker.Stop()
+
+	// Create more items than capacity
+	items := []common.SessionKeyActivity{
+		{
+			Addr:       gethcommon.HexToAddress("0x1111111111111111111111111111111111111111"),
+			UserID:     []byte("user1"),
+			LastActive: time.Now().Add(-4 * time.Hour), // oldest - should be dropped
+		},
+		{
+			Addr:       gethcommon.HexToAddress("0x2222222222222222222222222222222222222222"),
+			UserID:     []byte("user2"),
+			LastActive: time.Now().Add(-3 * time.Hour), // second oldest - should be dropped
+		},
+		{
+			Addr:       gethcommon.HexToAddress("0x3333333333333333333333333333333333333333"),
+			UserID:     []byte("user3"),
+			LastActive: time.Now().Add(-2 * time.Hour),
+		},
+		{
+			Addr:       gethcommon.HexToAddress("0x4444444444444444444444444444444444444444"),
+			UserID:     []byte("user4"),
+			LastActive: time.Now().Add(-1 * time.Hour),
+		},
+		{
+			Addr:       gethcommon.HexToAddress("0x5555555555555555555555555555555555555555"),
+			UserID:     []byte("user5"),
+			LastActive: time.Now(), // newest
+		},
+	}
+
+	tracker.Load(items)
+
+	all := tracker.ListAll()
+	require.Len(t, all, 3, "should only load up to capacity")
+
+	// Should have the 3 newest entries
+	addrs := make(map[gethcommon.Address]bool)
+	for _, a := range all {
+		addrs[a.Addr] = true
+	}
+
+	assert.False(t, addrs[gethcommon.HexToAddress("0x1111111111111111111111111111111111111111")], "oldest should be dropped")
+	assert.False(t, addrs[gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")], "second oldest should be dropped")
+	assert.True(t, addrs[gethcommon.HexToAddress("0x3333333333333333333333333333333333333333")])
+	assert.True(t, addrs[gethcommon.HexToAddress("0x4444444444444444444444444444444444444444")])
+	assert.True(t, addrs[gethcommon.HexToAddress("0x5555555555555555555555555555555555555555")])
+}

--- a/tools/walletextension/storage/session_key_activity_storage.go
+++ b/tools/walletextension/storage/session_key_activity_storage.go
@@ -1,14 +1,25 @@
 package storage
 
 import (
+	"time"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	wecommon "github.com/ten-protocol/go-ten/tools/walletextension/common"
 	"github.com/ten-protocol/go-ten/tools/walletextension/storage/database/cosmosdb"
 )
 
 // SessionKeyActivityStorage defines persistence for session key activity tracker
 type SessionKeyActivityStorage interface {
+	// Load retrieves all stored session key activities (used on startup)
 	Load() ([]wecommon.SessionKeyActivity, error)
+	// Save performs a full replacement of all stored activities
 	Save([]wecommon.SessionKeyActivity) error
+	// SaveBatch upserts a batch of activities (used for async persistence of evicted entries)
+	SaveBatch([]wecommon.SessionKeyActivity) error
+	// ListOlderThan returns activities with LastActive before the given cutoff
+	ListOlderThan(cutoff time.Time) ([]wecommon.SessionKeyActivity, error)
+	// Delete removes a specific activity by address
+	Delete(addr gethcommon.Address) error
 }
 
 // NewSessionKeyActivityStorage is a factory that returns a concrete storage based on dbType
@@ -31,3 +42,11 @@ func (n *noOpSessionKeyActivityStorage) Load() ([]wecommon.SessionKeyActivity, e
 }
 
 func (n *noOpSessionKeyActivityStorage) Save([]wecommon.SessionKeyActivity) error { return nil }
+
+func (n *noOpSessionKeyActivityStorage) SaveBatch([]wecommon.SessionKeyActivity) error { return nil }
+
+func (n *noOpSessionKeyActivityStorage) ListOlderThan(time.Time) ([]wecommon.SessionKeyActivity, error) {
+	return nil, nil
+}
+
+func (n *noOpSessionKeyActivityStorage) Delete(gethcommon.Address) error { return nil }

--- a/tools/walletextension/walletextension_container.go
+++ b/tools/walletextension/walletextension_container.go
@@ -105,7 +105,7 @@ func NewContainerFromConfig(config wecommon.Config, logger gethlog.Logger) *Cont
 	}
 
 	stopControl := stopcontrol.New()
-	walletExt := services.NewServices(hostRPCBindAddrHTTP, hostRPCBindAddrWS, userStorage, stopControl, version, logger, metricsTracker, &config)
+	walletExt := services.NewServices(hostRPCBindAddrHTTP, hostRPCBindAddrWS, userStorage, activityStorage, stopControl, version, logger, metricsTracker, &config)
 
 	// Create session key expiration service after services are created
 	var sessionKeyExpirationService *services.SessionKeyExpirationService


### PR DESCRIPTION
Why this change is needed
The SessionKeyActivityTracker has a hard limit of 100k entries. When this limit is reached, new session key activities are silently dropped (those keys will never expire and funds).

What changes were made as part of this PR
I replaced the simple map with an LRU cache. Instead of dropping new entries at capacity, we now evict the oldest entry and persist it to CosmosDB via an async batch writer.

Changes:

`session_key_activity.go` — LRU cache using container/list with O(1) eviction; background goroutine batches evicted entries (100 items or 5s flush interval) and writes to CosmosDB
`session_key_expiration.go `— Expiration check now queries both in-memory cache AND CosmosDB, merging results to catch entries that were evicted from memory
`session_key_activity_storage.go` — Added SaveBatch(), ListOlderThan(), and Delete() to storage interface
`cosmosdb/session_key_activity_storage.go` — Implemented incremental upsert (read-merge-write) for batched persistence
Graceful shutdown flushes pending writes before exit
Write frequency impact: No additional CosmosDB writes unless cache exceeds 100k entries. When evictions occur, writes are batched efficiently (~1-2 shard writes per 100 evictions).